### PR TITLE
Improve audio state handling and level meters

### DIFF
--- a/AdvancedAudio.qml
+++ b/AdvancedAudio.qml
@@ -28,7 +28,18 @@ Item {
   property string bluetoothProfilePreference: "quality"
   property bool bluetoothProfilePreferenceLoaded: false
   property bool bluetoothProfilePreferenceMutation: false
-  property string error: ""
+  property string profileLoadError: ""
+  property string portLoadError: ""
+  property string profileSetError: ""
+  property string portSetError: ""
+  property string bluetoothAutoswitchError: ""
+  property string bluetoothPreferenceError: ""
+  readonly property string error: {
+    var errors = [profileSetError, portSetError, bluetoothAutoswitchError,
+      bluetoothPreferenceError, profileLoadError, portLoadError]
+    for (var i = 0; i < errors.length; i++) if (errors[i] !== "") return errors[i]
+    return ""
+  }
   property int activeTab: 0  // 0 = devices, 1 = Bluetooth
   property bool cursorActive: false
   property int selectedIndex: 0
@@ -69,6 +80,7 @@ Item {
   readonly property int itemCount: activeTab === 0
     ? balanceStartIndex + (outputBalanceAvailable ? 1 : 0) + (inputBalanceAvailable ? 1 : 0)
     : 2 + bluetoothCards.length
+  readonly property bool audioMutationBusy: profileSetProc.running || portSetProc.running
   readonly property color hoverFill: Style.hoverFillFor(foreground, Color.accent)
   readonly property string settingsPath: {
     var configHome = Quickshell.env("XDG_CONFIG_HOME")
@@ -95,10 +107,21 @@ Item {
     closingFromHost = false
     cursorActive = false
     selectedIndex = 0
-    error = ""
+    clearErrors()
     profilesLoaded = false
+    bluetoothAutoSwitchLoaded = false
+    bluetoothProfilePreferenceLoaded = false
     if (windowRuleReady) showOnCurrentWorkspace()
     else if (!windowRuleProc.running) windowRuleProc.running = true
+  }
+
+  function clearErrors() {
+    profileLoadError = ""
+    portLoadError = ""
+    profileSetError = ""
+    portSetError = ""
+    bluetoothAutoswitchError = ""
+    bluetoothPreferenceError = ""
   }
 
   function showOnCurrentWorkspace() {
@@ -302,7 +325,7 @@ Item {
       return
     }
     if (activeTab === 1 && selectedIndex === 1) {
-      bluetoothPreferenceDropdown.toggle()
+      if (bluetoothPreferenceDropdown.enabled) bluetoothPreferenceDropdown.toggle()
       return
     }
     var row = activeTab === 0
@@ -325,8 +348,8 @@ Item {
   }
 
   function setAudioProfile(card, profile) {
-    if (!card || !card.name || !profile || profileSetProc.running) return
-    error = ""
+    if (!card || !card.name || !profile || audioMutationBusy) return
+    profileSetError = ""
     pendingSharedProfile = card.bluetooth && card.address ? {
       address: String(card.address),
       profile: String(profile)
@@ -336,15 +359,15 @@ Item {
   }
 
   function setAudioPort(port, value) {
-    if (!port || !value || portSetProc.running) return
-    error = ""
+    if (!port || !value || audioMutationBusy) return
+    portSetError = ""
     portSetProc.command = [pluginScript("audio-port-set"), port.direction, port.endpoint, value]
     portSetProc.running = true
   }
 
   function setBluetoothAutoSwitch(enabled) {
     if (!bluetoothAutoSwitchLoaded || bluetoothAutoswitchProc.running) return
-    error = ""
+    bluetoothAutoswitchError = ""
     autoswitchMutation = true
     bluetoothAutoswitchProc.command = [pluginScript("audio-bluetooth-autoswitch"), enabled ? "on" : "off"]
     bluetoothAutoswitchProc.running = true
@@ -353,8 +376,7 @@ Item {
   function setBluetoothProfilePreference(value) {
     if (!bluetoothProfilePreferenceLoaded || bluetoothPreferenceProc.running
         || (value !== "quality" && value !== "latency")) return
-    error = ""
-    bluetoothProfilePreference = value
+    bluetoothPreferenceError = ""
     bluetoothProfilePreferenceMutation = true
     bluetoothPreferenceProc.command = [pluginScript("audio-bluetooth-profile-preference"), value]
     bluetoothPreferenceProc.running = true
@@ -404,7 +426,8 @@ Item {
     }
     onExited: function(exitCode) {
       root.profilesLoaded = true
-      if (exitCode !== 0 && window.visible) root.error = "Could not load audio profiles"
+      root.profileLoadError = exitCode !== 0 && window.visible
+        ? "Could not load audio profiles" : ""
     }
   }
 
@@ -425,16 +448,17 @@ Item {
       onStreamFinished: root.parseAudioPorts(text)
     }
     onExited: function(exitCode) {
-      if (exitCode !== 0 && window.visible) root.error = "Could not load audio ports"
+      root.portLoadError = exitCode !== 0 && window.visible
+        ? "Could not load audio ports" : ""
     }
   }
 
   Process {
     id: profileSetProc
     onExited: function(exitCode) {
-      if (exitCode !== 0) root.error = "Could not change the audio profile"
+      if (exitCode !== 0) root.profileSetError = "Could not change the audio profile"
       else {
-        root.error = ""
+        root.profileSetError = ""
         if (root.pendingSharedProfile)
           Quickshell.execDetached([
             root.pluginScript("audio-preferences"),
@@ -451,8 +475,7 @@ Item {
   Process {
     id: portSetProc
     onExited: function(exitCode) {
-      if (exitCode !== 0) root.error = "Could not change the audio port"
-      else root.error = ""
+      root.portSetError = exitCode !== 0 ? "Could not change the audio port" : ""
       portRefreshTimer.restart()
     }
   }
@@ -470,8 +493,11 @@ Item {
       }
     }
     onExited: function(exitCode) {
-      if (root.autoswitchMutation && exitCode !== 0)
-        root.error = "Could not change automatic headset mode"
+      if (exitCode !== 0)
+        root.bluetoothAutoswitchError = root.autoswitchMutation
+          ? "Could not change automatic headset mode"
+          : "Could not load automatic headset mode"
+      else root.bluetoothAutoswitchError = ""
       root.autoswitchMutation = false
     }
   }
@@ -489,8 +515,11 @@ Item {
       }
     }
     onExited: function(exitCode) {
-      if (root.bluetoothProfilePreferenceMutation && exitCode !== 0)
-        root.error = "Could not change Bluetooth profile preference"
+      if (exitCode !== 0)
+        root.bluetoothPreferenceError = root.bluetoothProfilePreferenceMutation
+          ? "Could not change Bluetooth profile preference"
+          : "Could not load Bluetooth profile preference"
+      else root.bluetoothPreferenceError = ""
       root.bluetoothProfilePreferenceMutation = false
     }
   }
@@ -1061,7 +1090,7 @@ Item {
     fill: root.hoverFill
     bordered: true
 
-    function togglePortMenu() { portDropdown.toggle() }
+    function togglePortMenu() { if (portDropdown.enabled) portDropdown.toggle() }
     function closePortMenu() { portDropdown.close() }
 
     Row {
@@ -1106,7 +1135,7 @@ Item {
         value: String(portRow.port.activePort || "")
         options: portRow.port.ports
         hasCursor: portRow.hasCursor
-        enabled: !portSetProc.running
+        enabled: !root.audioMutationBusy
         opacity: enabled ? 1 : 0.6
         foreground: root.foreground
         fontFamily: root.fontFamily
@@ -1240,7 +1269,7 @@ Item {
     fill: root.hoverFill
     bordered: true
 
-    function toggleProfileMenu() { profileDropdown.toggle() }
+    function toggleProfileMenu() { if (profileDropdown.enabled) profileDropdown.toggle() }
     function closeProfileMenu() { profileDropdown.close() }
 
     Component.onDestruction: if (profileDropdown.popupOpen) root.profileMenuOpen = false
@@ -1288,7 +1317,7 @@ Item {
         value: root.selectedAudioProfile(profileRow.card)
         options: root.profileOptions(profileRow.card)
         hasCursor: profileRow.hasCursor
-        enabled: !profileSetProc.running
+        enabled: !root.audioMutationBusy
         opacity: enabled ? 1 : 0.6
         foreground: root.foreground
         fontFamily: root.fontFamily

--- a/AudioDropdown.qml
+++ b/AudioDropdown.qml
@@ -55,9 +55,12 @@ Item {
   // own keyCatcher so j/k inside the popup don't double-drive the panel
   // cursor.
   readonly property bool popupOpen: popup.opened
-  function open() { popup.open() }
+  function open() { if (enabled) popup.open() }
   function close() { popup.close() }
-  function toggle() { popup.opened ? popup.close() : popup.open() }
+  function toggle() {
+    if (popup.opened) popup.close()
+    else if (enabled) popup.open()
+  }
 
   signal changed(string value)
   signal hovered(bool isHovered)

--- a/Model.js
+++ b/Model.js
@@ -126,6 +126,35 @@ function applyBalance(volumes, leftIndex, rightIndex, balance) {
   return values
 }
 
+function audioMeterLevel(peaks, volumes, peak, volume, muted) {
+  if (muted) return 0
+
+  var peakValues = peaks && typeof peaks.length === "number" ? peaks : []
+  var volumeValues = volumes && typeof volumes.length === "number" ? volumes : []
+  var level = 0
+
+  // PwNodePeakMonitor deliberately removes each channel's node volume from
+  // its peaks. Reapply those volumes so the meter represents the signal that
+  // actually leaves the application, including channel balance.
+  if (peakValues.length > 0 && peakValues.length === volumeValues.length) {
+    for (var i = 0; i < peakValues.length; i++) {
+      var channelPeak = Number(peakValues[i])
+      var channelVolume = Number(volumeValues[i])
+      if (!isFinite(channelPeak) || channelPeak < 0) channelPeak = 0
+      if (!isFinite(channelVolume) || channelVolume < 0) channelVolume = 0
+      level = Math.max(level, channelPeak * channelVolume)
+    }
+  } else {
+    var maximumPeak = Number(peak)
+    var averageVolume = Number(volume)
+    if (!isFinite(maximumPeak) || maximumPeak < 0) maximumPeak = 0
+    if (!isFinite(averageVolume) || averageVolume < 0) averageVolume = 0
+    level = maximumPeak * averageVolume
+  }
+
+  return Math.max(0, Math.min(1, level))
+}
+
 function outputVolumeName(volume, muted) {
   if (muted) return "Muted"
   var p = Math.round(volume * 100)
@@ -581,6 +610,7 @@ if (typeof module !== "undefined") {
     parseAudioControlSettings: parseAudioControlSettings,
     balanceValue: balanceValue,
     applyBalance: applyBalance,
+    audioMeterLevel: audioMeterLevel,
     outputVolumeName: outputVolumeName,
     parseSinkAvailability: parseSinkAvailability,
     parseAudioProfiles: parseAudioProfiles,

--- a/Panel.qml
+++ b/Panel.qml
@@ -175,6 +175,14 @@ Panel {
   property string streamRouteSetError: ""
   readonly property string streamRouteError: streamRouteSetError !== ""
     ? streamRouteSetError : streamRouteReadError
+  property string defaultOutputError: ""
+  property string defaultInputError: ""
+  property var previousDefaultSink: null
+  property var previousDefaultSource: null
+  readonly property string defaultDeviceError: defaultOutputError !== ""
+    ? defaultOutputError : defaultInputError
+  readonly property string panelError: defaultDeviceError !== ""
+    ? defaultDeviceError : streamRouteError
   property var pendingStreamRoute: null
 
   // The default is ordered first and named by behavior. Applications on that
@@ -679,31 +687,33 @@ Panel {
   }
 
   function setDefaultSink(node) {
-    if (!node) return
+    if (!node || node.id === undefined || !node.name || defaultSinkProc.running) return
     var previousSinkName = sink && sink.name ? String(sink.name) : ""
+    previousDefaultSink = sink
     Pipewire.preferredDefaultAudioSink = node
-    if (node.id !== undefined && node.name) {
-      Quickshell.execDetached([
-        pluginScript("audio-output-set-default"),
-        String(node.id),
-        String(node.name),
-        previousSinkName
-      ])
-    }
+    defaultOutputError = ""
+    defaultSinkProc.command = [
+      pluginScript("audio-output-set-default"),
+      String(node.id),
+      String(node.name),
+      previousSinkName
+    ]
+    defaultSinkProc.running = true
   }
 
   function setDefaultSource(node) {
-    if (!node) return
+    if (!node || node.id === undefined || !node.name || defaultSourceProc.running) return
     var previousSourceName = source && source.name ? String(source.name) : ""
+    previousDefaultSource = source
     Pipewire.preferredDefaultAudioSource = node
-    if (node.id !== undefined && node.name) {
-      Quickshell.execDetached([
-        pluginScript("audio-input-set-default"),
-        String(node.id),
-        String(node.name),
-        previousSourceName
-      ])
-    }
+    defaultInputError = ""
+    defaultSourceProc.command = [
+      pluginScript("audio-input-set-default"),
+      String(node.id),
+      String(node.name),
+      previousSourceName
+    ]
+    defaultSourceProc.running = true
   }
 
   function sinkAvailable(node) {
@@ -856,6 +866,30 @@ Panel {
     stdout: StdioCollector {
       waitForEnd: true
       onStreamFinished: root.volumeSinkName = String(text).trim()
+    }
+  }
+
+  Process {
+    id: defaultSinkProc
+    onExited: function(exitCode) {
+      root.defaultOutputError = exitCode === 0 ? ""
+        : (exitCode === 2 ? "Default output changed, but its preference could not be saved"
+          : "Could not change the default audio output")
+      if (exitCode !== 0 && exitCode !== 2 && root.previousDefaultSink)
+        Pipewire.preferredDefaultAudioSink = root.previousDefaultSink
+      root.previousDefaultSink = null
+    }
+  }
+
+  Process {
+    id: defaultSourceProc
+    onExited: function(exitCode) {
+      root.defaultInputError = exitCode === 0 ? ""
+        : (exitCode === 2 ? "Default input changed, but its preference could not be saved"
+          : "Could not change the default audio input")
+      if (exitCode !== 0 && exitCode !== 2 && root.previousDefaultSource)
+        Pipewire.preferredDefaultAudioSource = root.previousDefaultSource
+      root.previousDefaultSource = null
     }
   }
 
@@ -1365,9 +1399,9 @@ Panel {
           }
 
           Text {
-            visible: root.streamRouteError !== ""
+            visible: root.panelError !== ""
             width: parent.width
-            text: root.streamRouteError
+            text: root.panelError
             color: root.bar.urgent
             font.family: root.bar.fontFamily
             font.pixelSize: Style.font.bodySmall
@@ -1430,8 +1464,9 @@ Panel {
 
     MouseArea {
       anchors.fill: parent
+      enabled: !defaultSinkProc.running
       hoverEnabled: true
-      cursorShape: Qt.PointingHandCursor
+      cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
       onContainsMouseChanged: if (containsMouse) {
         root.cursorActive = true
         root.focusSection = "output"
@@ -1489,8 +1524,9 @@ Panel {
 
     MouseArea {
       anchors.fill: parent
+      enabled: !defaultSourceProc.running
       hoverEnabled: true
-      cursorShape: Qt.PointingHandCursor
+      cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
       onContainsMouseChanged: if (containsMouse) {
         root.cursorActive = true
         root.focusSection = "input"
@@ -1510,6 +1546,12 @@ Panel {
 
     readonly property real streamVolume: node && node.audio ? node.audio.volume : 0
     readonly property bool streamMuted: node && node.audio ? node.audio.muted : false
+    readonly property real meterLevel: Model.audioMeterLevel(
+      streamPeakMonitor.peaks,
+      node && node.audio ? node.audio.volumes : [],
+      streamPeakMonitor.peak,
+      streamVolume,
+      streamMuted)
     readonly property bool isActive: !recording && root.streamRepresentsPlayer(node, root.activeMediaPlayer)
     readonly property string streamSerial: root.streamSerial(node)
     readonly property var currentRoute: recording
@@ -1741,7 +1783,7 @@ Panel {
 
         Rectangle {
           height: parent.height
-          width: parent.width * Math.max(0, Math.min(1, streamPeakMonitor.peak))
+          width: parent.width * streamRow.meterLevel
           color: root.bar.foreground
           Behavior on width { NumberAnimation { duration: 70 } }
         }

--- a/scripts/audio-bluetooth-autoswitch
+++ b/scripts/audio-bluetooth-autoswitch
@@ -14,8 +14,8 @@ fi
 
 case "$action" in
   "") ;;
-  on) wpctl settings --save "$setting" true >/dev/null ;;
-  off) wpctl settings --save "$setting" false >/dev/null ;;
+  on) wpctl settings --save "$setting" true >/dev/null || exit 1 ;;
+  off) wpctl settings --save "$setting" false >/dev/null || exit 1 ;;
   *)
     echo "Usage: omarchy-audio-bluetooth-autoswitch [on|off]" >&2
     exit 1

--- a/scripts/audio-input-set-default
+++ b/scripts/audio-input-set-default
@@ -12,7 +12,19 @@ if (( $# < 2 || $# > 3 )) || [[ -z $node_id || -z $source_name ]]; then
   exit 1
 fi
 
-[[ -n $old_source_name ]] || old_source_name=$(timeout 2 pactl get-default-source 2>/dev/null || true)
+preferences_file=${OMARCHY_AUDIO_PREFERENCES_FILE:-${XDG_CONFIG_HOME:-${HOME:?}/.config}/omarchy/audio-preferences.json}
+mkdir -p -- "$(dirname -- "$preferences_file")" || exit 1
+exec 8>"${preferences_file}.input.lock" || exit 1
+flock 8 || exit 1
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+"$script_dir/audio-preferences" show >/dev/null || exit 1
+
+live_source_name=$(timeout 2 pactl get-default-source 2>/dev/null || true)
+if [[ -n $live_source_name && $live_source_name != "$source_name" ]]; then
+  old_source_name=$live_source_name
+elif [[ -z $old_source_name ]]; then
+  old_source_name=$live_source_name
+fi
 old_source_index=$(timeout 2 pactl -f json list sources 2>/dev/null |
   jq -r --arg name "$old_source_name" 'map(select(.name == $name))[0].index // empty' || true)
 
@@ -42,9 +54,17 @@ fi
 timeout 2 wpctl set-default "$node_id" 2>/dev/null || true
 timeout 2 pactl set-default-source "$source_name" 2>/dev/null || true
 
+actual_source_name=$(timeout 2 pactl get-default-source 2>/dev/null || true)
+if [[ $actual_source_name != "$source_name" ]]; then
+  echo "Could not set the default audio input" >&2
+  exit 1
+fi
+
 for output in "${following_outputs[@]}"; do
   [[ -n $output ]] && timeout 2 pactl move-source-output "$output" "$source_name" 2>/dev/null || true
 done
 
-script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
-"$script_dir/audio-preferences" set-default input "$source_name"
+if ! "$script_dir/audio-preferences" set-default input "$source_name"; then
+  echo "The default input changed, but its preference could not be saved" >&2
+  exit 2
+fi

--- a/scripts/audio-output-set-default
+++ b/scripts/audio-output-set-default
@@ -13,11 +13,23 @@ if (( $# < 2 || $# > 3 )) || [[ -z $node_id || -z $sink_name ]]; then
   exit 1
 fi
 
+preferences_file=${OMARCHY_AUDIO_PREFERENCES_FILE:-${XDG_CONFIG_HOME:-${HOME:?}/.config}/omarchy/audio-preferences.json}
+mkdir -p -- "$(dirname -- "$preferences_file")" || exit 1
+exec 8>"${preferences_file}.output.lock" || exit 1
+flock 8 || exit 1
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+"$script_dir/audio-preferences" show >/dev/null || exit 1
+
 # Capture the applications following the old default before changing it.
 # PipeWire records explicit per-application routes in the default metadata, so
 # checking the current sink alone is not enough: an explicitly routed stream may
 # happen to be on the old default and must still remain there.
-[[ -n $old_sink_name ]] || old_sink_name=$(timeout 2 pactl get-default-sink 2>/dev/null || true)
+live_sink_name=$(timeout 2 pactl get-default-sink 2>/dev/null || true)
+if [[ -n $live_sink_name && $live_sink_name != "$sink_name" ]]; then
+  old_sink_name=$live_sink_name
+elif [[ -z $old_sink_name ]]; then
+  old_sink_name=$live_sink_name
+fi
 old_sink_index=$(timeout 2 pactl -f json list sinks 2>/dev/null |
   jq -r --arg name "$old_sink_name" 'map(select(.name == $name))[0].index // empty' || true)
 
@@ -49,9 +61,17 @@ fi
 timeout 2 wpctl set-default "$node_id" 2>/dev/null || true
 timeout 2 pactl set-default-sink "$sink_name" 2>/dev/null || true
 
+actual_sink_name=$(timeout 2 pactl get-default-sink 2>/dev/null || true)
+if [[ $actual_sink_name != "$sink_name" ]]; then
+  echo "Could not set the default audio output" >&2
+  exit 1
+fi
+
 for input in "${following_inputs[@]}"; do
   [[ -n $input ]] && timeout 2 pactl move-sink-input "$input" "$sink_name" 2>/dev/null || true
 done
 
-script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
-"$script_dir/audio-preferences" set-default output "$sink_name"
+if ! "$script_dir/audio-preferences" set-default output "$sink_name"; then
+  echo "The default output changed, but its preference could not be saved" >&2
+  exit 2
+fi

--- a/scripts/audio-preferences
+++ b/scripts/audio-preferences
@@ -19,7 +19,9 @@ default_preferences() {
 }
 
 read_preferences() {
-  if [[ -s $preferences_file ]] && jq -e 'type == "object"' "$preferences_file" >/dev/null 2>&1; then
+  if [[ ! -s $preferences_file ]]; then
+    default_preferences
+  elif jq -e 'type == "object"' "$preferences_file" >/dev/null 2>&1; then
     jq -c '
       .version = 1
       | .defaults = (if (.defaults | type) == "object" then .defaults else {} end)
@@ -28,7 +30,8 @@ read_preferences() {
       | .bluetoothProfiles = (if (.bluetoothProfiles | type) == "object" then .bluetoothProfiles else {} end)
     ' "$preferences_file"
   else
-    default_preferences
+    echo "Audio preferences contain invalid JSON; refusing to overwrite them" >&2
+    return 1
   fi
 }
 
@@ -45,7 +48,11 @@ write_preferences() {
 
   temporary_file=$(mktemp "$preferences_dir/.audio-preferences.XXXXXX")
   trap 'rm -f -- "$temporary_file"' EXIT
-  read_preferences | jq "$@" "$filter" >"$temporary_file"
+  if ! read_preferences | jq "$@" "$filter" >"$temporary_file"; then
+    rm -f -- "$temporary_file"
+    trap - EXIT
+    return 1
+  fi
   chmod 600 "$temporary_file"
   mv -f -- "$temporary_file" "$preferences_file"
   trap - EXIT

--- a/scripts/audio-profile-set
+++ b/scripts/audio-profile-set
@@ -16,49 +16,68 @@ fi
 set -o pipefail
 
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
-if ! "$script_dir/audio-profiles" |
-  jq -e --arg card "$card" --arg profile "$profile" '
-    any(.[]; .name == $card and any(.profiles[]; .value == $profile))
-  ' >/dev/null; then
+profiles=$("$script_dir/audio-profiles") || exit 1
+profile_state=$(jq -c --arg card "$card" --arg profile "$profile" '
+  [.[] | select(.name == $card) | .profiles[] | select(.value == $profile)][0] // empty
+' <<<"$profiles") || exit 1
+if [[ -z $profile_state ]]; then
   echo "Profile is not available for this device" >&2
   exit 1
 fi
+expected_sinks=$(jq -r '.sinks // 0' <<<"$profile_state")
+expected_sources=$(jq -r '.sources // 0' <<<"$profile_state")
+[[ $expected_sinks =~ ^[0-9]+$ ]] || expected_sinks=0
+[[ $expected_sources =~ ^[0-9]+$ ]] || expected_sources=0
 
 card_index=$(timeout 2 pactl -f json list cards 2>/dev/null |
   jq -r --arg card "$card" 'map(select(.name == $card))[0].index // empty') || exit 1
 [[ $card_index =~ ^[0-9]+$ ]] || exit 1
 
-sink_state=$(timeout 2 pactl -f json list sinks 2>/dev/null |
-  jq -r --argjson card "$card_index" '
-    map(select(.card == $card))[0]
-    | if . == null then empty
-      else [(.volume | to_entries[0].value.value_percent // ""), (.mute // false)] | @tsv
-      end' || true)
-source_state=$(timeout 2 pactl -f json list sources 2>/dev/null |
-  jq -r --argjson card "$card_index" '
-    map(select(.card == $card))[0]
-    | if . == null then empty
-      else [(.volume | to_entries[0].value.value_percent // ""), (.mute // false)] | @tsv
-      end' || true)
+read_endpoint_states() {
+  local endpoint_type=$1
+  timeout 2 pactl -f json list "$endpoint_type" 2>/dev/null |
+    jq -c --argjson card "$card_index" '
+      map(
+        select(.card == $card)
+        | {
+            index: .index,
+            name: (.name // ""),
+            mute: (.mute // false),
+            volumes: [
+              .volume // {}
+              | to_entries[]?
+              | if .value.value != null then (.value.value | tostring)
+                else (.value.value_percent // empty)
+                end
+            ]
+          }
+      )
+    '
+}
 
-IFS=$'\t' read -r sink_volume sink_muted <<<"$sink_state"
-IFS=$'\t' read -r source_volume source_muted <<<"$source_state"
+sink_states=$(read_endpoint_states sinks) || sink_states='[]'
+source_states=$(read_endpoint_states sources) || source_states='[]'
+jq -e 'type == "array"' <<<"$sink_states" >/dev/null 2>&1 || sink_states='[]'
+jq -e 'type == "array"' <<<"$source_states" >/dev/null 2>&1 || source_states='[]'
 
 # Profile changes recreate endpoints, and a newly exposed sink can carry a
 # previously stored 100% volume. Mute the old endpoint, create the new one,
 # restore its level first, and only then restore the original mute state.
-old_sinks=()
-while IFS= read -r sink_index; do
+mapfile -t old_sinks < <(jq -r '.[].index | select(type == "number")' <<<"$sink_states")
+mapfile -t old_sources < <(jq -r '.[].index | select(type == "number")' <<<"$source_states")
+for sink_index in "${old_sinks[@]}"; do
   [[ $sink_index =~ ^[0-9]+$ ]] || continue
-  old_sinks+=("$sink_index")
   timeout 2 pactl set-sink-mute "$sink_index" true >/dev/null 2>&1 || true
-done < <(timeout 2 pactl -f json list sinks 2>/dev/null |
-  jq -r --argjson card "$card_index" '.[] | select(.card == $card) | .index' || true)
+done
+for source_index in "${old_sources[@]}"; do
+  [[ $source_index =~ ^[0-9]+$ ]] || continue
+  timeout 2 pactl set-source-mute "$source_index" true >/dev/null 2>&1 || true
+done
 
 old_sink_inputs=()
 old_sink_input_mutes=()
 if (( ${#old_sinks[@]} > 0 )); then
-  old_sinks_json=$(printf '%s\n' "${old_sinks[@]}" | jq -Rsc 'split("\n") | map(select(length > 0) | tonumber)')
+  old_sinks_json=$(jq -c '[.[].index | select(type == "number")]' <<<"$sink_states")
   while IFS=$'\t' read -r input_index input_muted; do
     [[ $input_index =~ ^[0-9]+$ ]] || continue
     old_sink_inputs+=("$input_index")
@@ -77,34 +96,91 @@ restore_sink_inputs() {
   done
 }
 
-if ! timeout 2 pactl set-card-profile "$card" "$profile"; then
-  for sink_index in "${old_sinks[@]}"; do
-    timeout 2 pactl set-sink-mute "$sink_index" "${sink_muted:-false}" >/dev/null 2>&1 || true
+restore_endpoint_mutes() {
+  local endpoint_kind=$1
+  local states=$2
+  local count index endpoint_index endpoint_muted
+  count=$(jq 'length' <<<"$states")
+  for (( index = 0; index < count; index++ )); do
+    endpoint_index=$(jq -r --argjson index "$index" '.[$index].index // empty' <<<"$states")
+    endpoint_muted=$(jq -r --argjson index "$index" '.[$index].mute // false' <<<"$states")
+    [[ $endpoint_index =~ ^[0-9]+$ ]] || continue
+    timeout 2 pactl "set-${endpoint_kind}-mute" "$endpoint_index" "$endpoint_muted" >/dev/null 2>&1 || true
   done
+}
+
+if ! timeout 2 pactl set-card-profile "$card" "$profile"; then
+  restore_endpoint_mutes sink "$sink_states"
+  restore_endpoint_mutes source "$source_states"
   restore_sink_inputs
   exit 1
 fi
 
-for (( attempt = 0; attempt < 20; attempt++ )); do
-  mapfile -t new_sinks < <(timeout 2 pactl -f json list sinks 2>/dev/null |
-    jq -r --argjson card "$card_index" '.[] | select(.card == $card) | .index' || true)
-  mapfile -t new_sources < <(timeout 2 pactl -f json list sources 2>/dev/null |
-    jq -r --argjson card "$card_index" '.[] | select(.card == $card) | .index' || true)
-  (( ${#new_sinks[@]} > 0 || ${#new_sources[@]} > 0 )) && break
+new_sink_states='[]'
+new_source_states='[]'
+for (( attempt = 0; attempt < 40; attempt++ )); do
+  new_sink_states=$(read_endpoint_states sinks) || new_sink_states='[]'
+  new_source_states=$(read_endpoint_states sources) || new_source_states='[]'
+  new_sink_count=$(jq 'length' <<<"$new_sink_states")
+  new_source_count=$(jq 'length' <<<"$new_source_states")
+  (( new_sink_count >= expected_sinks && new_source_count >= expected_sources )) && break
   sleep 0.05
 done
 
-for sink_index in "${new_sinks[@]}"; do
-  [[ $sink_index =~ ^[0-9]+$ ]] || continue
-  timeout 2 pactl set-sink-mute "$sink_index" true >/dev/null 2>&1 || true
-  [[ -n $sink_volume ]] && timeout 2 pactl set-sink-volume "$sink_index" "$sink_volume" >/dev/null 2>&1 || true
-  timeout 2 pactl set-sink-mute "$sink_index" "${sink_muted:-false}" >/dev/null 2>&1 || true
-done
+restore_new_endpoint_states() {
+  local endpoint_kind=$1
+  local old_states=$2
+  local new_states=$3
+  local count index endpoint_index endpoint_name new_state saved_state restore_state
+  local saved_count new_channel_count endpoint_muted
+  local -a saved_volumes volume_arguments
 
-for source_index in "${new_sources[@]}"; do
-  [[ $source_index =~ ^[0-9]+$ ]] || continue
-  [[ -n $source_volume ]] && timeout 2 pactl set-source-volume "$source_index" "$source_volume" >/dev/null 2>&1 || true
-  timeout 2 pactl set-source-mute "$source_index" "${source_muted:-false}" >/dev/null 2>&1 || true
-done
+  count=$(jq 'length' <<<"$new_states")
+
+  # Mute every newly exposed endpoint before restoring any of them. This keeps
+  # later endpoints from becoming audible while an earlier one is configured.
+  for (( index = 0; index < count; index++ )); do
+    endpoint_index=$(jq -r --argjson index "$index" '.[$index].index // empty' <<<"$new_states")
+    [[ $endpoint_index =~ ^[0-9]+$ ]] || continue
+    timeout 2 pactl "set-${endpoint_kind}-mute" "$endpoint_index" true >/dev/null 2>&1 || true
+  done
+
+  for (( index = 0; index < count; index++ )); do
+    new_state=$(jq -c --argjson index "$index" '.[$index]' <<<"$new_states")
+    endpoint_index=$(jq -r '.index // empty' <<<"$new_state")
+    endpoint_name=$(jq -r '.name // ""' <<<"$new_state")
+    [[ $endpoint_index =~ ^[0-9]+$ ]] || continue
+
+    # Names remain stable for many profile changes. When a profile changes the
+    # endpoint name too, preserve state by endpoint order instead of copying the
+    # first endpoint's state to every new endpoint.
+    saved_state=$(jq -c --arg name "$endpoint_name" --argjson index "$index" '
+      ([.[] | select(.name == $name)][0] // .[$index] // empty)
+    ' <<<"$old_states")
+    restore_state=${saved_state:-$new_state}
+
+    if [[ -n $saved_state ]]; then
+      mapfile -t saved_volumes < <(jq -r '.volumes[]?' <<<"$saved_state")
+      saved_count=${#saved_volumes[@]}
+      new_channel_count=$(jq '.volumes | length' <<<"$new_state")
+      if (( saved_count > 0 )); then
+        if (( saved_count == new_channel_count )); then
+          volume_arguments=("${saved_volumes[@]}")
+        else
+          volume_arguments=("${saved_volumes[0]}")
+        fi
+        timeout 2 pactl "set-${endpoint_kind}-volume" "$endpoint_index" \
+          "${volume_arguments[@]}" >/dev/null 2>&1 || true
+      fi
+    fi
+
+    endpoint_muted=$(jq -r '.mute // false' <<<"$restore_state")
+    timeout 2 pactl "set-${endpoint_kind}-mute" "$endpoint_index" "$endpoint_muted" >/dev/null 2>&1 || true
+  done
+}
+
+restore_new_endpoint_states sink "$sink_states" "$new_sink_states"
+restore_new_endpoint_states source "$source_states" "$new_source_states"
 
 restore_sink_inputs
+exit 0

--- a/test/all
+++ b/test/all
@@ -64,6 +64,11 @@ assert.equal(model.balanceValue(1, 0.25), -0.75)
 assert.equal(model.balanceValue(0.5, 1), 0.5)
 assert.deepEqual(model.applyBalance([0.8, 0.8], 0, 1, 0.25), [0.6000000000000001, 0.8])
 assert.deepEqual(model.applyBalance([0.8, 0.8], 0, 1, -1), [0.8, 0])
+assert.deepEqual([0.2, 0.6, 1].map(volume =>
+  model.audioMeterLevel([], [], 1, volume, false)), [0.2, 0.6, 1])
+assert.ok(Math.abs(model.audioMeterLevel([0.8, 0.4], [0.25, 0.75], 0, 0, false) - 0.3) < 1e-9)
+assert.equal(model.audioMeterLevel([1], [1.5], 0, 0, false), 1)
+assert.equal(model.audioMeterLevel([1], [1], 1, 1, true), 0)
 assert.equal(model.outputVolumeName(1, false), 'Concert hall')
 assert.equal(model.outputVolumeName(1.25, false), 'Concert hall')
 assert.equal(model.outputVolumeName(1.26, false), 'Overdrive')
@@ -172,10 +177,27 @@ jq -e '
 ' <<<"$routes" >/dev/null || fail "playback and recording route snapshot"
 echo "PASS: persistent application routing"
 
+output_default_log=$(mktemp)
 input_default_log=$(mktemp)
 shared_preferences=$(mktemp)
 shared_preferences_lock="${shared_preferences}.lock"
-trap 'rm -f "$route_log" "$input_default_log" "$shared_preferences" "$shared_preferences_lock"' EXIT
+shared_preferences_output_lock="${shared_preferences}.output.lock"
+shared_preferences_input_lock="${shared_preferences}.input.lock"
+trap 'rm -f "$route_log" "$output_default_log" "$input_default_log" "$shared_preferences" "$shared_preferences_lock" "$shared_preferences_output_lock" "$shared_preferences_input_lock"' EXIT
+
+AUDIO_CONTROL_OUTPUT_DEFAULT_LOG="$output_default_log" \
+  OMARCHY_AUDIO_PREFERENCES_FILE="$shared_preferences" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-output-set-default" 51 new-speakers old-speakers
+
+expected_output_default_log=$(cat <<'EOF'
+wpctl set-default 51
+pactl set-default-sink new-speakers
+pactl move-sink-input 300 new-speakers
+EOF
+)
+[[ $(<"$output_default_log") == "$expected_output_default_log" ]] ||
+  fail "default output preserved pinned playback route"
+
 AUDIO_CONTROL_INPUT_DEFAULT_LOG="$input_default_log" \
   OMARCHY_AUDIO_PREFERENCES_FILE="$shared_preferences" PATH="$TEST_DIR/mocks:$PATH" \
   "$ROOT/scripts/audio-input-set-default" 52 new-microphone old-microphone
@@ -188,6 +210,38 @@ EOF
 )
 [[ $(<"$input_default_log") == "$expected_input_default_log" ]] ||
   fail "default input preserved pinned recording route"
+jq -e '
+  .defaults == {"output":"new-speakers","input":"new-microphone"}
+' "$shared_preferences" >/dev/null || fail "verified default devices"
+
+failed_preferences=$(mktemp)
+failed_preferences_output_lock="${failed_preferences}.output.lock"
+if AUDIO_CONTROL_DEFAULT_FAILURE=1 OMARCHY_AUDIO_PREFERENCES_FILE="$failed_preferences" \
+  PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-output-set-default" 99 missing-speakers old-speakers >/dev/null 2>&1; then
+  fail "failed default output reported success"
+fi
+[[ ! -s $failed_preferences ]] || fail "failed default output was persisted"
+
+invalid_preferences=$(mktemp)
+invalid_preferences_lock="${invalid_preferences}.lock"
+invalid_preferences_output_lock="${invalid_preferences}.output.lock"
+printf '{invalid json\n' >"$invalid_preferences"
+invalid_preferences_before=$(<"$invalid_preferences")
+: >"$output_default_log"
+if AUDIO_CONTROL_OUTPUT_DEFAULT_LOG="$output_default_log" \
+  OMARCHY_AUDIO_PREFERENCES_FILE="$invalid_preferences" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-output-set-default" 51 new-speakers old-speakers >/dev/null 2>&1; then
+  fail "invalid shared preferences allowed a default output change"
+fi
+[[ ! -s $output_default_log ]] || fail "default output changed before preferences validation"
+if OMARCHY_AUDIO_PREFERENCES_FILE="$invalid_preferences" \
+  "$ROOT/scripts/audio-preferences" set-default output speakers >/dev/null 2>&1; then
+  fail "invalid shared preferences were overwritten"
+fi
+[[ $(<"$invalid_preferences") == "$invalid_preferences_before" ]] ||
+  fail "invalid shared preferences changed"
+
 OMARCHY_AUDIO_PREFERENCES_FILE="$shared_preferences" \
   "$ROOT/scripts/audio-preferences" set-default output headphones
 OMARCHY_AUDIO_PREFERENCES_FILE="$shared_preferences" \
@@ -197,8 +251,11 @@ jq -e '
   and .defaults == {"output":"headphones","input":"new-microphone"}
   and .bluetoothProfiles == {"001122334455":"a2dp-aac"}
 ' "$shared_preferences" >/dev/null || fail "shared audio preferences"
-echo "PASS: default input recording routes"
-rm -f -- "$shared_preferences" "$shared_preferences_lock"
+echo "PASS: verified default device routing"
+rm -f -- "$output_default_log" "$shared_preferences" "$shared_preferences_lock" \
+  "$shared_preferences_output_lock" "$shared_preferences_input_lock" \
+  "$failed_preferences" "$failed_preferences_output_lock" \
+  "$invalid_preferences" "$invalid_preferences_lock" "$invalid_preferences_output_lock"
 
 port_log=$(mktemp)
 trap 'rm -f "$route_log" "$input_default_log" "$port_log"' EXIT
@@ -238,6 +295,28 @@ bluetooth_preference=$(AUDIO_CONTROL_BLUETOOTH_PREFERENCE_LOG="$bluetooth_prefer
 [[ $(<"$bluetooth_preference_log") == "settings --save bluetooth.profile-preference latency" ]] ||
   fail "Bluetooth profile preference command"
 echo "PASS: Bluetooth profile preference"
+
+bluetooth_autoswitch_log=$(mktemp)
+bluetooth_autoswitch_state=$(mktemp)
+trap 'rm -f "$route_log" "$input_default_log" "$port_log" "$bluetooth_preference_log" "$bluetooth_preference_state" "$bluetooth_autoswitch_log" "$bluetooth_autoswitch_state"' EXIT
+bluetooth_autoswitch=$(AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_LOG="$bluetooth_autoswitch_log" \
+  AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_STATE="$bluetooth_autoswitch_state" \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-bluetooth-autoswitch")
+[[ $bluetooth_autoswitch == true ]] || fail "Bluetooth autoswitch read"
+bluetooth_autoswitch=$(AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_LOG="$bluetooth_autoswitch_log" \
+  AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_STATE="$bluetooth_autoswitch_state" \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-bluetooth-autoswitch" off)
+[[ $bluetooth_autoswitch == false ]] || fail "Bluetooth autoswitch write"
+if AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_LOG="$bluetooth_autoswitch_log" \
+  AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_STATE="$bluetooth_autoswitch_state" \
+  AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_FAIL=1 PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-bluetooth-autoswitch" on >/dev/null 2>&1; then
+  fail "failed Bluetooth autoswitch write reported success"
+fi
+[[ $(<"$bluetooth_autoswitch_state") == false ]] ||
+  fail "failed Bluetooth autoswitch write changed state"
+echo "PASS: Bluetooth autoswitch failure handling"
+rm -f -- "$bluetooth_autoswitch_log" "$bluetooth_autoswitch_state"
 
 profiles=$(
   AUDIO_CONTROL_CARD_FIXTURE="$TEST_DIR/fixtures/cards.json" \
@@ -288,11 +367,13 @@ AUDIO_CONTROL_CARD_FIXTURE="$TEST_DIR/fixtures/cards.json" \
 
 expected_profile_log=$(cat <<'EOF'
 set-sink-mute 100 true
+set-source-mute 200 true
 set-sink-input-mute 300 true
 set-card-profile alsa_card.usb-example-headset output:analog-stereo+input:mono-fallback
 set-sink-mute 101 true
-set-sink-volume 101 42%
+set-sink-volume 101 42% 21%
 set-sink-mute 101 false
+set-source-mute 200 true
 set-source-volume 200 36%
 set-source-mute 200 true
 set-sink-input-mute 300 false
@@ -300,6 +381,35 @@ EOF
 )
 [[ $(<"$profile_log") == "$expected_profile_log" ]] || fail "safe profile transition order"
 echo "PASS: safe profile transition"
+
+: >"$profile_log"
+printf 'old\n' >"$profile_state"
+AUDIO_CONTROL_CARD_FIXTURE="$TEST_DIR/fixtures/cards.json" \
+  AUDIO_CONTROL_PROFILE_LOG="$profile_log" \
+  AUDIO_CONTROL_PROFILE_STATE="$profile_state" \
+  AUDIO_CONTROL_MULTI_PROFILE=1 PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-profile-set" \
+    alsa_card.pci-example-ucm 'HiFi (Mic1, Speaker)'
+
+expected_profile_log=$(cat <<'EOF'
+set-sink-mute 110 true
+set-source-mute 210 true
+set-source-mute 211 true
+set-card-profile alsa_card.pci-example-ucm HiFi (Mic1, Speaker)
+set-sink-mute 120 true
+set-sink-volume 120 60% 45%
+set-sink-mute 120 false
+set-source-mute 221 true
+set-source-mute 220 true
+set-source-volume 221 70%
+set-source-mute 221 true
+set-source-volume 220 30%
+set-source-mute 220 false
+EOF
+)
+[[ $(<"$profile_log") == "$expected_profile_log" ]] ||
+  fail "per-endpoint profile state preservation"
+echo "PASS: per-endpoint profile state preservation"
 
 menu_tmp=$(mktemp -d)
 menu_file="$menu_tmp/omarchy-menu.jsonc"

--- a/test/mocks/pactl
+++ b/test/mocks/pactl
@@ -5,6 +5,49 @@ if [[ $* == "-f json list cards" && -n ${AUDIO_CONTROL_CARD_FIXTURE:-} ]]; then
   exit 0
 fi
 
+if [[ -n ${AUDIO_CONTROL_DEFAULT_FAILURE:-} ]]; then
+  case "$*" in
+    "get-default-sink")
+      echo "old-speakers"
+      exit 0
+      ;;
+    "-f json list sinks")
+      echo '[{"index":100,"name":"old-speakers"},{"index":101,"name":"missing-speakers"}]'
+      exit 0
+      ;;
+    "-f json list sink-inputs")
+      echo '[]'
+      exit 0
+      ;;
+    "set-default-sink missing-speakers") exit 1 ;;
+  esac
+fi
+
+if [[ -n ${AUDIO_CONTROL_OUTPUT_DEFAULT_LOG:-} ]]; then
+  case "$*" in
+    "get-default-sink")
+      if grep -q '^pactl set-default-sink new-speakers$' "$AUDIO_CONTROL_OUTPUT_DEFAULT_LOG" 2>/dev/null; then
+        echo "new-speakers"
+      else
+        echo "old-speakers"
+      fi
+      exit 0
+      ;;
+    "-f json list sinks")
+      echo '[{"index":100,"name":"old-speakers"},{"index":101,"name":"new-speakers"}]'
+      exit 0
+      ;;
+    "-f json list sink-inputs")
+      echo '[{"index":300,"sink":100,"properties":{"object.id":"900","application.name":"Player"}},{"index":301,"sink":100,"properties":{"object.id":"901","application.name":"Pinned"}}]'
+      exit 0
+      ;;
+    "set-default-sink new-speakers"|"move-sink-input 300 new-speakers")
+      printf 'pactl %s\n' "$*" >>"$AUDIO_CONTROL_OUTPUT_DEFAULT_LOG"
+      exit 0
+      ;;
+  esac
+fi
+
 if [[ -n ${AUDIO_CONTROL_ROUTE_LIST:-} && $* == "-f json list" ]]; then
   echo '{"sink_inputs":[{"index":300,"sink":101,"properties":{"object.id":"900"}}],"source_outputs":[{"index":400,"source":201,"properties":{"object.id":"901"}}]}'
   exit 0
@@ -48,6 +91,14 @@ fi
 
 if [[ -n ${AUDIO_CONTROL_INPUT_DEFAULT_LOG:-} ]]; then
   case "$*" in
+    "get-default-source")
+      if grep -q '^pactl set-default-source new-microphone$' "$AUDIO_CONTROL_INPUT_DEFAULT_LOG" 2>/dev/null; then
+        echo "new-microphone"
+      else
+        echo "old-microphone"
+      fi
+      exit 0
+      ;;
     "-f json list sources")
       echo '[{"index":200,"name":"old-microphone"},{"index":201,"name":"new-microphone"}]'
       exit 0
@@ -68,19 +119,33 @@ if [[ -n ${AUDIO_CONTROL_PROFILE_LOG:-} && -n ${AUDIO_CONTROL_PROFILE_STATE:-} ]
 
   case "$*" in
     "-f json list sinks")
-      if [[ $state == old ]]; then
-        echo '[{"index":100,"card":10,"volume":{"front-left":{"value_percent":"42%"}},"mute":false}]'
+      if [[ ${AUDIO_CONTROL_MULTI_PROFILE:-0} == 1 && $state == old ]]; then
+        echo '[{"index":110,"name":"speaker-output","card":40,"volume":{"front-left":{"value_percent":"60%"},"front-right":{"value_percent":"45%"}},"mute":false}]'
+      elif [[ ${AUDIO_CONTROL_MULTI_PROFILE:-0} == 1 ]]; then
+        echo '[{"index":120,"name":"speaker-output","card":40,"volume":{"front-left":{"value_percent":"100%"},"front-right":{"value_percent":"100%"}},"mute":false}]'
+      elif [[ $state == old ]]; then
+        echo '[{"index":100,"name":"headset-output","card":10,"volume":{"front-left":{"value_percent":"42%"},"front-right":{"value_percent":"21%"}},"mute":false}]'
       else
-        echo '[{"index":101,"card":10,"volume":{"front-left":{"value_percent":"100%"}},"mute":false}]'
+        echo '[{"index":101,"name":"headset-output","card":10,"volume":{"front-left":{"value_percent":"100%"},"front-right":{"value_percent":"100%"}},"mute":false}]'
       fi
       exit 0
       ;;
     "-f json list sources")
-      echo '[{"index":200,"card":10,"volume":{"mono":{"value_percent":"36%"}},"mute":true}]'
+      if [[ ${AUDIO_CONTROL_MULTI_PROFILE:-0} == 1 && $state == old ]]; then
+        echo '[{"index":210,"name":"mic-a","card":40,"volume":{"mono":{"value_percent":"30%"}},"mute":false},{"index":211,"name":"mic-b","card":40,"volume":{"mono":{"value_percent":"70%"}},"mute":true}]'
+      elif [[ ${AUDIO_CONTROL_MULTI_PROFILE:-0} == 1 ]]; then
+        echo '[{"index":221,"name":"mic-b","card":40,"volume":{"mono":{"value_percent":"100%"}},"mute":false},{"index":220,"name":"mic-a","card":40,"volume":{"mono":{"value_percent":"100%"}},"mute":false}]'
+      else
+        echo '[{"index":200,"name":"headset-input","card":10,"volume":{"mono":{"value_percent":"36%"}},"mute":true}]'
+      fi
       exit 0
       ;;
     "-f json list sink-inputs")
-      echo '[{"index":300,"sink":100,"mute":false}]'
+      if [[ ${AUDIO_CONTROL_MULTI_PROFILE:-0} == 1 ]]; then
+        echo '[]'
+      else
+        echo '[{"index":300,"sink":100,"mute":false}]'
+      fi
       exit 0
       ;;
     set-card-profile\ *)

--- a/test/mocks/pw-metadata
+++ b/test/mocks/pw-metadata
@@ -8,6 +8,11 @@ EOF
   exit 0
 fi
 
+if [[ -n ${AUDIO_CONTROL_OUTPUT_DEFAULT_LOG:-} ]]; then
+  echo "update: id:901 key:'target.object' value:'101' type:'Spa:Id'"
+  exit 0
+fi
+
 if [[ -n ${AUDIO_CONTROL_INPUT_DEFAULT_LOG:-} ]]; then
   echo "update: id:902 key:'target.object' value:'200' type:'Spa:Id'"
   exit 0

--- a/test/mocks/wpctl
+++ b/test/mocks/wpctl
@@ -1,8 +1,35 @@
 #!/bin/bash
 
+if [[ -n ${AUDIO_CONTROL_DEFAULT_FAILURE:-} && $1 == "set-default" ]]; then
+  exit 1
+fi
+
+if [[ -n ${AUDIO_CONTROL_OUTPUT_DEFAULT_LOG:-} && $* == "set-default 51" ]]; then
+  printf 'wpctl %s\n' "$*" >>"$AUDIO_CONTROL_OUTPUT_DEFAULT_LOG"
+  exit 0
+fi
+
 if [[ -n ${AUDIO_CONTROL_INPUT_DEFAULT_LOG:-} && $* == "set-default 52" ]]; then
   printf 'wpctl %s\n' "$*" >>"$AUDIO_CONTROL_INPUT_DEFAULT_LOG"
   exit 0
+fi
+
+if [[ -n ${AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_LOG:-} ]]; then
+  state_file=${AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_STATE:?}
+  case "$*" in
+    "settings --save bluetooth.autoswitch-to-headset-profile true"|"settings --save bluetooth.autoswitch-to-headset-profile false")
+      printf '%s\n' "$*" >>"$AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_LOG"
+      [[ ${AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_FAIL:-0} == 1 ]] && exit 1
+      printf '%s\n' "${!#}" >"$state_file"
+      exit 0
+      ;;
+    "settings bluetooth.autoswitch-to-headset-profile")
+      value=true
+      [[ -s $state_file ]] && value=$(<"$state_file")
+      printf 'Value: %s\n' "$value"
+      exit 0
+      ;;
+  esac
 fi
 
 if [[ -n ${AUDIO_CONTROL_BLUETOOTH_PREFERENCE_LOG:-} ]]; then


### PR DESCRIPTION
## Summary
- make default-device and preference updates failure-aware and serialized
- preserve per-endpoint state across profile changes and prevent profile/port races
- report Bluetooth mutation failures and reconcile optimistic UI state
- scale live application meters by effective per-channel volume
- expand regression coverage for failure and state-preservation paths

## Validation
- ./test/all
- qmllint Panel.qml AdvancedAudio.qml AudioDropdown.qml
- omarchy-plugin-validate .
- bash syntax and git diff checks