### PR TITLE
Add recording routes and advanced mixer controls

### DIFF
--- a/AdvancedAudio.qml
+++ b/AdvancedAudio.qml
@@ -2,6 +2,7 @@ import QtQuick
 import QtQuick.Controls
 import Quickshell
 import Quickshell.Io
+import Quickshell.Services.Pipewire
 import qs.Ui
 import qs.Commons
 import "Model.js" as Model
@@ -19,14 +20,21 @@ Item {
   readonly property bool opened: window.visible
 
   property var audioCards: []
+  property var audioPorts: []
+  property bool profilesLoaded: false
   property bool bluetoothAutoSwitch: true
   property bool bluetoothAutoSwitchLoaded: false
   property bool autoswitchMutation: false
+  property string bluetoothProfilePreference: "quality"
+  property bool bluetoothProfilePreferenceLoaded: false
+  property bool bluetoothProfilePreferenceMutation: false
   property string error: ""
   property int activeTab: 0  // 0 = devices, 1 = Bluetooth
   property bool cursorActive: false
   property int selectedIndex: 0
   property bool profileMenuOpen: false
+  property var audioControlSettings: ({ version: 1, outputOverdrive: false })
+  property bool outputOverdrive: false
 
   readonly property color foreground: Color.foreground
   readonly property color background: Color.background
@@ -34,8 +42,38 @@ Item {
   readonly property string fontFamily: Style.font.family
   readonly property var bluetoothCards: Model.audioCardsByBluetooth(audioCards, true)
   readonly property var deviceCards: Model.audioCardsByBluetooth(audioCards, false)
-  readonly property int itemCount: activeTab === 0 ? deviceCards.length : 1 + bluetoothCards.length
+  readonly property var pipewireNodes: Pipewire.nodes ? Pipewire.nodes.values : []
+  readonly property var defaultOutputDevice: Pipewire.defaultAudioSink
+  property string volumeSinkName: ""
+  readonly property var outputDevice: {
+    if (!defaultOutputDevice || !volumeSinkName
+        || String(defaultOutputDevice.name) === volumeSinkName) return defaultOutputDevice
+    for (var i = 0; i < pipewireNodes.length; i++) {
+      var node = pipewireNodes[i]
+      if (node && node.isSink && !node.isStream && String(node.name) === volumeSinkName)
+        return node
+    }
+    return defaultOutputDevice
+  }
+  readonly property var inputDevice: Pipewire.defaultAudioSource
+  readonly property bool outputBalanceAvailable: balanceAvailable(outputDevice)
+  readonly property bool inputBalanceAvailable: balanceAvailable(inputDevice)
+  readonly property int audioPortStartIndex: 1
+  readonly property int deviceProfileStartIndex: audioPortStartIndex + audioPorts.length
+  readonly property int balanceStartIndex: deviceProfileStartIndex + deviceCards.length
+  readonly property int outputBalanceIndex: outputBalanceAvailable ? balanceStartIndex : -1
+  readonly property int inputBalanceIndex: inputBalanceAvailable
+    ? balanceStartIndex + (outputBalanceAvailable ? 1 : 0) : -1
+  readonly property int itemCount: activeTab === 0
+    ? balanceStartIndex + (outputBalanceAvailable ? 1 : 0) + (inputBalanceAvailable ? 1 : 0)
+    : 2 + bluetoothCards.length
   readonly property color hoverFill: Style.hoverFillFor(foreground, Color.accent)
+  readonly property string settingsPath: {
+    var configHome = Quickshell.env("XDG_CONFIG_HOME")
+    if (!configHome) configHome = Quickshell.env("HOME") + "/.config"
+    return configHome + "/omarchy/audio-control.json"
+  }
+  onDefaultOutputDeviceChanged: resolveVolumeSink()
 
   function pluginScript(name) {
     var url = String(Qt.resolvedUrl("scripts/" + name))
@@ -51,6 +89,7 @@ Item {
     cursorActive = false
     selectedIndex = 0
     error = ""
+    profilesLoaded = false
     if (windowRuleReady) showOnCurrentWorkspace()
     else if (!windowRuleProc.running) windowRuleProc.running = true
   }
@@ -88,20 +127,99 @@ Item {
       bluetoothAutoswitchProc.command = [pluginScript("audio-bluetooth-autoswitch")]
       bluetoothAutoswitchProc.running = true
     }
+    if (!bluetoothPreferenceProc.running) {
+      bluetoothProfilePreferenceMutation = false
+      bluetoothPreferenceProc.command = [pluginScript("audio-bluetooth-profile-preference")]
+      bluetoothPreferenceProc.running = true
+    }
+    if (!portsProc.running && !portSetProc.running) portsProc.running = true
+    resolveVolumeSink()
+  }
+
+  function resolveVolumeSink() {
+    if (!volumeSinkProc.running) volumeSinkProc.running = true
   }
 
   function parseAudioProfiles(raw) {
     audioCards = Model.parseAudioProfiles(raw)
+    profilesLoaded = true
     clampCursor()
+  }
+
+  function parseAudioPorts(raw) {
+    audioPorts = Model.parseAudioPorts(raw)
+    clampCursor()
+  }
+
+  function loadAudioControlSettings(raw) {
+    audioControlSettings = Model.parseAudioControlSettings(raw)
+    outputOverdrive = audioControlSettings.outputOverdrive
+  }
+
+  function setOutputOverdrive(enabled) {
+    var next = ({})
+    for (var key in audioControlSettings) next[key] = audioControlSettings[key]
+    next.version = 1
+    next.outputOverdrive = enabled
+    audioControlSettings = next
+    outputOverdrive = enabled
+    settingsFile.setText(JSON.stringify(next, null, 2) + "\n")
   }
 
   function profileOptions(card) {
     return Model.audioProfileOptions(card)
   }
 
+  function nodeLabel(node) {
+    return Model.nodeLabel(node)
+  }
+
+  function stereoIndices(node) {
+    if (!node || !node.audio || !node.audio.channels || !node.audio.volumes)
+      return { left: -1, right: -1 }
+    var channels = node.audio.channels
+    var left = -1
+    var right = -1
+    for (var i = 0; i < channels.length; i++) {
+      if (channels[i] === PwAudioChannel.FrontLeft) left = i
+      else if (channels[i] === PwAudioChannel.FrontRight) right = i
+    }
+    if ((left < 0 || right < 0) && node.audio.volumes.length === 2)
+      return { left: 0, right: 1 }
+    return { left: left, right: right }
+  }
+
+  function balanceAvailable(node) {
+    var indices = stereoIndices(node)
+    return indices.left >= 0 && indices.right >= 0
+  }
+
+  function balanceFor(node) {
+    if (!node || !node.audio) return 0
+    var indices = stereoIndices(node)
+    if (indices.left < 0 || indices.right < 0) return 0
+    return Model.balanceValue(node.audio.volumes[indices.left], node.audio.volumes[indices.right])
+  }
+
+  function setBalance(node, value) {
+    if (!node || !node.audio) return
+    var indices = stereoIndices(node)
+    if (indices.left < 0 || indices.right < 0) return
+    node.audio.volumes = Model.applyBalance(node.audio.volumes, indices.left, indices.right, value)
+  }
+
+  function adjustBalanceAtCursor(delta) {
+    var node = selectedIndex === outputBalanceIndex ? outputDevice
+      : (selectedIndex === inputBalanceIndex ? inputDevice : null)
+    if (!node) return false
+    setBalance(node, balanceFor(node) + delta * 0.1)
+    return true
+  }
+
   function clampCursor() {
     selectedIndex = Math.max(0, Math.min(Math.max(0, itemCount - 1), selectedIndex))
   }
+  onItemCountChanged: clampCursor()
 
   function moveCursor(delta) {
     if (itemCount === 0) return
@@ -109,12 +227,16 @@ Item {
   }
 
   function closeProfileMenus() {
-    var repeaters = [deviceProfileRepeater, bluetoothProfileRepeater]
+    bluetoothPreferenceDropdown.close()
+    var repeaters = [deviceProfileRepeater, bluetoothProfileRepeater, audioPortRepeater]
     for (var r = 0; r < repeaters.length; r++) {
       var repeater = repeaters[r]
+      if (!repeater) continue
       for (var i = 0; i < repeater.count; i++) {
         var row = repeater.itemAt(i)
-        if (row) row.closeProfileMenu()
+        if (!row) continue
+        if (typeof row.closeProfileMenu === "function") row.closeProfileMenu()
+        if (typeof row.closePortMenu === "function") row.closePortMenu()
       }
     }
   }
@@ -141,13 +263,33 @@ Item {
 
   function activateCursor() {
     if (!cursorActive || itemCount === 0) return
+    if (activeTab === 0 && selectedIndex === 0) {
+      setOutputOverdrive(!outputOverdrive)
+      return
+    }
+    if (activeTab === 0
+        && (selectedIndex === outputBalanceIndex || selectedIndex === inputBalanceIndex)) {
+      var balanceNode = selectedIndex === outputBalanceIndex ? outputDevice : inputDevice
+      setBalance(balanceNode, 0)
+      return
+    }
+    if (activeTab === 0 && selectedIndex >= audioPortStartIndex
+        && selectedIndex < deviceProfileStartIndex) {
+      var portRow = audioPortRepeater.itemAt(selectedIndex - audioPortStartIndex)
+      if (portRow) portRow.togglePortMenu()
+      return
+    }
     if (activeTab === 1 && selectedIndex === 0) {
       setBluetoothAutoSwitch(!bluetoothAutoSwitch)
       return
     }
+    if (activeTab === 1 && selectedIndex === 1) {
+      bluetoothPreferenceDropdown.toggle()
+      return
+    }
     var row = activeTab === 0
-      ? deviceProfileRepeater.itemAt(selectedIndex)
-      : bluetoothProfileRepeater.itemAt(selectedIndex - 1)
+      ? deviceProfileRepeater.itemAt(selectedIndex - deviceProfileStartIndex)
+      : bluetoothProfileRepeater.itemAt(selectedIndex - 2)
     if (row) row.toggleProfileMenu()
   }
 
@@ -171,12 +313,29 @@ Item {
     profileSetProc.running = true
   }
 
+  function setAudioPort(port, value) {
+    if (!port || !value || portSetProc.running) return
+    error = ""
+    portSetProc.command = [pluginScript("audio-port-set"), port.direction, port.endpoint, value]
+    portSetProc.running = true
+  }
+
   function setBluetoothAutoSwitch(enabled) {
     if (!bluetoothAutoSwitchLoaded || bluetoothAutoswitchProc.running) return
     error = ""
     autoswitchMutation = true
     bluetoothAutoswitchProc.command = [pluginScript("audio-bluetooth-autoswitch"), enabled ? "on" : "off"]
     bluetoothAutoswitchProc.running = true
+  }
+
+  function setBluetoothProfilePreference(value) {
+    if (!bluetoothProfilePreferenceLoaded || bluetoothPreferenceProc.running
+        || (value !== "quality" && value !== "latency")) return
+    error = ""
+    bluetoothProfilePreference = value
+    bluetoothProfilePreferenceMutation = true
+    bluetoothPreferenceProc.command = [pluginScript("audio-bluetooth-profile-preference"), value]
+    bluetoothPreferenceProc.running = true
   }
 
   Process {
@@ -191,6 +350,20 @@ Item {
     }
   }
 
+  FileView {
+    id: settingsFile
+    path: root.settingsPath
+    watchChanges: true
+    atomicWrites: true
+    printErrors: false
+    onLoaded: root.loadAudioControlSettings(text())
+    onLoadFailed: root.loadAudioControlSettings("")
+    onFileChanged: reload()
+  }
+
+  PwObjectTracker { objects: root.outputDevice ? [root.outputDevice] : [] }
+  PwObjectTracker { objects: root.inputDevice ? [root.inputDevice] : [] }
+
   Process {
     id: profilesProc
     command: [root.pluginScript("audio-profiles")]
@@ -199,7 +372,29 @@ Item {
       onStreamFinished: root.parseAudioProfiles(text)
     }
     onExited: function(exitCode) {
+      root.profilesLoaded = true
       if (exitCode !== 0 && window.visible) root.error = "Could not load audio profiles"
+    }
+  }
+
+  Process {
+    id: volumeSinkProc
+    command: ["omarchy-audio-output-sink"]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: root.volumeSinkName = String(text || "").trim()
+    }
+  }
+
+  Process {
+    id: portsProc
+    command: [root.pluginScript("audio-ports")]
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: root.parseAudioPorts(text)
+    }
+    onExited: function(exitCode) {
+      if (exitCode !== 0 && window.visible) root.error = "Could not load audio ports"
     }
   }
 
@@ -209,6 +404,15 @@ Item {
       if (exitCode !== 0) root.error = "Could not change the audio profile"
       else root.error = ""
       profileRefreshTimer.restart()
+    }
+  }
+
+  Process {
+    id: portSetProc
+    onExited: function(exitCode) {
+      if (exitCode !== 0) root.error = "Could not change the audio port"
+      else root.error = ""
+      portRefreshTimer.restart()
     }
   }
 
@@ -231,6 +435,25 @@ Item {
     }
   }
 
+  Process {
+    id: bluetoothPreferenceProc
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: {
+        var value = String(text || "").trim()
+        if (value === "quality" || value === "latency") {
+          root.bluetoothProfilePreference = value
+          root.bluetoothProfilePreferenceLoaded = true
+        }
+      }
+    }
+    onExited: function(exitCode) {
+      if (root.bluetoothProfilePreferenceMutation && exitCode !== 0)
+        root.error = "Could not change Bluetooth profile preference"
+      root.bluetoothProfilePreferenceMutation = false
+    }
+  }
+
   Timer {
     id: profileRefreshTimer
     interval: 200
@@ -239,11 +462,30 @@ Item {
   }
 
   Timer {
+    id: portRefreshTimer
+    interval: 200
+    repeat: false
+    onTriggered: if (window.visible && !portsProc.running) portsProc.running = true
+  }
+
+  Timer {
     interval: 2000
     running: window.visible
     repeat: true
-    onTriggered: if (!root.profileMenuOpen && !profilesProc.running && !profileSetProc.running)
+    onTriggered: if (!root.profileMenuOpen && !profilesProc.running && !profileSetProc.running
+        && !portsProc.running && !portSetProc.running) {
       profilesProc.running = true
+      portsProc.running = true
+    }
+  }
+
+
+  Timer {
+    interval: 15000
+    running: window.visible
+    repeat: true
+    triggeredOnStart: true
+    onTriggered: root.resolveVolumeSink()
   }
 
   FloatingWindow {
@@ -268,10 +510,11 @@ Item {
         id: keyCatcher
         anchors.fill: parent
         blocked: root.profileMenuOpen
-        onMoveRequested: function(dx, dy) {
-          if (dx !== 0) {
-            root.cursorActive = true
-            root.switchTab(dx)
+          onMoveRequested: function(dx, dy) {
+            if (dx !== 0) {
+              root.cursorActive = true
+              if (root.activeTab === 0 && root.adjustBalanceAtCursor(dx)) return
+              root.switchTab(dx)
             return
           }
           if (!root.cursorActive) { root.cursorActive = true; return }
@@ -349,11 +592,134 @@ Item {
             height: Math.max(0, frame.height - fixedHeader.height - frame.spacing)
             clip: true
             ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
+            ScrollBar.vertical: ScrollBar {
+              id: advancedScrollBar
+              policy: content.implicitHeight > scrollArea.height
+                ? ScrollBar.AsNeeded : ScrollBar.AlwaysOff
+              interactive: false
+              width: Style.space(5)
+              background: Item { }
+              contentItem: Rectangle {
+                implicitWidth: Style.space(3)
+                radius: width / 2
+                color: root.foreground
+                opacity: advancedScrollBar.active ? 0.55 : 0.25
+              }
+            }
 
             Column {
               id: content
               width: scrollArea.availableWidth
               spacing: Style.space(18)
+
+              Column {
+                visible: root.activeTab === 0
+                width: parent.width
+                spacing: Style.space(8)
+
+                PanelSectionHeader {
+                  text: "OUTPUT RANGE"
+                  foreground: root.foreground
+                  fontFamily: root.fontFamily
+                }
+
+                CursorSurface {
+                  id: outputOverdriveRow
+                  width: parent.width
+                  implicitHeight: outputOverdriveContent.implicitHeight + Style.space(18)
+                  hasCursor: root.cursorActive && root.activeTab === 0 && root.selectedIndex === 0
+                  onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(outputOverdriveRow)
+                  foreground: root.foreground
+                  fill: root.hoverFill
+                  bordered: true
+
+                  Row {
+                    id: outputOverdriveContent
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.leftMargin: Style.space(12)
+                    anchors.rightMargin: Style.space(12)
+                    spacing: Style.space(12)
+
+                    Column {
+                      width: parent.width - outputOverdriveToggle.width - parent.spacing
+                      spacing: Style.space(3)
+
+                      Text {
+                        width: parent.width
+                        text: "Allow volume boost"
+                        color: root.foreground
+                        font.family: root.fontFamily
+                        font.pixelSize: Style.font.body
+                        font.bold: true
+                        elide: Text.ElideRight
+                      }
+
+                      Text {
+                        width: parent.width
+                        text: "Extend the main output volume range from 100% to 150%."
+                        color: Qt.darker(root.foreground, 1.35)
+                        font.family: root.fontFamily
+                        font.pixelSize: Style.font.caption
+                        wrapMode: Text.WordWrap
+                      }
+                    }
+
+                    ToggleSwitch {
+                      id: outputOverdriveToggle
+                      checked: root.outputOverdrive
+                      interactive: false
+                      cursorRing: false
+                      foreground: root.foreground
+                      anchors.verticalCenter: parent.verticalCenter
+                    }
+                  }
+
+                  MouseArea {
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    cursorShape: Qt.PointingHandCursor
+                    onContainsMouseChanged: if (containsMouse) root.setCursor(0)
+                    onClicked: root.setOutputOverdrive(!root.outputOverdrive)
+                  }
+                }
+              }
+
+              PanelSeparator {
+                visible: root.activeTab === 0
+                foreground: root.foreground
+              }
+
+              Column {
+                visible: root.activeTab === 0 && root.audioPorts.length > 0
+                width: parent.width
+                spacing: Style.space(12)
+
+                PanelSectionHeader {
+                  text: "DEVICE PORTS"
+                  foreground: root.foreground
+                  fontFamily: root.fontFamily
+                }
+
+                Repeater {
+                  id: audioPortRepeater
+                  model: root.audioPorts
+
+                  PortRow {
+                    required property var modelData
+                    required property int index
+                    width: parent.width
+                    port: modelData
+                    rowIndex: root.audioPortStartIndex + index
+                  }
+                }
+              }
+
+              PanelSeparator {
+                visible: root.activeTab === 0 && root.audioPorts.length > 0
+                foreground: root.foreground
+              }
 
               Column {
                 visible: root.activeTab === 1
@@ -401,7 +767,7 @@ Item {
 
                       Text {
                         width: parent.width
-                        text: "Switch to communication audio when an application records from the headset microphone."
+                        text: "Switch to headset mode when an application records."
                         color: Qt.darker(root.foreground, 1.35)
                         font.family: root.fontFamily
                         font.pixelSize: Style.font.caption
@@ -429,6 +795,85 @@ Item {
                     onClicked: root.setBluetoothAutoSwitch(!root.bluetoothAutoSwitch)
                   }
                 }
+
+                CursorSurface {
+                  id: bluetoothPreferenceRow
+                  width: parent.width
+                  implicitHeight: Math.max(bluetoothPreferenceLabels.implicitHeight,
+                    bluetoothPreferenceDropdown.implicitHeight) + Style.space(18)
+                  hasCursor: root.cursorActive && root.selectedIndex === 1
+                  onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(bluetoothPreferenceRow)
+                  foreground: root.foreground
+                  fill: root.hoverFill
+                  bordered: true
+
+                  Row {
+                    anchors.left: parent.left
+                    anchors.right: parent.right
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.leftMargin: Style.space(12)
+                    anchors.rightMargin: Style.space(12)
+                    spacing: Style.space(16)
+
+                    Column {
+                      id: bluetoothPreferenceLabels
+                      width: Math.max(Style.space(180), parent.width * 0.4)
+                      anchors.verticalCenter: parent.verticalCenter
+                      spacing: Style.space(3)
+
+                      Text {
+                        width: parent.width
+                        text: "Profile preference"
+                        color: root.foreground
+                        font.family: root.fontFamily
+                        font.pixelSize: Style.font.body
+                        font.bold: true
+                        elide: Text.ElideRight
+                      }
+
+                      Text {
+                        width: parent.width
+                        text: "Automatic profile selection"
+                        color: Qt.darker(root.foreground, 1.35)
+                        font.family: root.fontFamily
+                        font.pixelSize: Style.font.caption
+                        elide: Text.ElideRight
+                      }
+                    }
+
+                    AudioDropdown {
+                      id: bluetoothPreferenceDropdown
+                      width: parent.width - bluetoothPreferenceLabels.width - parent.spacing
+                      showLabel: false
+                      popupDirection: "down"
+                      value: root.bluetoothProfilePreference
+                      options: [
+                        { value: "quality", label: "Prefer quality" },
+                        { value: "latency", label: "Prefer lower latency" }
+                      ]
+                      hasCursor: bluetoothPreferenceRow.hasCursor
+                      enabled: root.bluetoothProfilePreferenceLoaded && !bluetoothPreferenceProc.running
+                      opacity: enabled ? 1 : 0.6
+                      foreground: root.foreground
+                      fontFamily: root.fontFamily
+                      anchors.verticalCenter: parent.verticalCenter
+
+                      onHovered: function(on) { if (on) root.setCursor(1) }
+                      onChanged: function(value) { root.setBluetoothProfilePreference(value) }
+                      onPopupOpenChanged: {
+                        root.profileMenuOpen = popupOpen
+                        if (!popupOpen) Qt.callLater(function() { keyCatcher.forceActiveFocus() })
+                      }
+                    }
+                  }
+
+                  MouseArea {
+                    anchors.fill: parent
+                    acceptedButtons: Qt.NoButton
+                    hoverEnabled: true
+                    onContainsMouseChanged: if (containsMouse) root.setCursor(1)
+                  }
+                }
               }
 
               PanelSeparator {
@@ -441,7 +886,7 @@ Item {
                 spacing: Style.space(12)
 
                 Text {
-                  visible: profilesProc.running
+                  visible: !root.profilesLoaded
                     && ((root.activeTab === 0 && root.deviceCards.length === 0)
                       || (root.activeTab === 1 && root.bluetoothCards.length === 0))
                   text: "Loading device profiles…"
@@ -451,7 +896,7 @@ Item {
                 }
 
                 Text {
-                  visible: !profilesProc.running
+                  visible: root.profilesLoaded
                     && ((root.activeTab === 0 && root.deviceCards.length === 0)
                       || (root.activeTab === 1 && root.bluetoothCards.length === 0))
                   text: root.activeTab === 0
@@ -482,7 +927,7 @@ Item {
                       required property int index
                       width: parent.width
                       card: modelData
-                      rowIndex: 1 + index
+                      rowIndex: 2 + index
                     }
                   }
                 }
@@ -507,8 +952,41 @@ Item {
                       required property int index
                       width: parent.width
                       card: modelData
-                      rowIndex: index
+                      rowIndex: root.deviceProfileStartIndex + index
                     }
+                  }
+                }
+
+                PanelSeparator {
+                  visible: root.activeTab === 0
+                    && (root.outputBalanceAvailable || root.inputBalanceAvailable)
+                  foreground: root.foreground
+                }
+
+                Column {
+                  visible: root.activeTab === 0
+                    && (root.outputBalanceAvailable || root.inputBalanceAvailable)
+                  width: parent.width
+                  spacing: Style.space(8)
+
+                  PanelSectionHeader {
+                    text: "CHANNEL BALANCE"
+                    foreground: root.foreground
+                    fontFamily: root.fontFamily
+                  }
+
+                  BalanceRow {
+                    visible: root.outputBalanceAvailable
+                    node: root.outputDevice
+                    label: "Output"
+                    rowIndex: root.outputBalanceIndex
+                  }
+
+                  BalanceRow {
+                    visible: root.inputBalanceAvailable
+                    node: root.inputDevice
+                    label: "Input"
+                    rowIndex: root.inputBalanceIndex
                   }
                 }
 
@@ -526,6 +1004,185 @@ Item {
           }
         }
       }
+    }
+  }
+
+  component PortRow: CursorSurface {
+    id: portRow
+    required property var port
+    required property int rowIndex
+
+    width: parent ? parent.width : 0
+    implicitHeight: Math.max(portLabels.implicitHeight, portDropdown.implicitHeight) + Style.space(18)
+    hasCursor: root.cursorActive && root.activeTab === 0 && root.selectedIndex === rowIndex
+    onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(portRow)
+    foreground: root.foreground
+    fill: root.hoverFill
+    bordered: true
+
+    function togglePortMenu() { portDropdown.toggle() }
+    function closePortMenu() { portDropdown.close() }
+
+    Row {
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.verticalCenter: parent.verticalCenter
+      anchors.leftMargin: Style.space(12)
+      anchors.rightMargin: Style.space(12)
+      spacing: Style.space(16)
+
+      Column {
+        id: portLabels
+        width: Math.max(Style.space(180), parent.width * 0.4)
+        anchors.verticalCenter: parent.verticalCenter
+        spacing: Style.space(3)
+
+        Text {
+          width: parent.width
+          text: portRow.port.label
+          color: root.foreground
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.body
+          font.bold: true
+          elide: Text.ElideRight
+        }
+
+        Text {
+          width: parent.width
+          text: portRow.port.direction === "output" ? "Output port" : "Input port"
+          color: Qt.darker(root.foreground, 1.35)
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.caption
+          elide: Text.ElideRight
+        }
+      }
+
+      AudioDropdown {
+        id: portDropdown
+        width: parent.width - portLabels.width - parent.spacing
+        showLabel: false
+        popupDirection: "down"
+        value: String(portRow.port.activePort || "")
+        options: portRow.port.ports
+        hasCursor: portRow.hasCursor
+        enabled: !portSetProc.running
+        opacity: enabled ? 1 : 0.6
+        foreground: root.foreground
+        fontFamily: root.fontFamily
+        anchors.verticalCenter: parent.verticalCenter
+
+        onHovered: function(on) { if (on) root.setCursor(portRow.rowIndex) }
+        onChanged: function(value) { root.setAudioPort(portRow.port, value) }
+        onPopupOpenChanged: {
+          root.profileMenuOpen = popupOpen
+          if (!popupOpen) Qt.callLater(function() { keyCatcher.forceActiveFocus() })
+        }
+      }
+    }
+
+    MouseArea {
+      anchors.fill: parent
+      acceptedButtons: Qt.NoButton
+      hoverEnabled: true
+      onContainsMouseChanged: if (containsMouse) root.setCursor(portRow.rowIndex)
+    }
+  }
+
+  component BalanceRow: CursorSurface {
+    id: balanceRow
+    required property var node
+    required property string label
+    required property int rowIndex
+
+    width: parent ? parent.width : 0
+    implicitHeight: balanceColumn.implicitHeight + Style.space(18)
+    hasCursor: root.cursorActive && root.activeTab === 0 && root.selectedIndex === rowIndex
+    onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(balanceRow)
+    foreground: root.foreground
+    fill: root.hoverFill
+    bordered: true
+
+    Column {
+      id: balanceColumn
+      anchors.left: parent.left
+      anchors.right: parent.right
+      anchors.verticalCenter: parent.verticalCenter
+      anchors.leftMargin: Style.space(12)
+      anchors.rightMargin: Style.space(12)
+      spacing: Style.space(4)
+
+      Item {
+        width: parent.width
+        height: Math.max(balanceLabel.implicitHeight, balanceValue.implicitHeight)
+
+        Text {
+          id: balanceLabel
+          text: balanceRow.label + " · " + root.nodeLabel(balanceRow.node)
+          color: root.foreground
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.body
+          font.bold: true
+          elide: Text.ElideRight
+          width: parent.width - balanceValue.width - Style.space(8)
+          anchors.left: parent.left
+          anchors.verticalCenter: parent.verticalCenter
+        }
+
+        Text {
+          id: balanceValue
+          text: {
+            var value = root.balanceFor(balanceRow.node)
+            if (Math.abs(value) < 0.05) return "CENTER"
+            return value < 0 ? "L " + Math.round(-value * 100) : "R " + Math.round(value * 100)
+          }
+          color: Qt.darker(root.foreground, 1.4)
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.caption
+          font.bold: true
+          anchors.right: parent.right
+          anchors.verticalCenter: parent.verticalCenter
+        }
+      }
+
+      Row {
+        width: parent.width
+        spacing: Style.space(8)
+
+        Text {
+          text: "L"
+          color: Qt.darker(root.foreground, 1.35)
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.caption
+          width: Style.space(12)
+          anchors.verticalCenter: parent.verticalCenter
+        }
+
+        PanelSlider {
+          width: parent.width - Style.space(40)
+          minimum: -1
+          maximum: 1
+          step: 0.05
+          value: root.balanceFor(balanceRow.node)
+          tickCount: 3
+          onMoved: function(value) { root.setBalance(balanceRow.node, value) }
+        }
+
+        Text {
+          text: "R"
+          color: Qt.darker(root.foreground, 1.35)
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.caption
+          width: Style.space(12)
+          anchors.verticalCenter: parent.verticalCenter
+        }
+      }
+    }
+
+    MouseArea {
+      anchors.fill: parent
+      acceptedButtons: Qt.NoButton
+      hoverEnabled: true
+      onContainsMouseChanged: if (containsMouse) root.setCursor(balanceRow.rowIndex)
     }
   }
 

--- a/Model.js
+++ b/Model.js
@@ -8,6 +8,16 @@ function isPlaybackStream(node) {
     || mediaClass.indexOf("Output") !== -1
 }
 
+function isRecordingStream(node) {
+  if (!node || !node.isStream) return false
+  if (node.isSink === false) return true
+
+  var mediaClass = String(node.type || "")
+  return mediaClass.indexOf("Stream/Input/Audio") !== -1
+    || mediaClass.indexOf("AudioInStream") !== -1
+    || mediaClass.indexOf("Input") !== -1
+}
+
 function isAudioSource(node) {
   if (!node) return false
   if (node.audio) return true
@@ -22,10 +32,47 @@ function listSnapshot(list) {
   return list && list.slice ? list.slice() : []
 }
 
+function parseAudioControlSettings(raw) {
+  var parsed
+  try {
+    parsed = JSON.parse(String(raw || "{}"))
+  } catch (e) {
+    parsed = {}
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) parsed = {}
+  return {
+    version: 1,
+    outputOverdrive: parsed.outputOverdrive === true
+  }
+}
+
+function balanceValue(left, right) {
+  var l = Math.max(0, Number(left || 0))
+  var r = Math.max(0, Number(right || 0))
+  var peak = Math.max(l, r)
+  if (peak === 0) return 0
+  return r >= l ? 1 - l / peak : -(1 - r / peak)
+}
+
+function applyBalance(volumes, leftIndex, rightIndex, balance) {
+  var values = []
+  var source = volumes && typeof volumes.length === "number" ? volumes : []
+  for (var i = 0; i < source.length; i++) values.push(Number(source[i] || 0))
+  if (leftIndex < 0 || rightIndex < 0 || leftIndex >= values.length || rightIndex >= values.length)
+    return values
+
+  var value = Math.max(-1, Math.min(1, Number(balance || 0)))
+  var peak = Math.max(values[leftIndex], values[rightIndex])
+  values[leftIndex] = peak * (value > 0 ? 1 - value : 1)
+  values[rightIndex] = peak * (value < 0 ? 1 + value : 1)
+  return values
+}
+
 function outputVolumeName(volume, muted) {
   if (muted) return "Muted"
   var p = Math.round(volume * 100)
   if (p === 0) return "Silenced"
+  if (p > 125) return "Overdrive"
   if (p >= 100) return "Concert hall"
   if (p >= 85) return "Party mode"
   if (p >= 70) return "Cranked up"
@@ -91,6 +138,38 @@ function parseAudioProfiles(raw) {
     return a.label.localeCompare(b.label)
   })
   return normalized
+}
+
+function parseAudioPorts(raw) {
+  var values
+  try {
+    values = JSON.parse(String(raw || "[]"))
+  } catch (e) {
+    return []
+  }
+  if (!Array.isArray(values)) return []
+
+  var ports = []
+  for (var i = 0; i < values.length; i++) {
+    var item = values[i]
+    if (!item || (item.direction !== "output" && item.direction !== "input")
+        || !item.endpoint || !Array.isArray(item.ports) || item.ports.length < 2) continue
+    var options = []
+    for (var j = 0; j < item.ports.length; j++) {
+      var port = item.ports[j]
+      if (!port || !port.value) continue
+      options.push({ value: String(port.value), label: String(port.label || port.value) })
+    }
+    if (options.length < 2) continue
+    ports.push({
+      direction: item.direction,
+      endpoint: String(item.endpoint),
+      label: String(item.label || item.endpoint),
+      activePort: String(item.activePort || ""),
+      ports: options
+    })
+  }
+  return ports
 }
 
 function audioProfileLabel(profile, bluetooth) {
@@ -178,6 +257,30 @@ function streamOutputOptions(outputs, defaultOutput) {
     var outputSerial = nodeSerial(output)
     if (outputSerial === "" || outputSerial === defaultSerial) continue
     options.push({ value: "override:" + outputSerial, label: "Always use " + nodeLabel(output) })
+  }
+  return options
+}
+
+function recordingInputOptions(inputs, defaultInput) {
+  var values = Array.isArray(inputs) ? inputs : []
+  var options = []
+  var defaultSerial = nodeSerial(defaultInput)
+
+  for (var i = 0; i < values.length; i++) {
+    var candidate = values[i]
+    var serial = nodeSerial(candidate)
+    if (serial !== "" && serial === defaultSerial) {
+      options.push({ value: "default:" + serial, label: "Follow default input" })
+      options.push({ value: "override:" + serial, label: "Always use " + nodeLabel(candidate) })
+      break
+    }
+  }
+
+  for (var j = 0; j < values.length; j++) {
+    var input = values[j]
+    var inputSerial = nodeSerial(input)
+    if (inputSerial === "" || inputSerial === defaultSerial) continue
+    options.push({ value: "override:" + inputSerial, label: "Always use " + nodeLabel(input) })
   }
   return options
 }
@@ -355,6 +458,48 @@ function streamLabel(node, players, streams) {
     || label) || "Stream"
 }
 
+function recordingStreamLabel(node) {
+  return friendlyStreamLabel(rawStreamLabel(node)) || "Recording application"
+}
+
+function normalizeStreamIconName(name) {
+  var value = String(name || "").trim()
+  var aliases = {
+    "chromium-browser": "chromium",
+    "spotify-client": "spotify",
+    "discord": "discord"
+  }
+  return aliases[value.toLowerCase()] || value
+}
+
+function streamIconName(node, players, streams) {
+  var p = nodeProps(node)
+  var direct = p["application.icon_name"] || p["application.icon-name"] || ""
+  if (direct) return normalizeStreamIconName(direct)
+
+  var values = Array.isArray(players) ? players : []
+  for (var i = 0; i < values.length; i++) {
+    var player = values[i]
+    if (!player || !streamRepresentsPlayer(node, player, values, streams)) continue
+    if (player.desktopEntry)
+      return normalizeStreamIconName(String(player.desktopEntry).replace(/\.desktop$/i, ""))
+  }
+
+  var applicationId = String(p["application.id"] || "")
+  if (applicationId) return normalizeStreamIconName(applicationId.replace(/\.desktop$/i, ""))
+
+  var binary = String(p["application.process.binary"] || "")
+  if (binary) return normalizeStreamIconName(binary.split("/").pop())
+
+  var labelIcons = {
+    "spotify": "spotify",
+    "chromium": "chromium"
+  }
+  var label = streamLabelKey(rawStreamLabel(node))
+  if (labelIcons[label]) return labelIcons[label]
+  return ""
+}
+
 function streamRepresentsPlayer(node, player, players, streams) {
   if (!node || !player) return false
   var playerLabel = mprisPlayerLabel(player)
@@ -368,11 +513,16 @@ function streamRepresentsPlayer(node, player, players, streams) {
 if (typeof module !== "undefined") {
   module.exports = {
     isPlaybackStream: isPlaybackStream,
+    isRecordingStream: isRecordingStream,
     isAudioSource: isAudioSource,
     listSnapshot: listSnapshot,
+    parseAudioControlSettings: parseAudioControlSettings,
+    balanceValue: balanceValue,
+    applyBalance: applyBalance,
     outputVolumeName: outputVolumeName,
     parseSinkAvailability: parseSinkAvailability,
     parseAudioProfiles: parseAudioProfiles,
+    parseAudioPorts: parseAudioPorts,
     audioProfileLabel: audioProfileLabel,
     audioProfileOptions: audioProfileOptions,
     audioCardsByBluetooth: audioCardsByBluetooth,
@@ -381,6 +531,7 @@ if (typeof module !== "undefined") {
     nodeProps: nodeProps,
     nodeSerial: nodeSerial,
     streamOutputOptions: streamOutputOptions,
+    recordingInputOptions: recordingInputOptions,
     parseStreamOutputOption: parseStreamOutputOption,
     nodeLabel: nodeLabel,
     isHeadphones: isHeadphones,
@@ -397,6 +548,8 @@ if (typeof module !== "undefined") {
     matchingMprisStreamLabel: matchingMprisStreamLabel,
     unmatchedMprisStreamLabel: unmatchedMprisStreamLabel,
     streamLabel: streamLabel,
+    recordingStreamLabel: recordingStreamLabel,
+    streamIconName: streamIconName,
     streamRepresentsPlayer: streamRepresentsPlayer
   }
 }

--- a/Panel.qml
+++ b/Panel.qml
@@ -22,9 +22,17 @@ Panel {
   readonly property var source: Pipewire.defaultAudioSource
   readonly property var nodes: Pipewire.nodes ? Pipewire.nodes.values : []
   readonly property var mprisPlayers: Mpris.players ? Mpris.players.values : []
+  readonly property var appLibrary: bar && bar.shell ? bar.shell.appLibrary : null
   readonly property var mediaService: bar && bar.shell
     ? bar.shell.firstPartyServiceFor("omarchy.media") : null
   readonly property var activeMediaPlayer: mediaService ? mediaService.activePlayer : null
+  readonly property string settingsPath: {
+    var configHome = Quickshell.env("XDG_CONFIG_HOME")
+    if (!configHome) configHome = Quickshell.env("HOME") + "/.config"
+    return configHome + "/omarchy/audio-control.json"
+  }
+  property bool outputOverdrive: false
+  readonly property real outputVolumeMaximum: outputOverdrive ? 1.5 : 1.0
 
   readonly property var candidateSinks: {
     var list = []
@@ -61,6 +69,19 @@ Panel {
     return list
   }
 
+  readonly property var candidateRecordingStreams: {
+    var list = []
+    for (var i = 0; i < nodes.length; i++) {
+      var n = nodes[i]
+      if (!n || !isRecordingStream(n)) continue
+      // The microphone peak meter creates its own capture stream while this
+      // panel is open; it is instrumentation, not a recording application.
+      if (String(n.name || "").toLowerCase() === "quickshell") continue
+      list.push(n)
+    }
+    return list
+  }
+
   property var sinkAvailability: ({})
   property bool sinkAvailabilityLoaded: false
 
@@ -73,6 +94,10 @@ Panel {
   // `isSink: true`; capture streams publish as stream sources.
   function isPlaybackStream(node) {
     return Model.isPlaybackStream(node)
+  }
+
+  function isRecordingStream(node) {
+    return Model.isRecordingStream(node)
   }
 
   function isAudioSource(node) {
@@ -106,6 +131,13 @@ Panel {
     return list
   }
 
+  readonly property var recordingStreams: {
+    var list = []
+    for (var i = 0; i < candidateRecordingStreams.length; i++)
+      if (candidateRecordingStreams[i].audio) list.push(candidateRecordingStreams[i])
+    return list
+  }
+
   // Feed Repeaters with panel-local snapshots instead of the live PipeWire
   // model. PipeWire can remove nodes while Quickshell is dispatching the
   // removal signal; rebuilding a Repeater from that signal path has crashed
@@ -114,6 +146,7 @@ Panel {
   property var displayAudioSinks: []
   property var displayAudioSources: []
   property var displayAudioStreams: []
+  property var displayRecordingStreams: []
 
   // Per-application routing is separate from the preferred default sink.
   // WirePlumber persists explicit targets by application identity and restores
@@ -122,6 +155,7 @@ Panel {
   // values, so this live-state map remains exact even when several applications
   // share a display name.
   property var streamRoutes: ({})
+  property var recordingStreamRoutes: ({})
   property bool streamOutputMenuOpen: false
   property string streamRouteReadError: ""
   property string streamRouteSetError: ""
@@ -132,6 +166,7 @@ Panel {
   // The default is ordered first and named by behavior. Applications on that
   // option follow later default changes; all other choices are persistent.
   readonly property var streamOutputOptions: Model.streamOutputOptions(displayAudioSinks, sink)
+  readonly property var recordingInputOptions: Model.recordingInputOptions(displayAudioSources, source)
 
   // A DSP sink -- a speaker tuning, or EasyEffects -- can be the selected output
   // without being where loudness lives: changing its volume alters the level going
@@ -158,6 +193,7 @@ Panel {
     }
     return sink
   }
+  onVolumeSinkChanged: enforceOutputVolumeLimit()
 
   // Re-resolve whenever the selected output changes; the timer below is only a
   // safety net for the tuning being applied or removed underneath us.
@@ -178,7 +214,8 @@ Panel {
   // Single cursor model shared by keyboard and mouse. Sections:
   //   "output"  — output slider + sink device list
   //   "input"   — input slider + source device list
-  //   "streams" — per-app playback streams
+  //   "streams"   — per-app playback streams
+  //   "recording" — per-app recording streams
   // selectedIndex semantics within a section:
   //   -1            → on the slider row (h/l adjusts volume, m/Enter mute)
   //   0..N-1        → on the Nth device/stream row
@@ -212,6 +249,7 @@ Panel {
     if (section === "output") return displayAudioSinks.length
     if (section === "input") return displayAudioSources.length
     if (section === "streams") return displayAudioStreams.length
+    if (section === "recording") return displayRecordingStreams.length
     return 0
   }
 
@@ -219,6 +257,7 @@ Panel {
     if (section === "output") return true
     if (section === "input") return displayAudioSources.length > 0 || !!source
     if (section === "streams") return displayAudioStreams.length > 0
+    if (section === "recording") return displayRecordingStreams.length > 0
     return false
   }
 
@@ -235,6 +274,7 @@ Panel {
     if (sectionVisible("output")) list.push("output")
     if (sectionVisible("input")) list.push("input")
     if (sectionVisible("streams")) list.push("streams")
+    if (sectionVisible("recording")) list.push("recording")
     return list
   }
 
@@ -317,6 +357,12 @@ Panel {
     if (focusSection === "streams" && selectedIndex >= 0 && selectedIndex < displayAudioStreams.length) {
       var s = displayAudioStreams[selectedIndex]
       if (s && s.audio) s.audio.volume = Math.max(0, Math.min(1.5, s.audio.volume + delta))
+      return
+    }
+    if (focusSection === "recording" && selectedIndex >= 0 && selectedIndex < displayRecordingStreams.length) {
+      var recording = displayRecordingStreams[selectedIndex]
+      if (recording && recording.audio)
+        recording.audio.volume = Math.max(0, Math.min(1.5, recording.audio.volume + delta))
     }
   }
 
@@ -346,6 +392,16 @@ Panel {
         var st = displayAudioStreams[selectedIndex]
         if (st && st.audio) st.audio.muted = !st.audio.muted
       }
+      return
+    }
+    if (focusSection === "recording" && selectedIndex >= 0) {
+      var recordingRow = recordingStreamRepeater.itemAt(selectedIndex)
+      if (recordingRow && displayAudioSources.length > 1) recordingRow.toggleOutputMenu()
+      else {
+        var recordingStream = displayRecordingStreams[selectedIndex]
+        if (recordingStream && recordingStream.audio)
+          recordingStream.audio.muted = !recordingStream.audio.muted
+      }
     }
   }
 
@@ -359,6 +415,7 @@ Panel {
 
   onOpenedChanged: {
     if (opened) {
+      if (appLibrary && typeof appLibrary.refreshIcons === "function") appLibrary.refreshIcons()
       refreshDisplayAudioModels()
       focusSection = "output"
       headerIndex = 1
@@ -375,6 +432,7 @@ Panel {
   onAudioSinksChanged: scheduleDisplayAudioModelRefresh()
   onAudioSourcesChanged: scheduleDisplayAudioModelRefresh()
   onAudioStreamsChanged: scheduleDisplayAudioModelRefresh()
+  onRecordingStreamsChanged: scheduleDisplayAudioModelRefresh()
 
   function listSnapshot(list) {
     return Model.listSnapshot(list)
@@ -385,6 +443,9 @@ Panel {
     displayAudioSinks = listSnapshot(audioSinks)
     displayAudioSources = listSnapshot(audioSources)
     displayAudioStreams = listSnapshot(audioStreams)
+    displayRecordingStreams = listSnapshot(recordingStreams)
+    if (displayAudioStreams.length === 0) streamRoutes = ({})
+    if (displayRecordingStreams.length === 0) recordingStreamRoutes = ({})
     refreshStreamRoutes()
     clampCursor()
   }
@@ -399,14 +460,17 @@ Panel {
     displayAudioSinks = []
     displayAudioSources = []
     displayAudioStreams = []
+    displayRecordingStreams = []
     streamRoutes = ({})
+    recordingStreamRoutes = ({})
     streamRouteReadError = ""
     streamRouteSetError = ""
     pendingStreamRoute = null
   }
 
   function refreshStreamRoutes() {
-    if (!opened || displayAudioStreams.length === 0 || streamRoutesProc.running) return
+    if (!opened || (displayAudioStreams.length === 0 && displayRecordingStreams.length === 0)
+        || streamRoutesProc.running) return
     streamRoutesProc.running = true
   }
 
@@ -414,16 +478,22 @@ Panel {
     try {
       var routes = JSON.parse(String(raw || "{}"))
       if (!routes || typeof routes !== "object") routes = ({})
-      if (pendingStreamRoute)
-        routes[pendingStreamRoute.stream] = {
-          sink: pendingStreamRoute.sink,
+      var playback = routes.playback && typeof routes.playback === "object" ? routes.playback : ({})
+      var recording = routes.recording && typeof routes.recording === "object" ? routes.recording : ({})
+      if (pendingStreamRoute) {
+        var pendingRoutes = pendingStreamRoute.direction === "recording" ? recording : playback
+        pendingRoutes[pendingStreamRoute.stream] = {
+          target: pendingStreamRoute.target,
           mode: pendingStreamRoute.mode
         }
-      streamRoutes = routes
+      }
+      streamRoutes = playback
+      recordingStreamRoutes = recording
       streamRouteReadError = ""
     } catch (e) {
       streamRoutes = ({})
-      streamRouteReadError = "Could not read application outputs"
+      recordingStreamRoutes = ({})
+      streamRouteReadError = "Could not read application routes"
     }
   }
 
@@ -438,23 +508,34 @@ Panel {
     return route && typeof route === "object" ? route : null
   }
 
-  function setStreamRoute(node, optionValue) {
+  function recordingStreamRoute(node) {
+    var serial = streamSerial(node)
+    if (serial === "") return null
+    var route = recordingStreamRoutes[serial]
+    return route && typeof route === "object" ? route : null
+  }
+
+  function setStreamRoute(node, optionValue, direction) {
     var streamSerialValue = streamSerial(node)
     var route = Model.parseStreamOutputOption(optionValue)
     if (streamSerialValue === "" || route.sink === "" || route.mode === "" || streamRouteSetProc.running) return
 
+    var routes = direction === "recording" ? recordingStreamRoutes : streamRoutes
     var next = ({})
-    for (var key in streamRoutes) next[key] = streamRoutes[key]
-    next[streamSerialValue] = { sink: route.sink, mode: route.mode }
-    streamRoutes = next
+    for (var key in routes) next[key] = routes[key]
+    next[streamSerialValue] = { target: route.sink, mode: route.mode }
+    if (direction === "recording") recordingStreamRoutes = next
+    else streamRoutes = next
     streamRouteSetError = ""
     pendingStreamRoute = {
+      direction: direction,
       stream: streamSerialValue,
-      sink: route.sink,
+      target: route.sink,
       mode: route.mode
     }
     streamRouteSetProc.command = [
       pluginScript("audio-stream-route-set"),
+      direction,
       streamSerialValue,
       route.sink,
       route.mode
@@ -463,8 +544,8 @@ Panel {
   }
 
   // Keep the keyboard-focused row inside the visible viewport of the
-  // ScrollView. Each cursor target (slider rows, SinkRow, SourceRow,
-  // StreamRow) calls this when it gains hasCursor. Without it, j/k can
+  // ScrollView. Each cursor target (slider rows, device rows, application rows)
+  // calls this when it gains hasCursor. Without it, j/k can
   // walk the selection off-screen — wifi uses ListView.positionViewAtIndex
   // for this; we don't have that affordance with a multi-section Column.
   function resetScroll() {
@@ -539,9 +620,18 @@ Panel {
 
   function setOutputVolume(v) {
     if (!volumeSink || !volumeSink.audio) return outputVolume
-    var volume = Math.max(0, Math.min(1, v))
+    var volume = Math.max(0, Math.min(outputVolumeMaximum, v))
     volumeSink.audio.volume = volume
     return volume
+  }
+
+  function enforceOutputVolumeLimit() {
+    if (!outputOverdrive && outputVolume > 1) setOutputVolume(1)
+  }
+
+  function loadAudioControlSettings(raw) {
+    outputOverdrive = Model.parseAudioControlSettings(raw).outputOverdrive
+    enforceOutputVolumeLimit()
   }
 
   function showVolumeOsd(volume) {
@@ -590,12 +680,14 @@ Panel {
 
   function setDefaultSource(node) {
     if (!node) return
+    var previousSourceName = source && source.name ? String(source.name) : ""
     Pipewire.preferredDefaultAudioSource = node
     if (node.id !== undefined && node.name) {
       Quickshell.execDetached([
-        "omarchy-audio-input-set-default",
+        pluginScript("audio-input-set-default"),
         String(node.id),
-        String(node.name)
+        String(node.name),
+        previousSourceName
       ])
     }
   }
@@ -682,6 +774,22 @@ Panel {
     return Model.streamLabel(node, mprisPlayers, displayAudioStreams)
   }
 
+  function recordingStreamLabel(node) {
+    return Model.recordingStreamLabel(node)
+  }
+
+  function streamIconSource(node) {
+    var name = Model.streamIconName(node, mprisPlayers, displayAudioStreams)
+    if (!name) return ""
+    if (name.indexOf("file://") === 0 || name.indexOf("image://") === 0) return name
+    if (name.charAt(0) === "/") return Util.fileUrl(name)
+    var themed = Quickshell.iconPath(name, true)
+    if (themed) return themed
+    if (appLibrary && appLibrary.iconIndex && appLibrary.iconIndex[name]
+        && typeof appLibrary.iconSource === "function") return appLibrary.iconSource(name)
+    return ""
+  }
+
   function streamRepresentsPlayer(node, player) {
     return Model.streamRepresentsPlayer(node, player, mprisPlayers, displayAudioStreams)
   }
@@ -692,11 +800,22 @@ Panel {
   PwObjectTracker { objects: root.candidateSinks }
   PwObjectTracker { objects: root.candidateSources }
   PwObjectTracker { objects: root.audioStreams }
+  PwObjectTracker { objects: root.recordingStreams }
 
   PwNodePeakMonitor {
     id: inputPeakMonitor
     node: root.source
     enabled: root.opened && !!root.source
+  }
+
+  FileView {
+    id: settingsFile
+    path: root.settingsPath
+    watchChanges: true
+    printErrors: false
+    onLoaded: root.loadAudioControlSettings(text())
+    onLoadFailed: root.loadAudioControlSettings("")
+    onFileChanged: reload()
   }
 
   Process {
@@ -725,15 +844,16 @@ Panel {
       onStreamFinished: root.updateStreamRoutes(text)
     }
     onExited: function(exitCode) {
-      if (exitCode !== 0 && root.opened && root.displayAudioStreams.length > 0)
-        root.streamRouteReadError = "Could not read application outputs"
+      if (exitCode !== 0 && root.opened
+          && (root.displayAudioStreams.length > 0 || root.displayRecordingStreams.length > 0))
+        root.streamRouteReadError = "Could not read application routes"
     }
   }
 
   Process {
     id: streamRouteSetProc
     onExited: function(exitCode) {
-      if (exitCode !== 0) root.streamRouteSetError = "Could not change the application output"
+      if (exitCode !== 0) root.streamRouteSetError = "Could not change the application route"
       else root.streamRouteSetError = ""
       root.pendingStreamRoute = null
       streamRouteRefreshTimer.restart()
@@ -775,7 +895,7 @@ Panel {
 
   Timer {
     interval: 1500
-    running: root.opened && root.displayAudioStreams.length > 0
+    running: root.opened && (root.displayAudioStreams.length > 0 || root.displayRecordingStreams.length > 0)
     repeat: true
     onTriggered: if (!root.streamOutputMenuOpen && !streamRouteSetProc.running)
       root.refreshStreamRoutes()
@@ -825,12 +945,15 @@ Panel {
       onTabRequested: function(direction) { root.switchPanel(direction) }
       onTextKey: function(t) {
         // 'm' mutes whatever the cursor is on: focused section's slider
-        // for output/input, the focused stream for streams.
+        // for output/input, or the focused playback/recording application.
         if (t === "m" || t === "M") {
           if (!root.cursorActive) return
-          if (root.focusSection === "streams" && root.selectedIndex >= 0
-              && root.selectedIndex < root.displayAudioStreams.length) {
-            var s = root.displayAudioStreams[root.selectedIndex]
+          if ((root.focusSection === "streams" || root.focusSection === "recording")
+              && root.selectedIndex >= 0) {
+            var streams = root.focusSection === "recording"
+              ? root.displayRecordingStreams : root.displayAudioStreams
+            if (root.selectedIndex >= streams.length) return
+            var s = streams[root.selectedIndex]
             if (s && s.audio) s.audio.muted = !s.audio.muted
           } else if (root.focusSection === "input") {
             root.toggleInputMute()
@@ -845,7 +968,20 @@ Panel {
         anchors.fill: parent
         clip: true
         ScrollBar.horizontal.policy: ScrollBar.AlwaysOff
-        ScrollBar.vertical.policy: panelColumn.implicitHeight > height ? ScrollBar.AsNeeded : ScrollBar.AlwaysOff
+        ScrollBar.vertical: ScrollBar {
+          id: panelScrollBar
+          policy: panelColumn.implicitHeight > scrollArea.height
+            ? ScrollBar.AsNeeded : ScrollBar.AlwaysOff
+          interactive: false
+          width: Style.space(5)
+          background: Item { }
+          contentItem: Rectangle {
+            implicitWidth: Style.space(3)
+            radius: width / 2
+            color: root.bar.foreground
+            opacity: panelScrollBar.active ? 0.55 : 0.25
+          }
+        }
         Binding {
           target: scrollArea.contentItem
           property: "interactive"
@@ -1003,7 +1139,7 @@ Panel {
                 anchors.leftMargin: Style.space(6)
                 anchors.rightMargin: Style.space(6)
                 minimum: 0
-                maximum: 1
+                maximum: root.outputVolumeMaximum
                 step: 0.05
                 value: root.outputVolume
                 opacity: root.outputMuted ? 0.5 : 1.0
@@ -1142,7 +1278,7 @@ Panel {
             }
           }
 
-          // ---- Per-app streams ----
+          // ---- Per-app playback and recording streams ----
           PanelSeparator {
             visible: root.displayAudioStreams.length > 0
             foreground: root.bar.foreground
@@ -1154,7 +1290,7 @@ Panel {
             visible: root.displayAudioStreams.length > 0
 
             PanelSectionHeader {
-              text: "SOURCES"
+              text: "PLAYBACK"
               foreground: root.bar.foreground
               fontFamily: root.bar.fontFamily
             }
@@ -1163,24 +1299,56 @@ Panel {
               id: streamRepeater
               model: root.displayAudioStreams
 
-              StreamRow {
+              ApplicationStreamRow {
                 required property var modelData
                 required property int index
                 width: panelColumn.width
                 node: modelData
                 rowIndex: index
+                recording: false
               }
             }
+          }
 
-            Text {
-              visible: root.streamRouteError !== ""
-              width: parent.width
-              text: root.streamRouteError
-              color: root.bar.urgent
-              font.family: root.bar.fontFamily
-              font.pixelSize: Style.font.bodySmall
-              wrapMode: Text.WordWrap
+          PanelSeparator {
+            visible: root.displayRecordingStreams.length > 0
+            foreground: root.bar.foreground
+          }
+
+          Column {
+            width: parent.width
+            spacing: Style.space(10)
+            visible: root.displayRecordingStreams.length > 0
+
+            PanelSectionHeader {
+              text: "RECORDING"
+              foreground: root.bar.foreground
+              fontFamily: root.bar.fontFamily
             }
+
+            Repeater {
+              id: recordingStreamRepeater
+              model: root.displayRecordingStreams
+
+              ApplicationStreamRow {
+                required property var modelData
+                required property int index
+                width: panelColumn.width
+                node: modelData
+                rowIndex: index
+                recording: true
+              }
+            }
+          }
+
+          Text {
+            visible: root.streamRouteError !== ""
+            width: parent.width
+            text: root.streamRouteError
+            color: root.bar.urgent
+            font.family: root.bar.fontFamily
+            font.pixelSize: Style.font.bodySmall
+            wrapMode: Text.WordWrap
           }
         }
       }
@@ -1309,32 +1477,44 @@ Panel {
     }
   }
 
-  // Per-app stream row — cursor target inside the "streams" section.
-  // The stream has its own slider inline, so h/l from the keyboard adjusts
-  // THIS stream's volume. With multiple outputs, a compact device button (or
-  // Enter/Space from the row cursor) opens routing; `m` remains direct mute.
-  component StreamRow: CursorSurface {
+  // Playback and recording applications share interaction and volume controls;
+  // only their endpoint list, route map, label, and icon differ.
+  component ApplicationStreamRow: CursorSurface {
     id: streamRow
     required property var node
     required property int rowIndex
+    property bool recording: false
 
     readonly property real streamVolume: node && node.audio ? node.audio.volume : 0
     readonly property bool streamMuted: node && node.audio ? node.audio.muted : false
-    readonly property bool isActive: root.streamRepresentsPlayer(node, root.activeMediaPlayer)
+    readonly property bool isActive: !recording && root.streamRepresentsPlayer(node, root.activeMediaPlayer)
     readonly property string streamSerial: root.streamSerial(node)
-    readonly property var currentRoute: root.streamRoute(node)
-    readonly property string sinkSerial: currentRoute ? String(currentRoute.sink || "") : ""
+    readonly property var currentRoute: recording
+      ? root.recordingStreamRoute(node) : root.streamRoute(node)
+    readonly property string targetSerial: currentRoute ? String(currentRoute.target || "") : ""
     readonly property string routeMode: currentRoute ? String(currentRoute.mode || "") : ""
-    readonly property string routeOptionValue: routeMode !== "" && sinkSerial !== "" ? routeMode + ":" + sinkSerial : ""
+    readonly property string routeOptionValue: routeMode !== "" && targetSerial !== ""
+      ? routeMode + ":" + targetSerial : ""
     readonly property bool routeIsExplicit: routeMode === "override"
-    hasCursor: root.cursorActive && root.focusSection === "streams" && root.selectedIndex === rowIndex
+    readonly property string routeSection: recording ? "recording" : "streams"
+    readonly property int targetCount: recording
+      ? root.displayAudioSources.length : root.displayAudioSinks.length
+    readonly property var routeOptions: recording
+      ? root.recordingInputOptions : root.streamOutputOptions
+    hasCursor: root.cursorActive && root.focusSection === routeSection && root.selectedIndex === rowIndex
     onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(streamRow)
     foreground: root.bar.foreground
     fill: root.hoverFill
     implicitHeight: streamColumn.implicitHeight + Style.spacing.xl
 
+    PwNodePeakMonitor {
+      id: streamPeakMonitor
+      node: streamRow.node
+      enabled: root.opened && !!streamRow.node
+    }
+
     function toggleOutputMenu() {
-      if (root.displayAudioSinks.length > 1 && streamRow.sinkSerial !== "" && routeDropdown.enabled)
+      if (streamRow.targetCount > 1 && streamRow.targetSerial !== "" && routeDropdown.enabled)
         routeDropdown.toggle()
     }
 
@@ -1359,16 +1539,39 @@ Panel {
           anchors.fill: parent
           spacing: Style.space(8)
 
-          Text {
+          Item {
             id: streamMuteIcon
-            text: streamRow.streamMuted ? "󰝟" : "󰕾"
-            color: root.bar.foreground
-            font.family: root.bar.fontFamily
-            font.pixelSize: Style.font.title
             width: Style.space(22)
-            horizontalAlignment: Text.AlignHCenter
+            height: Style.font.title
             anchors.verticalCenter: parent.verticalCenter
-            opacity: streamRow.streamMuted ? 0.5 : 1.0
+
+            Image {
+              id: streamAppIcon
+              anchors.centerIn: parent
+              width: Style.font.title
+              height: Style.font.title
+              fillMode: Image.PreserveAspectFit
+              sourceSize.width: Math.round(width * Screen.devicePixelRatio)
+              sourceSize.height: Math.round(height * Screen.devicePixelRatio)
+              source: root.streamIconSource(streamRow.node)
+              asynchronous: true
+              visible: status === Image.Ready
+              opacity: streamRow.streamMuted ? 0.5 : 1.0
+            }
+
+            Text {
+              visible: !streamAppIcon.visible
+              anchors.fill: parent
+              text: streamRow.recording
+                ? (streamRow.streamMuted ? "󰍭" : "󰍬")
+                : (streamRow.streamMuted ? "󰝟" : "󰕾")
+              color: root.bar.foreground
+              font.family: root.bar.fontFamily
+              font.pixelSize: Style.font.title
+              horizontalAlignment: Text.AlignHCenter
+              verticalAlignment: Text.AlignVCenter
+              opacity: streamRow.streamMuted ? 0.5 : 1.0
+            }
 
             MouseArea {
               anchors.fill: parent
@@ -1387,7 +1590,8 @@ Panel {
 
             Text {
               id: streamName
-              text: root.streamLabel(streamRow.node)
+              text: streamRow.recording
+                ? root.recordingStreamLabel(streamRow.node) : root.streamLabel(streamRow.node)
               color: root.bar.foreground
               font.family: root.bar.fontFamily
               font.pixelSize: Style.font.body
@@ -1401,7 +1605,7 @@ Panel {
 
             Text {
               id: routeChevron
-              visible: root.displayAudioSinks.length > 1 && streamRow.sinkSerial !== ""
+              visible: streamRow.targetCount > 1 && streamRow.targetSerial !== ""
               width: Style.space(22)
               text: {
                 var position = root.bar ? root.bar.position : "left"
@@ -1437,8 +1641,8 @@ Panel {
 
         // Routing is a property of the application, so the dropdown's actual
         // trigger spans the whole header. Its chrome is hidden: the adjacent
-        // chevron communicates the submenu while the speaker exclusively owns
-        // mute and the slider below continues to own volume changes.
+        // chevron communicates the submenu while the leading icon owns mute
+        // and the slider below continues to own volume changes.
         AudioDropdown {
           id: routeDropdown
           anchors.left: parent.left
@@ -1447,7 +1651,7 @@ Panel {
           anchors.top: parent.top
           anchors.bottom: parent.bottom
           z: 1
-          visible: root.displayAudioSinks.length > 1 && streamRow.sinkSerial !== ""
+          visible: streamRow.targetCount > 1 && streamRow.targetSerial !== ""
           rowHeight: height
           popupRowHeight: Style.space(34)
           popupDirection: {
@@ -1468,17 +1672,19 @@ Panel {
           showChevron: false
           triggerChrome: false
           value: streamRow.routeOptionValue
-          options: root.streamOutputOptions
+          options: streamRow.routeOptions
           enabled: streamRow.streamSerial !== "" && !streamRouteSetProc.running
           foreground: root.bar.foreground
           fontFamily: root.bar.fontFamily
 
           onHovered: function(on) { if (on) {
             root.cursorActive = true
-            root.focusSection = "streams"
+            root.focusSection = streamRow.routeSection
             root.selectedIndex = streamRow.rowIndex
           } }
-          onChanged: function(route) { root.setStreamRoute(streamRow.node, route) }
+          onChanged: function(route) {
+            root.setStreamRoute(streamRow.node, route, streamRow.recording ? "recording" : "playback")
+          }
           onPopupOpenChanged: {
             root.streamOutputMenuOpen = popupOpen
             if (!popupOpen) Qt.callLater(function() { keyCatcher.forceActiveFocus() })
@@ -1503,6 +1709,20 @@ Panel {
             streamRow.node.audio.muted = !streamRow.node.audio.muted
         }
       }
+
+      Rectangle {
+        width: parent.width
+        height: Math.max(Style.space(4), Style.spacing.xs)
+        color: Util.alpha(root.bar.foreground, 0.18)
+        opacity: streamRow.streamMuted ? 0.35 : 1.0
+
+        Rectangle {
+          height: parent.height
+          width: parent.width * Math.max(0, Math.min(1, streamPeakMonitor.peak))
+          color: root.bar.foreground
+          Behavior on width { NumberAnimation { duration: 70 } }
+        }
+      }
     }
 
     MouseArea {
@@ -1512,7 +1732,7 @@ Panel {
       propagateComposedEvents: true
       onContainsMouseChanged: if (containsMouse) {
         root.cursorActive = true
-        root.focusSection = "streams"
+        root.focusSection = streamRow.routeSection
         root.selectedIndex = streamRow.rowIndex
       }
     }

--- a/README.md
+++ b/README.md
@@ -9,8 +9,13 @@ instead of introducing a separate mixer application.
 ## Features
 
 - Remember each application's chosen output across stream and application restarts.
+- Route recording applications to a preferred microphone and control their gain.
+- Show application icons and live playback/recording activity meters.
+- Optionally extend output volume to 150% and adjust stereo channel balance.
+- Select endpoint ports when a live device exposes multiple usable paths.
 - Configure device profiles and Bluetooth codecs in separate keyboard-navigable tabs.
 - Control when Bluetooth headsets switch into communication mode.
+- Choose whether automatic Bluetooth profile selection favors quality or latency.
 
 The optional [Advanced Bluetooth Audio](https://github.com/ssupt/omarchy-bluetooth-audio)
 companion brings the same codec controls into Omarchy's Bluetooth panel while
@@ -30,6 +35,8 @@ not require `sudo` or install a background service.
 Application routes use WirePlumber's native stream-target restoration. Choosing
 **Follow default output** removes the remembered target; choosing **Always use**
 an output restores that choice whenever the application creates a new stream.
+Recording routes follow the same behavior for microphones. Explicitly routed
+recording applications stay pinned when the default input changes.
 
 ## Installation
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,9 +2,9 @@
   "schemaVersion": 1,
   "id": "ssupt.audio-control",
   "name": "Advanced Audio Control",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": "ssupt",
-  "description": "Adds per-application output routing, device profiles, and Bluetooth codec controls to Omarchy's audio panel",
+  "description": "Adds application playback and recording routing, volume boost, balance, device ports, and Bluetooth audio controls to Omarchy",
   "kinds": [
     "bar-widget",
     "panel"
@@ -15,7 +15,7 @@
   },
   "barWidget": {
     "displayName": "Advanced Audio Control",
-    "description": "Adds per-application output routing, device profiles, and Bluetooth codec controls to Omarchy's audio panel",
+    "description": "Adds application playback and recording routing, volume boost, balance, device ports, and Bluetooth audio controls to Omarchy",
     "category": "Audio",
     "allowMultiple": false
   },

--- a/scripts/audio-bluetooth-profile-preference
+++ b/scripts/audio-bluetooth-profile-preference
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# omarchy:summary=Show or set Bluetooth profile quality preference
+# omarchy:group=audio
+# omarchy:args=[quality|latency]
+
+setting=bluetooth.profile-preference
+preference=${1:-}
+
+if (( $# > 1 )) || [[ -n $preference && $preference != "quality" && $preference != "latency" ]]; then
+  echo "Usage: audio-bluetooth-profile-preference [quality|latency]" >&2
+  exit 1
+fi
+
+if [[ -n $preference ]]; then
+  wpctl settings --save "$setting" "$preference" >/dev/null || exit 1
+fi
+
+wpctl settings "$setting" 2>/dev/null | awk '
+  $1 == "Value:" {
+    gsub(/^"|"$/, "", $2)
+    if ($2 == "quality" || $2 == "latency") { print $2; found=1 }
+  }
+  END { exit !found }
+'

--- a/scripts/audio-input-set-default
+++ b/scripts/audio-input-set-default
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# omarchy:summary=Set the default audio input and move streams following it
+# omarchy:args=<node-id> <source-name> [current-source-name]
+
+node_id=${1:-}
+source_name=${2:-}
+old_source_name=${3:-}
+
+if (( $# < 2 || $# > 3 )) || [[ -z $node_id || -z $source_name ]]; then
+  echo "Usage: audio-input-set-default <node-id> <source-name> [current-source-name]" >&2
+  exit 1
+fi
+
+[[ -n $old_source_name ]] || old_source_name=$(timeout 2 pactl get-default-source 2>/dev/null || true)
+old_source_index=$(timeout 2 pactl -f json list sources 2>/dev/null |
+  jq -r --arg name "$old_source_name" 'map(select(.name == $name))[0].index // empty' || true)
+
+following_outputs=()
+if [[ -n $old_source_index && $old_source_name != "$source_name" ]]; then
+  if metadata=$(timeout 2 pw-metadata -n default 2>/dev/null); then
+    declare -A explicitly_targeted=()
+    while IFS=$'\t' read -r object_id target; do
+      if [[ $object_id =~ ^[0-9]+$ && $target != "-1" ]]; then
+        explicitly_targeted["$object_id"]=1
+      fi
+    done < <(sed -n "s/^update: id:\([0-9][0-9]*\) key:'target\.\(object\|node\)' value:'\([^']*\)'.*/\1\t\3/p" <<<"$metadata")
+
+    while IFS=$'\t' read -r output object_id; do
+      [[ -n $output ]] || continue
+      if [[ -z $object_id || -z ${explicitly_targeted[$object_id]:-} ]]; then
+        following_outputs+=("$output")
+      fi
+    done < <(timeout 2 pactl -f json list source-outputs 2>/dev/null |
+      jq -r --arg source "$old_source_index" '.[]
+        | select((.source | tostring) == $source)
+        | [.index, (.properties."object.id" // "")]
+        | @tsv' || true)
+  fi
+fi
+
+timeout 2 wpctl set-default "$node_id" 2>/dev/null || true
+timeout 2 pactl set-default-source "$source_name" 2>/dev/null || true
+
+for output in "${following_outputs[@]}"; do
+  [[ -n $output ]] && timeout 2 pactl move-source-output "$output" "$source_name" 2>/dev/null || true
+done

--- a/scripts/audio-port-set
+++ b/scripts/audio-port-set
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# omarchy:summary=Select a port on a live audio endpoint
+# omarchy:group=audio
+# omarchy:args=<output|input> <endpoint> <port>
+
+direction=${1:-}
+endpoint=${2:-}
+port=${3:-}
+
+if (( $# != 3 )) || [[ $direction != "output" && $direction != "input" ]] ||
+  [[ -z $endpoint || -z $port ]]; then
+  echo "Usage: audio-port-set <output|input> <endpoint> <port>" >&2
+  exit 1
+fi
+
+if [[ $direction == "output" ]]; then
+  list=sinks
+  command=set-sink-port
+else
+  list=sources
+  command=set-source-port
+fi
+
+if ! timeout 2 pactl -f json list "$list" 2>/dev/null | jq -e \
+  --arg endpoint "$endpoint" --arg port "$port" '
+    any(.[];
+      .name == $endpoint
+      and (. as $audio_endpoint
+        | any(.ports[]?;
+            .name == $port
+            and (.availability != "not available" or $port == $audio_endpoint.active_port))))
+  ' >/dev/null; then
+  echo "Audio port is not available" >&2
+  exit 1
+fi
+
+timeout 2 pactl "$command" "$endpoint" "$port"

--- a/scripts/audio-ports
+++ b/scripts/audio-ports
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# omarchy:summary=List live audio endpoints with multiple usable ports
+# omarchy:group=audio
+
+if (( $# != 0 )); then
+  echo "Usage: audio-ports" >&2
+  exit 1
+fi
+
+set -o pipefail
+
+timeout 2 pactl -f json list 2>/dev/null | jq -c '
+  def usable_ports($endpoint):
+    [
+      $endpoint.ports[]?
+      | select(.availability != "not available" or .name == $endpoint.active_port)
+      | { value: .name, label: (.description // .name) }
+    ];
+
+  def endpoints($direction; $values):
+    [
+      $values[]?
+      | select($direction == "output" or (.name | endswith(".monitor") | not))
+      | . as $endpoint
+      | usable_ports($endpoint) as $ports
+      | select($ports | length > 1)
+      | {
+          direction: $direction,
+          endpoint: $endpoint.name,
+          label: ($endpoint.description // $endpoint.name),
+          activePort: ($endpoint.active_port // ""),
+          ports: $ports
+        }
+    ];
+
+  endpoints("output"; (.sinks // [])) + endpoints("input"; (.sources // []))
+' || exit 1

--- a/scripts/audio-stream-route-set
+++ b/scripts/audio-stream-route-set
@@ -1,35 +1,51 @@
 #!/bin/bash
 
-# omarchy:summary=Set or clear a persistent application output route
+# omarchy:summary=Set or clear a persistent playback or recording application route
 # omarchy:group=audio
-# omarchy:args=<stream-serial> <sink-serial> [override|default]
+# omarchy:args=<playback|recording> <stream-serial> <target-serial> [override|default]
 
-stream=${1:-}
-sink=${2:-}
-mode=${3:-override}
+direction=${1:-}
+stream=${2:-}
+target=${3:-}
+mode=${4:-override}
 
-if (( $# < 2 || $# > 3 )) || [[ ! $stream =~ ^[0-9]+$ || ! $sink =~ ^[0-9]+$ ]] ||
+if (( $# < 3 || $# > 4 )) || [[ $direction != "playback" && $direction != "recording" ]] ||
+  [[ ! $stream =~ ^[0-9]+$ || ! $target =~ ^[0-9]+$ ]] ||
   [[ $mode != "override" && $mode != "default" ]]; then
-  echo "Usage: omarchy-audio-stream-route-set <stream-serial> <sink-serial> [override|default]" >&2
+  echo "Usage: omarchy-audio-stream-route-set <playback|recording> <stream-serial> <target-serial> [override|default]" >&2
   exit 1
 fi
-timeout 2 pactl move-sink-input "$stream" "$sink" || exit 1
+
+if [[ $direction == "playback" ]]; then
+  move_command=move-sink-input
+  streams_key=sink_inputs
+  targets_key=sinks
+else
+  move_command=move-source-output
+  streams_key=source_outputs
+  targets_key=sources
+fi
+
+timeout 2 pactl "$move_command" "$stream" "$target" || exit 1
 
 # WirePlumber stores explicit stream targets by application identity and restores
 # them when that application creates a new stream. Moving through Pulse normally
 # writes such a target, except when the stream is already on that sink. Write both
 # target forms ourselves so choosing the current default is still persistent,
 # and clear both when the user returns to default-following mode.
-stream_object_id=$(timeout 2 pactl -f json list sink-inputs 2>/dev/null |
-  jq -r --arg stream "$stream" 'map(select((.index | tostring) == $stream))[0].properties."object.id" // empty') || exit 1
+state=$(timeout 2 pactl -f json list 2>/dev/null) || exit 1
+stream_object_id=$(jq -r --arg key "$streams_key" --arg stream "$stream" '
+  .[$key] | map(select((.index | tostring) == $stream))[0].properties."object.id" // empty
+' <<<"$state") || exit 1
 [[ $stream_object_id =~ ^[0-9]+$ ]] || exit 1
 
 if [[ $mode == "override" ]]; then
-  sink_object_id=$(timeout 2 pactl -f json list sinks 2>/dev/null |
-    jq -r --arg sink "$sink" 'map(select((.index | tostring) == $sink))[0].properties."object.id" // empty') || exit 1
-  [[ $sink_object_id =~ ^[0-9]+$ ]] || exit 1
-  timeout 2 pw-metadata -n default -- "$stream_object_id" target.object "$sink" Spa:Id >/dev/null 2>&1 || exit 1
-  timeout 2 pw-metadata -n default -- "$stream_object_id" target.node "$sink_object_id" Spa:Id >/dev/null 2>&1 || exit 1
+  target_object_id=$(jq -r --arg key "$targets_key" --arg target "$target" '
+    .[$key] | map(select((.index | tostring) == $target))[0].properties."object.id" // empty
+  ' <<<"$state") || exit 1
+  [[ $target_object_id =~ ^[0-9]+$ ]] || exit 1
+  timeout 2 pw-metadata -n default -- "$stream_object_id" target.object "$target" Spa:Id >/dev/null 2>&1 || exit 1
+  timeout 2 pw-metadata -n default -- "$stream_object_id" target.node "$target_object_id" Spa:Id >/dev/null 2>&1 || exit 1
 else
   timeout 2 pw-metadata -n default -- "$stream_object_id" target.object -1 Spa:Id >/dev/null 2>&1 || exit 1
   timeout 2 pw-metadata -n default -- "$stream_object_id" target.node -1 Spa:Id >/dev/null 2>&1 || exit 1

--- a/scripts/audio-stream-routes
+++ b/scripts/audio-stream-routes
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# omarchy:summary=List live application audio routes as JSON
+# omarchy:summary=List live playback and recording application routes as JSON
 # omarchy:group=audio
 
 if (( $# != 0 )); then
@@ -10,9 +10,9 @@ fi
 
 set -o pipefail
 
-# PipeWire's Pulse server exposes its object.serial as the sink-input index and
-# the destination sink's object.serial as `sink`. Quickshell exposes those same
-# serials on its nodes, giving the native panel an exact, label-independent map.
+# PipeWire's Pulse server exposes stream and endpoint object.serial values as
+# sink-input/source-output and sink/source indices. Quickshell exposes those
+# same serials on its nodes, giving the panel an exact, label-independent map.
 # Explicit targets live in PipeWire metadata; retain that distinction so an app
 # pinned to the current default is not presented as following the default.
 metadata=$(timeout 2 pw-metadata -n default 2>/dev/null) || exit 1
@@ -20,16 +20,23 @@ explicit_targets=$(sed -n "s/^update: id:\([0-9][0-9]*\) key:'target\.\(object\|
   awk -F '\t' '$2 != "-1" { print $1 }' |
   jq -Rsc 'split("\n") | map(select(length > 0)) | map({key: ., value: true}) | from_entries') || exit 1
 
-timeout 2 pactl -f json list sink-inputs 2>/dev/null | jq -c --argjson explicit "$explicit_targets" '
-  map(
-    select(.index != null and .sink != null)
-    | {
-        key: (.index | tostring),
-        value: {
-          sink: (.sink | tostring),
-          mode: (if ($explicit[(.properties."object.id" | tostring)] // false) then "override" else "default" end)
-        }
-      }
-  )
-  | from_entries
+timeout 2 pactl -f json list 2>/dev/null | jq -c --argjson explicit "$explicit_targets" '
+  def routes($streams; $endpoint):
+    $streams
+    | map(
+        select(.index != null and .[$endpoint] != null)
+        | {
+            key: (.index | tostring),
+            value: {
+              target: (.[$endpoint] | tostring),
+              mode: (if ($explicit[(.properties."object.id" | tostring)] // false) then "override" else "default" end)
+            }
+          }
+      )
+    | from_entries;
+
+  {
+    playback: routes((.sink_inputs // []); "sink"),
+    recording: routes((.source_outputs // []); "source")
+  }
 ' || exit 1

--- a/test/all
+++ b/test/all
@@ -30,6 +30,30 @@ const cards = model.parseAudioProfiles(JSON.stringify([{
   ]
 }]))
 
+assert.deepEqual(model.parseAudioControlSettings('{"outputOverdrive":true}'), {
+  version: 1,
+  outputOverdrive: true
+})
+assert.deepEqual(model.parseAudioControlSettings('not json'), {
+  version: 1,
+  outputOverdrive: false
+})
+assert.equal(model.balanceValue(1, 1), 0)
+assert.equal(model.balanceValue(1, 0.25), -0.75)
+assert.equal(model.balanceValue(0.5, 1), 0.5)
+assert.deepEqual(model.applyBalance([0.8, 0.8], 0, 1, 0.25), [0.6000000000000001, 0.8])
+assert.deepEqual(model.applyBalance([0.8, 0.8], 0, 1, -1), [0.8, 0])
+assert.equal(model.outputVolumeName(1, false), 'Concert hall')
+assert.equal(model.outputVolumeName(1.25, false), 'Concert hall')
+assert.equal(model.outputVolumeName(1.26, false), 'Overdrive')
+assert.deepEqual(model.parseAudioPorts(JSON.stringify([{
+  direction: 'output', endpoint: 'speakers', label: 'Built-in Audio', activePort: 'speaker',
+  ports: [{ value: 'speaker', label: 'Speakers' }, { value: 'headphones', label: 'Headphones' }]
+}])), [{
+  direction: 'output', endpoint: 'speakers', label: 'Built-in Audio', activePort: 'speaker',
+  ports: [{ value: 'speaker', label: 'Speakers' }, { value: 'headphones', label: 'Headphones' }]
+}])
+
 assert.equal(cards.length, 1)
 assert.equal(model.hasBluetoothCards(cards), true)
 assert.deepEqual(model.audioCardsByBluetooth(cards, true).map(card => card.label), ['Headphones'])
@@ -50,11 +74,34 @@ const headphones = {
   ready: true,
   properties: { 'object.serial': 11 }
 }
+const defaultInput = {
+  name: 'default-input',
+  nickname: 'Desk Microphone',
+  ready: true,
+  properties: { 'object.serial': 20 }
+}
+const headsetInput = {
+  name: 'headset-input',
+  nickname: 'Headset Microphone',
+  ready: true,
+  properties: { 'object.serial': 21 }
+}
 assert.deepEqual(model.streamOutputOptions([defaultOutput, headphones], defaultOutput), [
   { value: 'default:10', label: 'Follow default output' },
   { value: 'override:10', label: 'Always use Desk Speakers' },
   { value: 'override:11', label: 'Always use Headphones' }
 ])
+assert.deepEqual(model.recordingInputOptions([defaultInput, headsetInput], defaultInput), [
+  { value: 'default:20', label: 'Follow default input' },
+  { value: 'override:20', label: 'Always use Desk Microphone' },
+  { value: 'override:21', label: 'Always use Headset Microphone' }
+])
+assert.equal(model.isRecordingStream({ isStream: true, isSink: false }), true)
+assert.equal(model.isRecordingStream({ isStream: true, isSink: true }), false)
+assert.equal(model.streamIconName({ ready: true, properties: { 'application.icon_name': 'firefox' } }, [], []), 'firefox')
+assert.equal(model.streamIconName({ ready: true, properties: { 'application.icon_name': 'chromium-browser' } }, [], []), 'chromium')
+assert.equal(model.streamIconName({ ready: true, properties: { 'application.id': 'org.example.App.desktop' } }, [], []), 'org.example.App')
+assert.equal(model.streamIconName({ description: 'Spotify' }, [], []), 'spotify')
 console.log('PASS: profile and routing model')
 JS
 
@@ -62,7 +109,7 @@ route_log=$(mktemp)
 trap 'rm -f "$route_log"' EXIT
 
 AUDIO_CONTROL_ROUTE_LOG="$route_log" PATH="$TEST_DIR/mocks:$PATH" \
-  "$ROOT/scripts/audio-stream-route-set" 300 101 override
+  "$ROOT/scripts/audio-stream-route-set" playback 300 101 override
 
 expected_route_log=$(cat <<'EOF'
 move-sink-input 300 101
@@ -74,7 +121,7 @@ EOF
 
 : >"$route_log"
 AUDIO_CONTROL_ROUTE_LOG="$route_log" PATH="$TEST_DIR/mocks:$PATH" \
-  "$ROOT/scripts/audio-stream-route-set" 300 101 default
+  "$ROOT/scripts/audio-stream-route-set" playback 300 101 default
 
 expected_route_log=$(cat <<'EOF'
 move-sink-input 300 101
@@ -83,7 +130,80 @@ pw-metadata -n default -- 900 target.node -1 Spa:Id
 EOF
 )
 [[ $(<"$route_log") == "$expected_route_log" ]] || fail "default-following stream target"
+
+: >"$route_log"
+AUDIO_CONTROL_ROUTE_LOG="$route_log" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-stream-route-set" recording 400 201 override
+
+expected_route_log=$(cat <<'EOF'
+move-source-output 400 201
+pw-metadata -n default -- 901 target.object 201 Spa:Id
+pw-metadata -n default -- 901 target.node 2001 Spa:Id
+EOF
+)
+[[ $(<"$route_log") == "$expected_route_log" ]] || fail "persistent recording target"
+
+routes=$(AUDIO_CONTROL_ROUTE_LIST=1 PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-stream-routes")
+jq -e '
+  .playback["300"] == {"target":"101","mode":"override"}
+  and .recording["400"] == {"target":"201","mode":"override"}
+' <<<"$routes" >/dev/null || fail "playback and recording route snapshot"
 echo "PASS: persistent application routing"
+
+input_default_log=$(mktemp)
+trap 'rm -f "$route_log" "$input_default_log"' EXIT
+AUDIO_CONTROL_INPUT_DEFAULT_LOG="$input_default_log" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-input-set-default" 52 new-microphone old-microphone
+
+expected_input_default_log=$(cat <<'EOF'
+wpctl set-default 52
+pactl set-default-source new-microphone
+pactl move-source-output 400 new-microphone
+EOF
+)
+[[ $(<"$input_default_log") == "$expected_input_default_log" ]] ||
+  fail "default input preserved pinned recording route"
+echo "PASS: default input recording routes"
+
+port_log=$(mktemp)
+trap 'rm -f "$route_log" "$input_default_log" "$port_log"' EXIT
+ports=$(AUDIO_CONTROL_PORT_LOG="$port_log" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-ports")
+jq -e '
+  length == 2
+  and .[0].direction == "output"
+  and .[0].ports == [
+    {"value":"analog-output-speaker","label":"Speakers"},
+    {"value":"analog-output-headphones","label":"Headphones"}
+  ]
+  and .[1].direction == "input"
+' <<<"$ports" >/dev/null || fail "multi-port endpoint discovery"
+
+AUDIO_CONTROL_PORT_LOG="$port_log" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-port-set" output speakers analog-output-headphones
+[[ $(<"$port_log") == "set-sink-port speakers analog-output-headphones" ]] ||
+  fail "audio port selection"
+if AUDIO_CONTROL_PORT_LOG="$port_log" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-port-set" output speakers hdmi-output >/dev/null 2>&1; then
+  fail "unavailable audio port accepted"
+fi
+echo "PASS: audio port controls"
+
+bluetooth_preference_log=$(mktemp)
+bluetooth_preference_state=$(mktemp)
+trap 'rm -f "$route_log" "$input_default_log" "$port_log" "$bluetooth_preference_log" "$bluetooth_preference_state"' EXIT
+bluetooth_preference=$(AUDIO_CONTROL_BLUETOOTH_PREFERENCE_LOG="$bluetooth_preference_log" \
+  AUDIO_CONTROL_BLUETOOTH_PREFERENCE_STATE="$bluetooth_preference_state" \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-bluetooth-profile-preference")
+[[ $bluetooth_preference == quality ]] || fail "Bluetooth profile preference read"
+bluetooth_preference=$(AUDIO_CONTROL_BLUETOOTH_PREFERENCE_LOG="$bluetooth_preference_log" \
+  AUDIO_CONTROL_BLUETOOTH_PREFERENCE_STATE="$bluetooth_preference_state" \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-bluetooth-profile-preference" latency)
+[[ $bluetooth_preference == latency ]] || fail "Bluetooth profile preference write"
+[[ $(<"$bluetooth_preference_log") == "settings --save bluetooth.profile-preference latency" ]] ||
+  fail "Bluetooth profile preference command"
+echo "PASS: Bluetooth profile preference"
 
 profiles=$(
   AUDIO_CONTROL_CARD_FIXTURE="$TEST_DIR/fixtures/cards.json" \
@@ -112,7 +232,7 @@ echo "PASS: safe profile filtering"
 
 profile_log=$(mktemp)
 profile_state=$(mktemp)
-trap 'rm -f "$route_log" "$profile_log" "$profile_state"' EXIT
+trap 'rm -f "$route_log" "$input_default_log" "$port_log" "$bluetooth_preference_log" "$bluetooth_preference_state" "$profile_log" "$profile_state"' EXIT
 printf 'old\n' >"$profile_state"
 
 if AUDIO_CONTROL_CARD_FIXTURE="$TEST_DIR/fixtures/cards.json" \
@@ -149,7 +269,7 @@ echo "PASS: safe profile transition"
 
 menu_tmp=$(mktemp -d)
 menu_file="$menu_tmp/omarchy-menu.jsonc"
-trap 'rm -f "$route_log" "$profile_log" "$profile_state"; rm -rf "$menu_tmp"' EXIT
+trap 'rm -f "$route_log" "$input_default_log" "$port_log" "$bluetooth_preference_log" "$bluetooth_preference_state" "$profile_log" "$profile_state"; rm -rf "$menu_tmp"' EXIT
 cat >"$menu_file" <<'EOF'
 {
   // Existing customization
@@ -181,7 +301,7 @@ echo "PASS: menu integration"
 jq -e '
   .schemaVersion == 1
   and .id == "ssupt.audio-control"
-  and .version == "0.2.0"
+  and .version == "0.3.0"
   and .author == "ssupt"
   and (.kinds | index("bar-widget") != null)
   and (.kinds | index("panel") != null)

--- a/test/mocks/pactl
+++ b/test/mocks/pactl
@@ -5,18 +5,59 @@ if [[ $* == "-f json list cards" && -n ${AUDIO_CONTROL_CARD_FIXTURE:-} ]]; then
   exit 0
 fi
 
+if [[ -n ${AUDIO_CONTROL_ROUTE_LIST:-} && $* == "-f json list" ]]; then
+  echo '{"sink_inputs":[{"index":300,"sink":101,"properties":{"object.id":"900"}}],"source_outputs":[{"index":400,"source":201,"properties":{"object.id":"901"}}]}'
+  exit 0
+fi
+
+if [[ -n ${AUDIO_CONTROL_PORT_LOG:-} ]]; then
+  port_sinks='[{"name":"speakers","description":"Built-in Audio","active_port":"analog-output-speaker","ports":[{"name":"analog-output-speaker","description":"Speakers","availability":"available"},{"name":"analog-output-headphones","description":"Headphones","availability":"available"},{"name":"hdmi-output","description":"HDMI","availability":"not available"}]}]'
+  port_sources='[{"name":"microphone","description":"Built-in Audio","active_port":"analog-input-internal-mic","ports":[{"name":"analog-input-internal-mic","description":"Internal Microphone","availability":"available"},{"name":"analog-input-headset-mic","description":"Headset Microphone","availability":"available"}]},{"name":"speakers.monitor","description":"Monitor","active_port":"analog-output-speaker","ports":[{"name":"one","description":"One","availability":"available"},{"name":"two","description":"Two","availability":"available"}]}]'
+  case "$*" in
+    "-f json list")
+      printf '{"sinks":%s,"sources":%s}\n' "$port_sinks" "$port_sources"
+      exit 0
+      ;;
+    "-f json list sinks")
+      printf '%s\n' "$port_sinks"
+      exit 0
+      ;;
+    "set-sink-port speakers analog-output-headphones")
+      printf '%s\n' "$*" >>"$AUDIO_CONTROL_PORT_LOG"
+      exit 0
+      ;;
+  esac
+fi
+
 if [[ -n ${AUDIO_CONTROL_ROUTE_LOG:-} ]]; then
   case "$*" in
     "move-sink-input 300 101")
       printf '%s\n' "$*" >>"$AUDIO_CONTROL_ROUTE_LOG"
       exit 0
       ;;
-    "-f json list sink-inputs")
-      echo '[{"index":300,"sink":101,"properties":{"object.id":"900"}}]'
+    "move-source-output 400 201")
+      printf '%s\n' "$*" >>"$AUDIO_CONTROL_ROUTE_LOG"
       exit 0
       ;;
-    "-f json list sinks")
-      echo '[{"index":101,"properties":{"object.id":"1001"}}]'
+    "-f json list")
+      echo '{"sink_inputs":[{"index":300,"sink":101,"properties":{"object.id":"900"}}],"source_outputs":[{"index":400,"source":201,"properties":{"object.id":"901"}}],"sinks":[{"index":101,"properties":{"object.id":"1001"}}],"sources":[{"index":201,"properties":{"object.id":"2001"}}]}'
+      exit 0
+      ;;
+  esac
+fi
+
+if [[ -n ${AUDIO_CONTROL_INPUT_DEFAULT_LOG:-} ]]; then
+  case "$*" in
+    "-f json list sources")
+      echo '[{"index":200,"name":"old-microphone"},{"index":201,"name":"new-microphone"}]'
+      exit 0
+      ;;
+    "-f json list source-outputs")
+      echo '[{"index":400,"source":200,"properties":{"object.id":"901"}},{"index":401,"source":200,"properties":{"object.id":"902"}}]'
+      exit 0
+      ;;
+    "set-default-source new-microphone"|"move-source-output 400 new-microphone")
+      printf 'pactl %s\n' "$*" >>"$AUDIO_CONTROL_INPUT_DEFAULT_LOG"
       exit 0
       ;;
   esac

--- a/test/mocks/pw-metadata
+++ b/test/mocks/pw-metadata
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+if [[ -n ${AUDIO_CONTROL_ROUTE_LIST:-} ]]; then
+  cat <<'EOF'
+update: id:900 key:'target.object' value:'101' type:'Spa:Id'
+update: id:901 key:'target.node' value:'2001' type:'Spa:Id'
+EOF
+  exit 0
+fi
+
+if [[ -n ${AUDIO_CONTROL_INPUT_DEFAULT_LOG:-} ]]; then
+  echo "update: id:902 key:'target.object' value:'200' type:'Spa:Id'"
+  exit 0
+fi
+
 [[ -n ${AUDIO_CONTROL_ROUTE_LOG:-} ]] || {
   echo "Unexpected pw-metadata call: $*" >&2
   exit 1

--- a/test/mocks/wpctl
+++ b/test/mocks/wpctl
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+if [[ -n ${AUDIO_CONTROL_INPUT_DEFAULT_LOG:-} && $* == "set-default 52" ]]; then
+  printf 'wpctl %s\n' "$*" >>"$AUDIO_CONTROL_INPUT_DEFAULT_LOG"
+  exit 0
+fi
+
+if [[ -n ${AUDIO_CONTROL_BLUETOOTH_PREFERENCE_LOG:-} ]]; then
+  state_file=${AUDIO_CONTROL_BLUETOOTH_PREFERENCE_STATE:?}
+  case "$*" in
+    "settings --save bluetooth.profile-preference quality"|"settings --save bluetooth.profile-preference latency")
+      printf '%s\n' "$*" >>"$AUDIO_CONTROL_BLUETOOTH_PREFERENCE_LOG"
+      printf '%s\n' "${!#}" >"$state_file"
+      exit 0
+      ;;
+    "settings bluetooth.profile-preference")
+      value=quality
+      [[ -s $state_file ]] && value=$(<"$state_file")
+      printf 'Value: %s\n' "$value"
+      exit 0
+      ;;
+  esac
+fi
+
+echo "Unexpected wpctl call: $*" >&2
+exit 1


### PR DESCRIPTION
## Summary
- add persistent per-application recording routes with gain and mute controls
- add output boost, stereo balance, endpoint port selection, and Bluetooth quality policy
- add stream icons and meters, refine scrolling/loading behavior, and release version 0.3.0
- document the expanded controls

## Verification
- `./test/all`
- `qmllint -I /usr/lib/qt6/qml -I /home/ssupt/omarchy/shell Panel.qml AdvancedAudio.qml AudioDropdown.qml`
- `omarchy-plugin-validate .`
- live route, port, and Bluetooth preference helper queries