### PR TITLE
Detect UCM port direction when filtering card profiles

### DIFF
--- a/scripts/audio-profiles
+++ b/scripts/audio-profiles
@@ -6,6 +6,8 @@
 set -o pipefail
 
 timeout 2 pactl -f json list cards 2>/dev/null | jq -c '
+  # Cards that ship a UCM profile name their ports "[Out] Speaker" instead of
+  # following the classic ACP scheme ("analog-output"), so match both.
   def port_supports($card; $profile; $direction):
     any(
       (($card.ports // {}) | to_entries)[]?;
@@ -30,8 +32,8 @@ timeout 2 pactl -f json list cards 2>/dev/null | jq -c '
               or .key == "off"
               or (($card.properties["device.api"] // "") == "bluez5")
               or (
-                ((.value.sinks // 0) == 0 or port_supports($card; .key; "output"))
-                and ((.value.sources // 0) == 0 or port_supports($card; .key; "input"))
+                ((.value.sinks // 0) == 0 or port_supports($card; .key; "^\\[Out\\] |output"))
+                and ((.value.sources // 0) == 0 or port_supports($card; .key; "^\\[In\\] |input"))
               )
             )
           | {

--- a/test/all
+++ b/test/all
@@ -102,6 +102,11 @@ jq -e '
   and (values("Bluetooth Headphones") | index("a2dp-sink-aac") != null)
   and (values("Bluetooth Headphones") | index("headset-head-unit-msbc") != null)
   and (values("HDMI Receiver") | index("output:hdmi-surround") != null)
+  and (values("UCM Analog Codec") == [
+    "HiFi (Headphones, Mic1)",
+    "HiFi (Mic1, Speaker)",
+    "off"
+  ])
 ' <<<"$profiles" >/dev/null || fail "safe profile filtering"
 echo "PASS: safe profile filtering"
 

--- a/test/fixtures/cards.json
+++ b/test/fixtures/cards.json
@@ -80,5 +80,41 @@
       "output:hdmi-stereo": { "description": "Digital Stereo (HDMI) Output", "sinks": 1, "sources": 0, "priority": 5900, "available": true },
       "output:hdmi-surround": { "description": "Digital Surround 5.1 (HDMI) Output", "sinks": 1, "sources": 0, "priority": 800, "available": true }
     }
+  },
+  {
+    "index": 40,
+    "name": "alsa_card.pci-example-ucm",
+    "active_profile": "HiFi (Headphones, Mic1)",
+    "properties": {
+      "device.api": "alsa",
+      "device.description": "UCM Analog Codec"
+    },
+    "ports": {
+      "[Out] Headphones": {
+        "priority": 200,
+        "profiles": [
+          "HiFi (Headphones, Mic1)"
+        ]
+      },
+      "[Out] Speaker": {
+        "priority": 100,
+        "profiles": [
+          "HiFi (Mic1, Speaker)"
+        ]
+      },
+      "[In] Mic1": {
+        "priority": 100,
+        "profiles": [
+          "HiFi (Headphones, Mic1)",
+          "HiFi (Mic1, Speaker)"
+        ]
+      }
+    },
+    "profiles": {
+      "off": { "description": "Off", "sinks": 0, "sources": 0, "priority": 0, "available": true },
+      "HiFi (Headphones, Mic1)": { "description": "Play HiFi quality Music (Headphones, Mic1)", "sinks": 1, "sources": 1, "priority": 8500, "available": true },
+      "HiFi (Mic1, Speaker)": { "description": "Play HiFi quality Music (Mic1, Speaker)", "sinks": 1, "sources": 1, "priority": 8400, "available": true },
+      "pro-audio": { "description": "Pro Audio", "sinks": 1, "sources": 1, "priority": 1, "available": true }
+    }
   }
 ]


### PR DESCRIPTION
Fixes #1.

## Problem

`scripts/audio-profiles` decides whether a profile has a usable output/input by looking for the substring `output` / `input` in the **port name**:

```jq
and (.key | test($direction))
```

That holds for classic ACP port names (`analog-output`, `analog-input-mic`, `hdmi-output-0`), but cards that ship an ALSA use case manager profile name their ports `[Out] Speaker`, `[In] Mic1` instead. On those cards no port ever matches, so every profile except the active one and `off` is dropped and the *Devices* tab offers nothing to switch to.

On a Realtek ALC257 laptop that hides `HiFi (Mic1, Mic2, Speaker)` — the only way to reach the built-in speakers while headphones are plugged in — and reduces the HDMI card (`[Out] HDMI1..3`) to `["off"]`, so HDMI output cannot be enabled from the panel at all.

## Change

Accept the UCM prefix in addition to the classic scheme:

```jq
port_supports($card; .key; "^\\[Out\\] |output")
port_supports($card; .key; "^\\[In\\] |input")
```

`[Out] ` and `[In] ` (trailing space included) are the exact literals emitted by `spa/plugins/alsa`, so the alternative is anchored and matched case-sensitively — it cannot collide with a classic port name, and nothing about the existing matching changes. The filtering semantics are otherwise untouched: `pro-audio` is still excluded because no port references it, and Bluetooth cards still bypass the port check entirely.

`.direction` would be the natural field to use instead of parsing names, but `pactl -f json list cards` reports it as `null` for these ports. (`pw-dump` does expose a real per-route `direction`, but it identifies profiles by index rather than name, so using it would mean reworking this pactl-based pipeline rather than fixing the heuristic.)

## Tests

`test/fixtures/cards.json` gains a UCM card — two `HiFi` profiles, `pro-audio`, and `[Out]`/`[In]` ports — and `test/all` asserts its profile list is exactly:

```
["HiFi (Headphones, Mic1)", "HiFi (Mic1, Speaker)", "off"]
```

Checked against pristine `scripts/audio-profiles`, that assertion fails (`FAIL: safe profile filtering`); with the change `./test/all` passes all seven checks. Verified on the affected hardware too: both profiles now appear, the HDMI card regains its `HiFi` profile, the USB headset's list is unchanged, and switching through `scripts/audio-profile-set` moves the sink between headphones and speakers while preserving volume.
