### PR TITLE
Share audio preferences with Bluetooth companion

### DIFF
--- a/AdvancedAudio.qml
+++ b/AdvancedAudio.qml
@@ -33,6 +33,8 @@ Item {
   property bool cursorActive: false
   property int selectedIndex: 0
   property bool profileMenuOpen: false
+  property var pendingSharedProfile: null
+  property var audioPreferences: Model.parseAudioPreferences("")
   property var audioControlSettings: ({ version: 1, outputOverdrive: false })
   property bool outputOverdrive: false
 
@@ -72,6 +74,11 @@ Item {
     var configHome = Quickshell.env("XDG_CONFIG_HOME")
     if (!configHome) configHome = Quickshell.env("HOME") + "/.config"
     return configHome + "/omarchy/audio-control.json"
+  }
+  readonly property string audioPreferencesPath: {
+    var configHome = Quickshell.env("XDG_CONFIG_HOME")
+    if (!configHome) configHome = Quickshell.env("HOME") + "/.config"
+    return configHome + "/omarchy/audio-preferences.json"
   }
   onDefaultOutputDeviceChanged: resolveVolumeSink()
 
@@ -151,6 +158,10 @@ Item {
     clampCursor()
   }
 
+  function loadAudioPreferences(raw) {
+    audioPreferences = Model.parseAudioPreferences(raw)
+  }
+
   function loadAudioControlSettings(raw) {
     audioControlSettings = Model.parseAudioControlSettings(raw)
     outputOverdrive = audioControlSettings.outputOverdrive
@@ -168,6 +179,13 @@ Item {
 
   function profileOptions(card) {
     return Model.audioProfileOptions(card)
+  }
+
+  function selectedAudioProfile(card) {
+    if (!card) return ""
+    if (!card.bluetooth) return String(card.activeProfile || "off")
+    return Model.preferredAudioProfile(
+      audioPreferences, card.address, profileOptions(card), card.activeProfile)
   }
 
   function nodeLabel(node) {
@@ -307,9 +325,13 @@ Item {
   }
 
   function setAudioProfile(card, profile) {
-    if (!card || !profile || profileSetProc.running) return
+    if (!card || !card.name || !profile || profileSetProc.running) return
     error = ""
-    profileSetProc.command = [pluginScript("audio-profile-set"), card, profile]
+    pendingSharedProfile = card.bluetooth && card.address ? {
+      address: String(card.address),
+      profile: String(profile)
+    } : null
+    profileSetProc.command = [pluginScript("audio-profile-set"), String(card.name), profile]
     profileSetProc.running = true
   }
 
@@ -361,6 +383,15 @@ Item {
     onFileChanged: reload()
   }
 
+  FileView {
+    path: root.audioPreferencesPath
+    watchChanges: true
+    printErrors: false
+    onLoaded: root.loadAudioPreferences(text())
+    onLoadFailed: root.loadAudioPreferences("")
+    onFileChanged: reload()
+  }
+
   PwObjectTracker { objects: root.outputDevice ? [root.outputDevice] : [] }
   PwObjectTracker { objects: root.inputDevice ? [root.inputDevice] : [] }
 
@@ -402,7 +433,17 @@ Item {
     id: profileSetProc
     onExited: function(exitCode) {
       if (exitCode !== 0) root.error = "Could not change the audio profile"
-      else root.error = ""
+      else {
+        root.error = ""
+        if (root.pendingSharedProfile)
+          Quickshell.execDetached([
+            root.pluginScript("audio-preferences"),
+            "set-profile",
+            root.pendingSharedProfile.address,
+            root.pendingSharedProfile.profile
+          ])
+      }
+      root.pendingSharedProfile = null
       profileRefreshTimer.restart()
     }
   }
@@ -1244,7 +1285,7 @@ Item {
         width: parent.width - profileLabels.width - parent.spacing
         showLabel: false
         popupDirection: "down"
-        value: String(profileRow.card.activeProfile || "off")
+        value: root.selectedAudioProfile(profileRow.card)
         options: root.profileOptions(profileRow.card)
         hasCursor: profileRow.hasCursor
         enabled: !profileSetProc.running
@@ -1254,7 +1295,7 @@ Item {
         anchors.verticalCenter: parent.verticalCenter
 
         onHovered: function(on) { if (on) root.setCursor(profileRow.rowIndex) }
-        onChanged: function(profile) { root.setAudioProfile(profileRow.card.name, profile) }
+        onChanged: function(profile) { root.setAudioProfile(profileRow.card, profile) }
         onPopupOpenChanged: {
           root.profileMenuOpen = popupOpen
           if (!popupOpen) Qt.callLater(function() { keyCatcher.forceActiveFocus() })

--- a/Model.js
+++ b/Model.js
@@ -32,6 +32,64 @@ function listSnapshot(list) {
   return list && list.slice ? list.slice() : []
 }
 
+function normalizedBluetoothAddress(value) {
+  return String(value || "").trim().toLowerCase().replace(/[^0-9a-f]/g, "")
+}
+
+function parseAudioPreferences(raw) {
+  var parsed
+  try {
+    parsed = JSON.parse(String(raw || "{}"))
+  } catch (e) {
+    parsed = {}
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) parsed = {}
+
+  var defaults = parsed.defaults
+  if (!defaults || typeof defaults !== "object" || Array.isArray(defaults)) defaults = {}
+  var rawProfiles = parsed.bluetoothProfiles
+  if (!rawProfiles || typeof rawProfiles !== "object" || Array.isArray(rawProfiles)) rawProfiles = {}
+
+  var profiles = {}
+  for (var address in rawProfiles) {
+    var key = normalizedBluetoothAddress(address)
+    var profile = rawProfiles[address]
+    if (key !== "" && typeof profile === "string" && profile !== "") profiles[key] = profile
+  }
+
+  return {
+    version: 1,
+    defaults: {
+      output: typeof defaults.output === "string" ? defaults.output : "",
+      input: typeof defaults.input === "string" ? defaults.input : ""
+    },
+    bluetoothProfiles: profiles
+  }
+}
+
+function preferredAudioProfile(preferences, address, options, activeProfile) {
+  var profiles = preferences && preferences.bluetoothProfiles
+  var saved = profiles ? String(profiles[normalizedBluetoothAddress(address)] || "") : ""
+  var values = options && typeof options.length === "number" ? options : []
+  for (var i = 0; i < values.length; i++) {
+    var value = values[i] && typeof values[i] === "object" ? values[i].value : values[i]
+    if (String(value || "") === saved) return saved
+  }
+  return String(activeProfile || "")
+}
+
+function preferredAudioNodeName(preferences, direction, liveNode, nodes) {
+  var defaults = preferences && preferences.defaults
+  var saved = defaults && (direction === "output" || direction === "input")
+    ? String(defaults[direction] || "") : ""
+  var values = nodes && typeof nodes.length === "number" ? nodes : []
+  if (saved !== "") {
+    for (var i = 0; i < values.length; i++)
+      if (values[i] && String(values[i].name || "") === saved) return saved
+  }
+  return liveNode ? String(liveNode.name || "") : ""
+}
+
 function parseAudioControlSettings(raw) {
   var parsed
   try {
@@ -516,6 +574,10 @@ if (typeof module !== "undefined") {
     isRecordingStream: isRecordingStream,
     isAudioSource: isAudioSource,
     listSnapshot: listSnapshot,
+    normalizedBluetoothAddress: normalizedBluetoothAddress,
+    parseAudioPreferences: parseAudioPreferences,
+    preferredAudioProfile: preferredAudioProfile,
+    preferredAudioNodeName: preferredAudioNodeName,
     parseAudioControlSettings: parseAudioControlSettings,
     balanceValue: balanceValue,
     applyBalance: applyBalance,

--- a/Panel.qml
+++ b/Panel.qml
@@ -31,6 +31,12 @@ Panel {
     if (!configHome) configHome = Quickshell.env("HOME") + "/.config"
     return configHome + "/omarchy/audio-control.json"
   }
+  readonly property string audioPreferencesPath: {
+    var configHome = Quickshell.env("XDG_CONFIG_HOME")
+    if (!configHome) configHome = Quickshell.env("HOME") + "/.config"
+    return configHome + "/omarchy/audio-preferences.json"
+  }
+  property var audioPreferences: Model.parseAudioPreferences("")
   property bool outputOverdrive: false
   readonly property real outputVolumeMaximum: outputOverdrive ? 1.5 : 1.0
 
@@ -104,6 +110,10 @@ Panel {
     return Model.isAudioSource(node)
   }
 
+  function loadAudioPreferences(raw) {
+    audioPreferences = Model.parseAudioPreferences(raw)
+  }
+
   property var cachedAudioSinks: []
   property var cachedAudioSources: []
 
@@ -123,6 +133,10 @@ Panel {
 
   readonly property var audioSinks: rawAudioSinks.length > 0 ? rawAudioSinks : cachedAudioSinks
   readonly property var audioSources: rawAudioSources.length > 0 ? rawAudioSources : cachedAudioSources
+  readonly property string preferredOutputName: Model.preferredAudioNodeName(
+    audioPreferences, "output", sink, audioSinks)
+  readonly property string preferredInputName: Model.preferredAudioNodeName(
+    audioPreferences, "input", source, audioSources)
 
   readonly property var audioStreams: {
     var list = []
@@ -818,6 +832,15 @@ Panel {
     onFileChanged: reload()
   }
 
+  FileView {
+    path: root.audioPreferencesPath
+    watchChanges: true
+    printErrors: false
+    onLoaded: root.loadAudioPreferences(text())
+    onLoadFailed: root.loadAudioPreferences("")
+    onFileChanged: reload()
+  }
+
   Process {
     id: sinkAvailabilityProc
     command: ["omarchy-audio-sink-availability"]
@@ -1365,7 +1388,7 @@ Panel {
     required property var node
     required property int rowIndex
 
-    readonly property bool isActive: root.sink && node && root.sink.id === node.id
+    readonly property bool isActive: node && String(node.name || "") === root.preferredOutputName
     hasCursor: root.cursorActive && root.focusSection === "output" && root.selectedIndex === rowIndex
     onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(sinkRow)
     current: isActive
@@ -1424,7 +1447,7 @@ Panel {
     required property var node
     required property int rowIndex
 
-    readonly property bool isActive: root.source && node && root.source.id === node.id
+    readonly property bool isActive: node && String(node.name || "") === root.preferredInputName
     hasCursor: root.cursorActive && root.focusSection === "input" && root.selectedIndex === rowIndex
     onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(sourceRow)
     current: isActive

--- a/README.md
+++ b/README.md
@@ -19,7 +19,9 @@ instead of introducing a separate mixer application.
 
 The optional [Advanced Bluetooth Audio](https://github.com/ssupt/omarchy-bluetooth-audio)
 companion brings the same codec controls into Omarchy's Bluetooth panel while
-preserving its native pairing, discovery, and connection behavior.
+preserving its native pairing, discovery, and connection behavior. When both
+plugins are enabled, codec and preferred-device choices are shared immediately
+through `~/.config/omarchy/audio-preferences.json`.
 
 More plugins by `ssupt`: [omarchy-plugins](https://github.com/ssupt/omarchy-plugins).
 
@@ -27,7 +29,7 @@ More plugins by `ssupt`: [omarchy-plugins](https://github.com/ssupt/omarchy-plug
 
 - Omarchy Quattro
 - PipeWire with WirePlumber (`pactl`, `wpctl`, and `pw-metadata`)
-- `jq`, `hyprctl`, and `timeout`
+- `jq`, `hyprctl`, `timeout`, and `flock`
 
 These commands are present in a standard Omarchy installation. The plugin does
 not require `sudo` or install a background service.

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "ssupt.audio-control",
   "name": "Advanced Audio Control",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": "ssupt",
   "description": "Adds application playback and recording routing, volume boost, balance, device ports, and Bluetooth audio controls to Omarchy",
   "kinds": [

--- a/scripts/audio-input-set-default
+++ b/scripts/audio-input-set-default
@@ -45,3 +45,6 @@ timeout 2 pactl set-default-source "$source_name" 2>/dev/null || true
 for output in "${following_outputs[@]}"; do
   [[ -n $output ]] && timeout 2 pactl move-source-output "$output" "$source_name" 2>/dev/null || true
 done
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+"$script_dir/audio-preferences" set-default input "$source_name"

--- a/scripts/audio-output-set-default
+++ b/scripts/audio-output-set-default
@@ -52,3 +52,6 @@ timeout 2 pactl set-default-sink "$sink_name" 2>/dev/null || true
 for input in "${following_inputs[@]}"; do
   [[ -n $input ]] && timeout 2 pactl move-sink-input "$input" "$sink_name" 2>/dev/null || true
 done
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+"$script_dir/audio-preferences" set-default output "$sink_name"

--- a/scripts/audio-preferences
+++ b/scripts/audio-preferences
@@ -1,0 +1,80 @@
+#!/bin/bash
+
+# omarchy:summary=Show or update preferences shared by Omarchy audio plugins
+# omarchy:group=audio
+# omarchy:args=[set-default <output|input> <node-name> | set-profile <bluetooth-address> <profile>]
+
+set -euo pipefail
+
+preferences_file=${OMARCHY_AUDIO_PREFERENCES_FILE:-${XDG_CONFIG_HOME:-${HOME:?}/.config}/omarchy/audio-preferences.json}
+action=${1:-show}
+
+usage() {
+  echo "Usage: audio-preferences [show | set-default <output|input> <node-name> | set-profile <bluetooth-address> <profile>]" >&2
+  exit 1
+}
+
+default_preferences() {
+  printf '%s\n' '{"version":1,"defaults":{"output":"","input":""},"bluetoothProfiles":{}}'
+}
+
+read_preferences() {
+  if [[ -s $preferences_file ]] && jq -e 'type == "object"' "$preferences_file" >/dev/null 2>&1; then
+    jq -c '
+      .version = 1
+      | .defaults = (if (.defaults | type) == "object" then .defaults else {} end)
+      | .defaults.output = (if (.defaults.output | type) == "string" then .defaults.output else "" end)
+      | .defaults.input = (if (.defaults.input | type) == "string" then .defaults.input else "" end)
+      | .bluetoothProfiles = (if (.bluetoothProfiles | type) == "object" then .bluetoothProfiles else {} end)
+    ' "$preferences_file"
+  else
+    default_preferences
+  fi
+}
+
+write_preferences() {
+  local filter=$1
+  shift
+
+  local preferences_dir lock_file temporary_file
+  preferences_dir=$(dirname -- "$preferences_file")
+  mkdir -p -- "$preferences_dir"
+  lock_file="${preferences_file}.lock"
+  exec 9>"$lock_file"
+  flock 9
+
+  temporary_file=$(mktemp "$preferences_dir/.audio-preferences.XXXXXX")
+  trap 'rm -f -- "$temporary_file"' EXIT
+  read_preferences | jq "$@" "$filter" >"$temporary_file"
+  chmod 600 "$temporary_file"
+  mv -f -- "$temporary_file" "$preferences_file"
+  trap - EXIT
+}
+
+case "$action" in
+  show)
+    (( $# == 0 || $# == 1 )) || usage
+    read_preferences
+    ;;
+  set-default)
+    (( $# == 3 )) || usage
+    direction=$2
+    node_name=$3
+    [[ $direction == output || $direction == input ]] || usage
+    [[ -n $node_name ]] || usage
+    write_preferences \
+      '.version = 1 | .defaults[$direction] = $node' \
+      --arg direction "$direction" --arg node "$node_name"
+    ;;
+  set-profile)
+    (( $# == 3 )) || usage
+    address=${2,,}
+    address=${address//[^0-9a-f]/}
+    profile=$3
+    [[ $address =~ ^[0-9a-f]{12}$ && -n $profile ]] || usage
+    write_preferences \
+      '.version = 1 | .bluetoothProfiles[$address] = $profile' \
+      --arg address "$address" --arg profile "$profile"
+    ;;
+  *) usage ;;
+esac

--- a/test/all
+++ b/test/all
@@ -38,6 +38,27 @@ assert.deepEqual(model.parseAudioControlSettings('not json'), {
   version: 1,
   outputOverdrive: false
 })
+const audioPreferences = model.parseAudioPreferences(JSON.stringify({
+  defaults: { output: 'headphones', input: 'headset-microphone' },
+  bluetoothProfiles: { '00:11:22:33:44:55': 'a2dp-aac' }
+}))
+assert.deepEqual(audioPreferences, {
+  version: 1,
+  defaults: { output: 'headphones', input: 'headset-microphone' },
+  bluetoothProfiles: { '001122334455': 'a2dp-aac' }
+})
+assert.equal(model.preferredAudioProfile(
+  audioPreferences, '00-11-22-33-44-55', cards[0].profiles, cards[0].activeProfile
+), 'a2dp-aac')
+assert.equal(model.preferredAudioProfile(
+  audioPreferences, '00:11:22:33:44:55', [{ value: 'headset-msbc' }], 'headset-msbc'
+), 'headset-msbc')
+assert.equal(model.preferredAudioNodeName(
+  audioPreferences, 'output', { name: 'speakers' }, [{ name: 'headphones' }]
+), 'headphones')
+assert.equal(model.preferredAudioNodeName(
+  audioPreferences, 'output', { name: 'speakers' }, [{ name: 'speakers' }]
+), 'speakers')
 assert.equal(model.balanceValue(1, 1), 0)
 assert.equal(model.balanceValue(1, 0.25), -0.75)
 assert.equal(model.balanceValue(0.5, 1), 0.5)
@@ -152,8 +173,11 @@ jq -e '
 echo "PASS: persistent application routing"
 
 input_default_log=$(mktemp)
-trap 'rm -f "$route_log" "$input_default_log"' EXIT
-AUDIO_CONTROL_INPUT_DEFAULT_LOG="$input_default_log" PATH="$TEST_DIR/mocks:$PATH" \
+shared_preferences=$(mktemp)
+shared_preferences_lock="${shared_preferences}.lock"
+trap 'rm -f "$route_log" "$input_default_log" "$shared_preferences" "$shared_preferences_lock"' EXIT
+AUDIO_CONTROL_INPUT_DEFAULT_LOG="$input_default_log" \
+  OMARCHY_AUDIO_PREFERENCES_FILE="$shared_preferences" PATH="$TEST_DIR/mocks:$PATH" \
   "$ROOT/scripts/audio-input-set-default" 52 new-microphone old-microphone
 
 expected_input_default_log=$(cat <<'EOF'
@@ -164,7 +188,17 @@ EOF
 )
 [[ $(<"$input_default_log") == "$expected_input_default_log" ]] ||
   fail "default input preserved pinned recording route"
+OMARCHY_AUDIO_PREFERENCES_FILE="$shared_preferences" \
+  "$ROOT/scripts/audio-preferences" set-default output headphones
+OMARCHY_AUDIO_PREFERENCES_FILE="$shared_preferences" \
+  "$ROOT/scripts/audio-preferences" set-profile 00:11:22:33:44:55 a2dp-aac
+jq -e '
+  .version == 1
+  and .defaults == {"output":"headphones","input":"new-microphone"}
+  and .bluetoothProfiles == {"001122334455":"a2dp-aac"}
+' "$shared_preferences" >/dev/null || fail "shared audio preferences"
 echo "PASS: default input recording routes"
+rm -f -- "$shared_preferences" "$shared_preferences_lock"
 
 port_log=$(mktemp)
 trap 'rm -f "$route_log" "$input_default_log" "$port_log"' EXIT
@@ -301,7 +335,7 @@ echo "PASS: menu integration"
 jq -e '
   .schemaVersion == 1
   and .id == "ssupt.audio-control"
-  and .version == "0.3.0"
+  and .version == "0.4.0"
   and .author == "ssupt"
   and (.kinds | index("bar-widget") != null)
   and (.kinds | index("panel") != null)


### PR DESCRIPTION
## Summary
- share Bluetooth profile and default-device preferences through a neutral user config file
- reflect saved choices in the quick panel and Advanced Audio window
- preserve route-aware default switching when used with Advanced Bluetooth Audio

## Validation
- ./test/all
- omarchy-plugin-validate .
- qmlformat syntax parsing