### PR TITLE
Add audio safety policies and microphone visibility

### DIFF
--- a/AdvancedAudio.qml
+++ b/AdvancedAudio.qml
@@ -28,19 +28,26 @@ Item {
   property string bluetoothProfilePreference: "quality"
   property bool bluetoothProfilePreferenceLoaded: false
   property bool bluetoothProfilePreferenceMutation: false
+  property var policySettings: ({})
+  property bool policySettingsLoaded: false
+  property bool policyMutation: false
+  property bool policyResponseValid: false
+  property var previousPolicySettings: ({})
+  property string pendingPolicyKey: ""
   property string profileLoadError: ""
   property string portLoadError: ""
   property string profileSetError: ""
   property string portSetError: ""
   property string bluetoothAutoswitchError: ""
   property string bluetoothPreferenceError: ""
+  property string policyError: ""
   readonly property string error: {
     var errors = [profileSetError, portSetError, bluetoothAutoswitchError,
-      bluetoothPreferenceError, profileLoadError, portLoadError]
+      bluetoothPreferenceError, policyError, profileLoadError, portLoadError]
     for (var i = 0; i < errors.length; i++) if (errors[i] !== "") return errors[i]
     return ""
   }
-  property int activeTab: 0  // 0 = devices, 1 = Bluetooth
+  property int activeTab: 0  // 0 = devices, 1 = Bluetooth, 2 = policy
   property bool cursorActive: false
   property int selectedIndex: 0
   property bool profileMenuOpen: false
@@ -53,6 +60,60 @@ Item {
   readonly property color background: Color.background
   readonly property color urgent: Color.urgent
   readonly property string fontFamily: Style.font.family
+  readonly property var policyCoreDefinitions: [
+    {
+      key: "node.features.audio.mono",
+      label: "Mono audio",
+      description: "Mix left and right output channels so every sound is audible from either speaker."
+    },
+    {
+      key: "linking.pause-playback",
+      label: "Pause on output loss",
+      description: "Pause compatible media players when their active output device disappears."
+    },
+    {
+      key: "device.routes.mute-on-alsa-playback-removed",
+      label: "Mute after wired disconnect",
+      description: "Keep playback muted instead of unexpectedly moving it to another output."
+    },
+    {
+      key: "device.routes.mute-on-bluetooth-playback-removed",
+      label: "Mute after Bluetooth disconnect",
+      description: "Prevent private audio from jumping to speakers when Bluetooth drops."
+    }
+  ]
+  readonly property var policyVolumeDefinitions: [
+    {
+      key: "device.routes.default-sink-volume",
+      label: "New output devices",
+      description: "Starting level before WirePlumber has remembered a volume for the device."
+    },
+    {
+      key: "device.routes.default-source-volume",
+      label: "New input devices",
+      description: "Starting level before WirePlumber has remembered a volume for the microphone."
+    },
+    {
+      key: "node.stream.default-playback-volume",
+      label: "New playback apps",
+      description: "Starting level for applications that have not played audio before."
+    },
+    {
+      key: "node.stream.default-capture-volume",
+      label: "New recording apps",
+      description: "Starting level for applications that have not recorded before."
+    }
+  ]
+  readonly property var policyExperimentalDefinitions: [
+    {
+      key: "monitor.alsa.autodetect-hdmi-channels",
+      label: "Detect HDMI channel layout",
+      description: "Let WirePlumber infer HDMI channel counts. Experimental; some receivers report them incorrectly."
+    }
+  ]
+  readonly property var availablePolicyCore: supportedPolicyDefinitions(policyCoreDefinitions)
+  readonly property var availablePolicyVolumes: supportedPolicyDefinitions(policyVolumeDefinitions)
+  readonly property var availablePolicyExperimental: supportedPolicyDefinitions(policyExperimentalDefinitions)
   readonly property var bluetoothCards: Model.audioCardsByBluetooth(audioCards, true)
   readonly property var deviceCards: Model.audioCardsByBluetooth(audioCards, false)
   readonly property var pipewireNodes: Pipewire.nodes ? Pipewire.nodes.values : []
@@ -77,9 +138,12 @@ Item {
   readonly property int outputBalanceIndex: outputBalanceAvailable ? balanceStartIndex : -1
   readonly property int inputBalanceIndex: inputBalanceAvailable
     ? balanceStartIndex + (outputBalanceAvailable ? 1 : 0) : -1
+  readonly property int policyVolumeStartIndex: availablePolicyCore.length
+  readonly property int policyExperimentalStartIndex: policyVolumeStartIndex + availablePolicyVolumes.length
+  readonly property int policyItemCount: policyExperimentalStartIndex + availablePolicyExperimental.length
   readonly property int itemCount: activeTab === 0
     ? balanceStartIndex + (outputBalanceAvailable ? 1 : 0) + (inputBalanceAvailable ? 1 : 0)
-    : 2 + bluetoothCards.length
+    : (activeTab === 1 ? 2 + bluetoothCards.length : policyItemCount)
   readonly property bool audioMutationBusy: profileSetProc.running || portSetProc.running
   readonly property color hoverFill: Style.hoverFillFor(foreground, Color.accent)
   readonly property string settingsPath: {
@@ -102,7 +166,7 @@ Item {
   function open(payloadJson) {
     var payload = ({})
     try { payload = JSON.parse(payloadJson || "{}") } catch (e) { payload = ({}) }
-    activeTab = payload.tab === "bluetooth" ? 1 : 0
+    activeTab = payload.tab === "bluetooth" ? 1 : (payload.tab === "policy" ? 2 : 0)
     openRequested = true
     closingFromHost = false
     cursorActive = false
@@ -111,6 +175,7 @@ Item {
     profilesLoaded = false
     bluetoothAutoSwitchLoaded = false
     bluetoothProfilePreferenceLoaded = false
+    policySettingsLoaded = false
     if (windowRuleReady) showOnCurrentWorkspace()
     else if (!windowRuleProc.running) windowRuleProc.running = true
   }
@@ -122,6 +187,7 @@ Item {
     portSetError = ""
     bluetoothAutoswitchError = ""
     bluetoothPreferenceError = ""
+    policyError = ""
   }
 
   function showOnCurrentWorkspace() {
@@ -163,6 +229,13 @@ Item {
       bluetoothPreferenceProc.running = true
     }
     if (!portsProc.running && !portSetProc.running) portsProc.running = true
+    if (!policyProc.running) {
+      policyMutation = false
+      policyResponseValid = false
+      pendingPolicyKey = ""
+      policyProc.command = [pluginScript("audio-policy-settings")]
+      policyProc.running = true
+    }
     resolveVolumeSink()
   }
 
@@ -188,6 +261,76 @@ Item {
   function loadAudioControlSettings(raw) {
     audioControlSettings = Model.parseAudioControlSettings(raw)
     outputOverdrive = audioControlSettings.outputOverdrive
+  }
+
+  function supportedPolicyDefinitions(definitions) {
+    var supported = []
+    for (var i = 0; i < definitions.length; i++) {
+      var definition = definitions[i]
+      if (policySettings[definition.key] !== undefined) supported.push(definition)
+    }
+    return supported
+  }
+
+  function copyPolicySettings(source) {
+    var copy = ({})
+    for (var key in source) copy[key] = source[key]
+    return copy
+  }
+
+  function loadPolicySettings(raw) {
+    var response = Model.parseAudioPolicySettings(raw)
+    policyResponseValid = response.valid
+    if (!response.valid) return
+    policySettings = response.values
+    policySettingsLoaded = true
+    clampCursor()
+  }
+
+  function setPolicySetting(key, value) {
+    if (!policySettingsLoaded || policyProc.running || policySettings[key] === undefined) return
+    var current = policySettings[key]
+    var normalized
+    if (typeof current === "boolean") {
+      if (typeof value !== "boolean") return
+      normalized = value
+    } else {
+      normalized = Math.max(0, Math.min(1, Math.round(Number(value) * 20) / 20))
+      if (!isFinite(normalized)) return
+    }
+    if (normalized === current) return
+
+    policyError = ""
+    previousPolicySettings = copyPolicySettings(policySettings)
+    var next = copyPolicySettings(policySettings)
+    next[key] = normalized
+    policySettings = next
+    policyMutation = true
+    policyResponseValid = false
+    pendingPolicyKey = key
+    policyProc.command = [pluginScript("audio-policy-settings"), "set", key, String(normalized)]
+    policyProc.running = true
+  }
+
+  function policyToggleAtCursor() {
+    if (activeTab !== 2) return null
+    if (selectedIndex < availablePolicyCore.length)
+      return availablePolicyCore[selectedIndex]
+    if (selectedIndex >= policyExperimentalStartIndex) {
+      var experimentalIndex = selectedIndex - policyExperimentalStartIndex
+      if (experimentalIndex < availablePolicyExperimental.length)
+        return availablePolicyExperimental[experimentalIndex]
+    }
+    return null
+  }
+
+  function adjustPolicyVolumeAtCursor(delta) {
+    if (activeTab !== 2) return false
+    var index = selectedIndex - policyVolumeStartIndex
+    if (index < 0 || index >= availablePolicyVolumes.length) return false
+    var definition = availablePolicyVolumes[index]
+    setPolicySetting(definition.key, Number(policySettings[definition.key]) + delta * 0.05)
+    return true
   }
 
   function setOutputOverdrive(enabled) {
@@ -283,7 +426,7 @@ Item {
   }
 
   function selectTab(index) {
-    var next = Math.max(0, Math.min(1, index))
+    var next = Math.max(0, Math.min(2, index))
     if (next === activeTab) return
     closeProfileMenus()
     activeTab = next
@@ -294,7 +437,7 @@ Item {
   }
 
   function switchTab(direction) {
-    selectTab((activeTab + (direction < 0 ? -1 : 1) + 2) % 2)
+    selectTab((activeTab + (direction < 0 ? -1 : 1) + 3) % 3)
   }
 
   function setCursor(index) {
@@ -304,6 +447,12 @@ Item {
 
   function activateCursor() {
     if (!cursorActive || itemCount === 0) return
+    if (activeTab === 2) {
+      var policyToggle = policyToggleAtCursor()
+      if (policyToggle)
+        setPolicySetting(policyToggle.key, policySettings[policyToggle.key] !== true)
+      return
+    }
     if (activeTab === 0 && selectedIndex === 0) {
       setOutputOverdrive(!outputOverdrive)
       return
@@ -524,6 +673,31 @@ Item {
     }
   }
 
+  Process {
+    id: policyProc
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: root.loadPolicySettings(text)
+    }
+    onExited: function(exitCode) {
+      var mutation = root.policyMutation
+      if (exitCode !== 0 || !root.policyResponseValid) {
+        if (mutation) root.policySettings = root.previousPolicySettings
+        else root.policySettings = ({})
+        root.policySettingsLoaded = true
+        root.policyError = mutation
+          ? "Could not change the audio safety policy"
+          : "Could not load audio safety policies"
+      } else {
+        root.policyError = ""
+      }
+      root.policyMutation = false
+      root.pendingPolicyKey = ""
+      root.previousPolicySettings = ({})
+      root.clampCursor()
+    }
+  }
+
   Timer {
     id: profileRefreshTimer
     interval: 200
@@ -584,6 +758,7 @@ Item {
             if (dx !== 0) {
               root.cursorActive = true
               if (root.activeTab === 0 && root.adjustBalanceAtCursor(dx)) return
+              if (root.activeTab === 2 && root.adjustPolicyVolumeAtCursor(dx)) return
               root.switchTab(dx)
             return
           }
@@ -631,7 +806,7 @@ Item {
 
                 Text {
                   width: parent.width
-                  text: "Configure audio devices, Bluetooth codecs, and headset behavior."
+                  text: "Configure devices, Bluetooth behavior, and system-wide audio safety."
                   color: Qt.darker(root.foreground, 1.35)
                   font.family: root.fontFamily
                   font.pixelSize: Style.font.bodySmall
@@ -645,14 +820,17 @@ Item {
             ButtonGroup {
               options: [
                 { value: "devices", label: "Devices", icon: "󰓃" },
-                { value: "bluetooth", label: "Bluetooth", icon: "󰂯" }
+                { value: "bluetooth", label: "Bluetooth", icon: "󰂯" },
+                { value: "policy", label: "Policy", icon: "󰒃" }
               ]
-              value: root.activeTab === 0 ? "devices" : "bluetooth"
+              value: root.activeTab === 0 ? "devices" : (root.activeTab === 1 ? "bluetooth" : "policy")
               focusable: false
               foreground: root.foreground
               background: root.background
               fontFamily: root.fontFamily
-              onChanged: function(value) { root.selectTab(value === "bluetooth" ? 1 : 0) }
+              onChanged: function(value) {
+                root.selectTab(value === "bluetooth" ? 1 : (value === "policy" ? 2 : 0))
+              }
             }
           }
 
@@ -949,6 +1127,164 @@ Item {
               PanelSeparator {
                 visible: root.activeTab === 1
                 foreground: root.foreground
+              }
+
+              Column {
+                visible: root.activeTab === 2
+                width: parent.width
+                spacing: Style.space(18)
+
+                Text {
+                  visible: !root.policySettingsLoaded
+                  width: parent.width
+                  text: "Loading audio safety policies…"
+                  color: Qt.darker(root.foreground, 1.35)
+                  font.family: root.fontFamily
+                  font.pixelSize: Style.font.bodySmall
+                }
+
+                Text {
+                  visible: root.policySettingsLoaded && root.policyItemCount === 0
+                    && root.policyError === ""
+                  width: parent.width
+                  text: "This WirePlumber version does not expose the supported policy controls."
+                  color: Qt.darker(root.foreground, 1.35)
+                  font.family: root.fontFamily
+                  font.pixelSize: Style.font.bodySmall
+                  wrapMode: Text.WordWrap
+                }
+
+                Text {
+                  visible: root.policySettingsLoaded && root.policyItemCount > 0
+                  width: parent.width
+                  text: "Changes apply system-wide and are saved by WirePlumber. Unsupported controls are hidden automatically."
+                  color: Qt.darker(root.foreground, 1.35)
+                  font.family: root.fontFamily
+                  font.pixelSize: Style.font.bodySmall
+                  wrapMode: Text.WordWrap
+                }
+
+                Column {
+                  visible: root.availablePolicyCore.length > 0
+                  width: parent.width
+                  spacing: Style.space(8)
+
+                  PanelSectionHeader {
+                    text: "SAFETY & ACCESSIBILITY"
+                    foreground: root.foreground
+                    fontFamily: root.fontFamily
+                  }
+
+                  Repeater {
+                    model: root.availablePolicyCore
+
+                    AudioPolicyToggleRow {
+                      id: policyCoreRow
+                      required property var modelData
+                      required property int index
+                      width: parent.width
+                      definition: modelData
+                      checked: root.policySettings[modelData.key] === true
+                      busy: policyProc.running && root.pendingPolicyKey === modelData.key
+                      enabled: root.policySettingsLoaded && !policyProc.running
+                      opacity: enabled ? 1 : 0.6
+                      hasCursor: root.cursorActive && root.activeTab === 2
+                        && root.selectedIndex === index
+                      foreground: root.foreground
+                      fill: root.hoverFill
+                      fontFamily: root.fontFamily
+                      onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(policyCoreRow)
+                      onHovered: root.setCursor(index)
+                      onActivated: root.setPolicySetting(modelData.key, !checked)
+                    }
+                  }
+                }
+
+                PanelSeparator {
+                  visible: root.availablePolicyCore.length > 0
+                    && (root.availablePolicyVolumes.length > 0
+                      || root.availablePolicyExperimental.length > 0)
+                  foreground: root.foreground
+                }
+
+                Column {
+                  visible: root.availablePolicyVolumes.length > 0
+                  width: parent.width
+                  spacing: Style.space(8)
+
+                  PanelSectionHeader {
+                    text: "STARTING VOLUMES"
+                    foreground: root.foreground
+                    fontFamily: root.fontFamily
+                  }
+
+                  Repeater {
+                    model: root.availablePolicyVolumes
+
+                    AudioPolicyVolumeRow {
+                      id: policyVolumeRow
+                      required property var modelData
+                      required property int index
+                      readonly property int rowIndex: root.policyVolumeStartIndex + index
+                      width: parent.width
+                      definition: modelData
+                      value: Number(root.policySettings[modelData.key])
+                      enabled: root.policySettingsLoaded && !policyProc.running
+                      opacity: enabled ? 1 : 0.6
+                      hasCursor: root.cursorActive && root.activeTab === 2
+                        && root.selectedIndex === rowIndex
+                      foreground: root.foreground
+                      fill: root.hoverFill
+                      fontFamily: root.fontFamily
+                      onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(policyVolumeRow)
+                      onHovered: root.setCursor(rowIndex)
+                      onCommitted: function(value) { root.setPolicySetting(modelData.key, value) }
+                    }
+                  }
+                }
+
+                PanelSeparator {
+                  visible: root.availablePolicyExperimental.length > 0
+                    && (root.availablePolicyCore.length > 0 || root.availablePolicyVolumes.length > 0)
+                  foreground: root.foreground
+                }
+
+                Column {
+                  visible: root.availablePolicyExperimental.length > 0
+                  width: parent.width
+                  spacing: Style.space(8)
+
+                  PanelSectionHeader {
+                    text: "EXPERIMENTAL"
+                    foreground: root.foreground
+                    fontFamily: root.fontFamily
+                  }
+
+                  Repeater {
+                    model: root.availablePolicyExperimental
+
+                    AudioPolicyToggleRow {
+                      id: policyExperimentalRow
+                      required property var modelData
+                      required property int index
+                      readonly property int rowIndex: root.policyExperimentalStartIndex + index
+                      width: parent.width
+                      definition: modelData
+                      checked: root.policySettings[modelData.key] === true
+                      busy: policyProc.running && root.pendingPolicyKey === modelData.key
+                      enabled: root.policySettingsLoaded && !policyProc.running
+                      opacity: enabled ? 1 : 0.6
+                      hasCursor: root.cursorActive && root.activeTab === 2
+                        && root.selectedIndex === rowIndex
+                      foreground: root.foreground
+                      fill: root.hoverFill
+                      fontFamily: root.fontFamily
+                      onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(policyExperimentalRow)
+                      onHovered: root.setCursor(rowIndex)
+                      onActivated: root.setPolicySetting(modelData.key, !checked)
+                    }
+                  }
+                }
               }
 
               Column {

--- a/AudioBarIcon.qml
+++ b/AudioBarIcon.qml
@@ -1,0 +1,53 @@
+import QtQuick
+import qs.Ui
+import qs.Commons
+
+Item {
+  id: root
+
+  property string outputGlyph: ""
+  property int recordingCount: 0
+  property bool microphoneMuted: false
+  property real iconSize: Style.bar.iconFont
+  property color foreground: Color.foreground
+  property color urgent: Color.urgent
+  property color badgeBorder: Color.popups.background
+  property string fontFamily: Style.font.family
+
+  OpticalGlyph {
+    anchors.fill: parent
+    text: root.outputGlyph
+    fontFamily: root.fontFamily
+    fontSize: root.iconSize
+    color: root.foreground
+  }
+
+  BorderSurface {
+    id: badge
+    readonly property real badgeHeight: Math.max(Style.space(8), Math.round(root.iconSize * 0.58))
+    visible: root.recordingCount > 0
+    width: Math.max(badgeHeight, badgeText.implicitWidth + Style.space(3))
+    height: badgeHeight
+    radius: height / 2
+    color: root.urgent
+    borderSpec: Border.flat(root.badgeBorder, 1)
+    anchors.right: parent.right
+    anchors.bottom: parent.bottom
+    opacity: root.microphoneMuted ? 0.68 : 1
+    scale: visible ? 1 : 0.65
+
+    Behavior on opacity { NumberAnimation { duration: 140; easing.type: Easing.OutCubic } }
+    Behavior on scale { NumberAnimation { duration: 140; easing.type: Easing.OutBack } }
+
+    Text {
+      id: badgeText
+      anchors.centerIn: parent
+      text: root.recordingCount > 9 ? "9+" : String(root.recordingCount)
+      color: Color.background
+      font.family: root.fontFamily
+      font.pixelSize: Math.max(6, Math.round(parent.height * 0.62))
+      font.bold: true
+      renderType: Text.NativeRendering
+    }
+  }
+}

--- a/AudioPolicyToggleRow.qml
+++ b/AudioPolicyToggleRow.qml
@@ -1,0 +1,71 @@
+import QtQuick
+import qs.Ui
+import qs.Commons
+
+CursorSurface {
+  id: root
+
+  required property var definition
+  required property bool checked
+  property bool busy: false
+  property string fontFamily: Style.font.family
+
+  signal activated()
+  signal hovered()
+
+  implicitHeight: content.implicitHeight + Style.space(18)
+  bordered: true
+
+  Row {
+    id: content
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.verticalCenter: parent.verticalCenter
+    anchors.leftMargin: Style.space(12)
+    anchors.rightMargin: Style.space(12)
+    spacing: Style.space(12)
+
+    Column {
+      width: parent.width - toggle.width - parent.spacing
+      spacing: Style.space(3)
+
+      Text {
+        width: parent.width
+        text: root.definition.label
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.body
+        font.bold: true
+        elide: Text.ElideRight
+      }
+
+      Text {
+        width: parent.width
+        text: root.definition.description
+        color: Qt.darker(root.foreground, 1.35)
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.caption
+        wrapMode: Text.WordWrap
+      }
+    }
+
+    ToggleSwitch {
+      id: toggle
+      checked: root.checked
+      busy: root.busy
+      interactive: false
+      cursorRing: false
+      foreground: root.foreground
+      anchors.verticalCenter: parent.verticalCenter
+    }
+  }
+
+  MouseArea {
+    anchors.fill: parent
+    enabled: root.enabled
+    hoverEnabled: true
+    cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+    onContainsMouseChanged: if (containsMouse) root.hovered()
+    onClicked: root.activated()
+  }
+}

--- a/AudioPolicyVolumeRow.qml
+++ b/AudioPolicyVolumeRow.qml
@@ -1,0 +1,87 @@
+import QtQuick
+import qs.Ui
+import qs.Commons
+
+CursorSurface {
+  id: root
+
+  required property var definition
+  required property real value
+  property string fontFamily: Style.font.family
+
+  signal committed(real value)
+  signal hovered()
+
+  implicitHeight: content.implicitHeight + Style.space(18)
+  bordered: true
+
+  Column {
+    id: content
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.verticalCenter: parent.verticalCenter
+    anchors.leftMargin: Style.space(12)
+    anchors.rightMargin: Style.space(12)
+    spacing: Style.space(6)
+
+    Item {
+      width: parent.width
+      height: Math.max(labels.implicitHeight, percentage.implicitHeight)
+
+      Column {
+        id: labels
+        width: parent.width - percentage.width - Style.space(16)
+        spacing: Style.space(3)
+
+        Text {
+          width: parent.width
+          text: root.definition.label
+          color: root.foreground
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.body
+          font.bold: true
+          elide: Text.ElideRight
+        }
+
+        Text {
+          width: parent.width
+          text: root.definition.description
+          color: Qt.darker(root.foreground, 1.35)
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.caption
+          wrapMode: Text.WordWrap
+        }
+      }
+
+      Text {
+        id: percentage
+        text: Math.round((slider.dragging ? slider.liveValue : root.value) * 100) + "%"
+        color: Qt.darker(root.foreground, 1.35)
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.caption
+        font.bold: true
+        anchors.right: parent.right
+        anchors.top: parent.top
+      }
+    }
+
+    PanelSlider {
+      id: slider
+      width: parent.width
+      minimum: 0
+      maximum: 1
+      step: 0.05
+      tickCount: 5
+      value: root.value
+      enabled: root.enabled
+      onReleased: function(value) { root.committed(value) }
+    }
+  }
+
+  MouseArea {
+    anchors.fill: parent
+    acceptedButtons: Qt.NoButton
+    hoverEnabled: true
+    onContainsMouseChanged: if (containsMouse) root.hovered()
+  }
+}

--- a/Model.js
+++ b/Model.js
@@ -104,6 +104,44 @@ function parseAudioControlSettings(raw) {
   }
 }
 
+function parseAudioPolicySettings(raw) {
+  var parsed
+  try {
+    parsed = JSON.parse(String(raw || ""))
+  } catch (e) {
+    return { valid: false, values: {} }
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed))
+    return { valid: false, values: {} }
+
+  var booleanKeys = [
+    "node.features.audio.mono",
+    "linking.pause-playback",
+    "device.routes.mute-on-alsa-playback-removed",
+    "device.routes.mute-on-bluetooth-playback-removed",
+    "monitor.alsa.autodetect-hdmi-channels"
+  ]
+  var volumeKeys = [
+    "device.routes.default-sink-volume",
+    "device.routes.default-source-volume",
+    "node.stream.default-playback-volume",
+    "node.stream.default-capture-volume"
+  ]
+  var values = {}
+  var i
+  for (i = 0; i < booleanKeys.length; i++) {
+    var booleanKey = booleanKeys[i]
+    if (typeof parsed[booleanKey] === "boolean") values[booleanKey] = parsed[booleanKey]
+  }
+  for (i = 0; i < volumeKeys.length; i++) {
+    var volumeKey = volumeKeys[i]
+    var volume = parsed[volumeKey]
+    if (typeof volume === "number" && isFinite(volume) && volume >= 0 && volume <= 1)
+      values[volumeKey] = volume
+  }
+  return { valid: true, values: values }
+}
+
 function balanceValue(left, right) {
   var l = Math.max(0, Number(left || 0))
   var r = Math.max(0, Number(right || 0))
@@ -549,6 +587,20 @@ function recordingStreamLabel(node) {
   return friendlyStreamLabel(rawStreamLabel(node)) || "Recording application"
 }
 
+function uniqueRecordingStreamLabels(streams) {
+  var values = Array.isArray(streams) ? streams : []
+  var labels = []
+  var keys = []
+  for (var i = 0; i < values.length; i++) {
+    var label = recordingStreamLabel(values[i])
+    var key = streamLabelKey(label)
+    if (keys.indexOf(key) !== -1) continue
+    keys.push(key)
+    labels.push(label)
+  }
+  return labels
+}
+
 function normalizeStreamIconName(name) {
   var value = String(name || "").trim()
   var aliases = {
@@ -608,6 +660,7 @@ if (typeof module !== "undefined") {
     preferredAudioProfile: preferredAudioProfile,
     preferredAudioNodeName: preferredAudioNodeName,
     parseAudioControlSettings: parseAudioControlSettings,
+    parseAudioPolicySettings: parseAudioPolicySettings,
     balanceValue: balanceValue,
     applyBalance: applyBalance,
     audioMeterLevel: audioMeterLevel,
@@ -641,6 +694,7 @@ if (typeof module !== "undefined") {
     unmatchedMprisStreamLabel: unmatchedMprisStreamLabel,
     streamLabel: streamLabel,
     recordingStreamLabel: recordingStreamLabel,
+    uniqueRecordingStreamLabels: uniqueRecordingStreamLabels,
     streamIconName: streamIconName,
     streamRepresentsPlayer: streamRepresentsPlayer
   }

--- a/Panel.qml
+++ b/Panel.qml
@@ -152,6 +152,26 @@ Panel {
     return list
   }
 
+  readonly property var activeRecordingLabels: Model.uniqueRecordingStreamLabels(recordingStreams)
+  readonly property int recordingApplicationCount: activeRecordingLabels.length
+  readonly property color urgent: bar ? bar.urgent : Color.urgent
+  readonly property string recordingTooltip: {
+    var microphoneAction = hasInput
+      ? "Middle-click to " + (inputMuted ? "unmute" : "mute") + " microphone"
+      : ""
+    if (recordingApplicationCount === 0) {
+      var outputStatus = outputMuted ? "Output muted" : "Output " + Math.round(outputVolume * 100) + "%"
+      return microphoneAction === "" ? outputStatus : outputStatus + "\n" + microphoneAction
+    }
+
+    var access = recordingApplicationCount === 1
+      ? "Microphone access · " + activeRecordingLabels[0]
+      : "Microphone access by " + recordingApplicationCount + " apps\n"
+        + activeRecordingLabels.join(", ")
+    var state = inputMuted ? "Microphone muted" : "Microphone in use"
+    return access + "\n" + state + (microphoneAction === "" ? "" : " · " + microphoneAction)
+  }
+
   // Feed Repeaters with panel-local snapshots instead of the live PipeWire
   // model. PipeWire can remove nodes while Quickshell is dispatching the
   // removal signal; rebuilding a Repeater from that signal path has crashed
@@ -962,9 +982,23 @@ Panel {
     id: button
     anchors.fill: parent
     bar: root.bar
-    text: root.outputIcon()
+    tooltipText: root.recordingTooltip
+    iconComponent: Component {
+      Item {
+        AudioBarIcon {
+          anchors.fill: parent
+          outputGlyph: root.outputIcon()
+          recordingCount: root.recordingApplicationCount
+          microphoneMuted: root.inputMuted
+          foreground: root.barForeground
+          urgent: root.urgent
+          fontFamily: root.bar ? root.bar.fontFamily : Style.font.family
+        }
+      }
+    }
     onPressed: function(b) {
       if (b === Qt.RightButton) root.toggleAllMuted()
+      else if (b === Qt.MiddleButton) root.toggleInputMute()
       else root.toggle()
     }
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,15 @@ instead of introducing a separate mixer application.
 - Configure device profiles and Bluetooth codecs in separate keyboard-navigable tabs.
 - Control when Bluetooth headsets switch into communication mode.
 - Choose whether automatic Bluetooth profile selection favors quality or latency.
+- Configure supported WirePlumber safety policies, including mono audio, pause on
+  output loss, disconnect protection, and HDMI channel detection.
+- Set safe starting volumes for new devices and playback or recording applications.
+- Keep microphone use visible on the bar, including the recording applications and
+  a persistent app-count badge even while the microphone is muted.
+
+The bar audio icon uses left-click for the quick mixer, middle-click to mute or
+unmute the microphone, right-click to mute or unmute all audio, and the wheel to
+adjust output volume. Hovering it lists applications with active microphone access.
 
 The optional [Advanced Bluetooth Audio](https://github.com/ssupt/omarchy-bluetooth-audio)
 companion brings the same codec controls into Omarchy's Bluetooth panel while
@@ -39,6 +48,11 @@ Application routes use WirePlumber's native stream-target restoration. Choosing
 an output restores that choice whenever the application creates a new stream.
 Recording routes follow the same behavior for microphones. Explicitly routed
 recording applications stay pinned when the default input changes.
+
+The Policy tab discovers settings from the installed WirePlumber version, so it
+only shows controls the system supports. Changes use WirePlumber's persistent
+settings API. Starting-volume percentages are converted to its cubic storage
+scale before they are saved, keeping the displayed values perceptually accurate.
 
 ## Installation
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,9 +2,9 @@
   "schemaVersion": 1,
   "id": "ssupt.audio-control",
   "name": "Advanced Audio Control",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": "ssupt",
-  "description": "Adds application playback and recording routing, volume boost, balance, device ports, and Bluetooth audio controls to Omarchy",
+  "description": "Advanced PipeWire and WirePlumber audio mixer for Omarchy: persistent per-application speaker/output and microphone/input routing; app volume, mute, icons, and live playback/recording meters; default device selection; ports and profiles; Bluetooth codecs, headset autoswitch, and quality/latency preference; 150% volume boost; stereo balance; mono audio; pause or mute protection when wired/Bluetooth devices disconnect; starting volumes for new devices and apps; HDMI channel detection; and a persistent microphone privacy/recording badge with app names and quick mute",
   "kinds": [
     "bar-widget",
     "panel"
@@ -15,7 +15,7 @@
   },
   "barWidget": {
     "displayName": "Advanced Audio Control",
-    "description": "Adds application playback and recording routing, volume boost, balance, device ports, and Bluetooth audio controls to Omarchy",
+    "description": "Advanced PipeWire and WirePlumber audio mixer for Omarchy: persistent per-application speaker/output and microphone/input routing; app volume, mute, icons, and live playback/recording meters; default device selection; ports and profiles; Bluetooth codecs, headset autoswitch, and quality/latency preference; 150% volume boost; stereo balance; mono audio; pause or mute protection when wired/Bluetooth devices disconnect; starting volumes for new devices and apps; HDMI channel detection; and a persistent microphone privacy/recording badge with app names and quick mute",
     "category": "Audio",
     "allowMultiple": false
   },

--- a/scripts/audio-policy-settings
+++ b/scripts/audio-policy-settings
@@ -1,0 +1,110 @@
+#!/bin/bash
+
+# omarchy:summary=Show or set curated audio safety policies
+# omarchy:group=audio
+# omarchy:args=[show | set <setting> <value>]
+
+set -euo pipefail
+
+readonly boolean_settings=(
+  node.features.audio.mono
+  linking.pause-playback
+  device.routes.mute-on-alsa-playback-removed
+  device.routes.mute-on-bluetooth-playback-removed
+  monitor.alsa.autodetect-hdmi-channels
+)
+
+readonly volume_settings=(
+  device.routes.default-sink-volume
+  device.routes.default-source-volume
+  node.stream.default-playback-volume
+  node.stream.default-capture-volume
+)
+
+usage() {
+  echo "Usage: audio-policy-settings [show | set <setting> <value>]" >&2
+  exit 1
+}
+
+setting_kind() {
+  case "$1" in
+    node.features.audio.mono|linking.pause-playback|device.routes.mute-on-alsa-playback-removed|device.routes.mute-on-bluetooth-playback-removed|monitor.alsa.autodetect-hdmi-channels)
+      printf '%s\n' boolean
+      ;;
+    device.routes.default-sink-volume|device.routes.default-source-volume|node.stream.default-playback-volume|node.stream.default-capture-volume)
+      printf '%s\n' volume
+      ;;
+    *) return 1 ;;
+  esac
+}
+
+read_raw_setting() {
+  local setting=$1 output
+  output=$(wpctl settings "$setting" 2>/dev/null) || return 1
+  awk '
+    $1 == "Value:" { print $2; found=1; exit }
+    END { if (!found) exit 1 }
+  ' <<<"$output"
+}
+
+snapshot() {
+  local result='{}' setting kind raw display
+
+  for setting in "${boolean_settings[@]}" "${volume_settings[@]}"; do
+    kind=$(setting_kind "$setting")
+    raw=$(read_raw_setting "$setting") || continue
+
+    if [[ $kind == boolean ]]; then
+      [[ $raw == true || $raw == false ]] || continue
+      result=$(jq -c --arg key "$setting" --argjson value "$raw" \
+        '. + {($key): $value}' <<<"$result")
+      continue
+    fi
+
+    display=$(jq -ner --arg raw "$raw" '
+      ($raw | tonumber) as $value
+      | select($value >= 0 and $value <= 1)
+      | pow($value; (1 / 3))
+    ') || continue
+    result=$(jq -c --arg key "$setting" --argjson value "$display" \
+      '. + {($key): $value}' <<<"$result")
+  done
+
+  printf '%s\n' "$result"
+}
+
+action=${1:-show}
+case "$action" in
+  show)
+    (( $# <= 1 )) || usage
+    snapshot
+    ;;
+  set)
+    (( $# == 3 )) || usage
+    setting=$2
+    value=$3
+    kind=$(setting_kind "$setting") || usage
+
+    # Query first so unsupported settings remain hidden and cannot be created
+    # accidentally on WirePlumber versions that do not provide them.
+    read_raw_setting "$setting" >/dev/null || {
+      echo "Unsupported audio policy: $setting" >&2
+      exit 1
+    }
+
+    if [[ $kind == boolean ]]; then
+      [[ $value == true || $value == false ]] || usage
+      wireplumber_value=$value
+    else
+      wireplumber_value=$(jq -ner --arg value "$value" '
+        ($value | tonumber) as $linear
+        | select($linear >= 0 and $linear <= 1)
+        | $linear * $linear * $linear
+      ') || usage
+    fi
+
+    wpctl settings --save "$setting" "$wireplumber_value" >/dev/null
+    snapshot
+    ;;
+  *) usage ;;
+esac

--- a/test/all
+++ b/test/all
@@ -38,6 +38,20 @@ assert.deepEqual(model.parseAudioControlSettings('not json'), {
   version: 1,
   outputOverdrive: false
 })
+assert.deepEqual(model.parseAudioPolicySettings(JSON.stringify({
+  'node.features.audio.mono': true,
+  'linking.pause-playback': 'true',
+  'device.routes.default-sink-volume': 0.4,
+  'device.routes.default-source-volume': 2,
+  'unknown.setting': false
+})), {
+  valid: true,
+  values: {
+    'node.features.audio.mono': true,
+    'device.routes.default-sink-volume': 0.4
+  }
+})
+assert.deepEqual(model.parseAudioPolicySettings('not json'), { valid: false, values: {} })
 const audioPreferences = model.parseAudioPreferences(JSON.stringify({
   defaults: { output: 'headphones', input: 'headset-microphone' },
   bluetoothProfiles: { '00:11:22:33:44:55': 'a2dp-aac' }
@@ -124,6 +138,11 @@ assert.deepEqual(model.recordingInputOptions([defaultInput, headsetInput], defau
 ])
 assert.equal(model.isRecordingStream({ isStream: true, isSink: false }), true)
 assert.equal(model.isRecordingStream({ isStream: true, isSink: true }), false)
+assert.deepEqual(model.uniqueRecordingStreamLabels([
+  { ready: true, properties: { 'application.name': 'Firefox' } },
+  { ready: true, properties: { 'application.name': 'firefox' } },
+  { ready: true, properties: { 'application.name': 'Discord' } }
+]), ['Firefox', 'Discord'])
 assert.equal(model.streamIconName({ ready: true, properties: { 'application.icon_name': 'firefox' } }, [], []), 'firefox')
 assert.equal(model.streamIconName({ ready: true, properties: { 'application.icon_name': 'chromium-browser' } }, [], []), 'chromium')
 assert.equal(model.streamIconName({ ready: true, properties: { 'application.id': 'org.example.App.desktop' } }, [], []), 'org.example.App')
@@ -280,6 +299,62 @@ if AUDIO_CONTROL_PORT_LOG="$port_log" PATH="$TEST_DIR/mocks:$PATH" \
   fail "unavailable audio port accepted"
 fi
 echo "PASS: audio port controls"
+
+policy_log=$(mktemp)
+policy_state=$(mktemp)
+trap 'rm -f "$route_log" "$input_default_log" "$port_log" "$policy_log" "$policy_state"' EXIT
+printf '{}\n' >"$policy_state"
+
+policy=$(AUDIO_CONTROL_POLICY_LOG="$policy_log" AUDIO_CONTROL_POLICY_STATE="$policy_state" \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-policy-settings")
+jq -e '
+  .["node.features.audio.mono"] == false
+  and .["linking.pause-playback"] == true
+  and ((.["device.routes.default-sink-volume"] - 0.4) | fabs) < 0.000001
+  and .["node.stream.default-capture-volume"] == 1
+' <<<"$policy" >/dev/null || fail "audio policy snapshot"
+
+policy=$(AUDIO_CONTROL_POLICY_LOG="$policy_log" AUDIO_CONTROL_POLICY_STATE="$policy_state" \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-policy-settings" \
+  set node.features.audio.mono true)
+jq -e '.["node.features.audio.mono"] == true' "$policy_state" >/dev/null ||
+  fail "boolean audio policy write"
+jq -e '.["node.features.audio.mono"] == true' <<<"$policy" >/dev/null ||
+  fail "boolean audio policy confirmation"
+
+policy=$(AUDIO_CONTROL_POLICY_LOG="$policy_log" AUDIO_CONTROL_POLICY_STATE="$policy_state" \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-policy-settings" \
+  set device.routes.default-sink-volume 0.5)
+jq -e '((.["device.routes.default-sink-volume"] - 0.125) | fabs) < 0.000001' \
+  "$policy_state" >/dev/null || fail "cubic audio policy write"
+jq -e '((.["device.routes.default-sink-volume"] - 0.5) | fabs) < 0.000001' \
+  <<<"$policy" >/dev/null || fail "linear audio policy confirmation"
+
+if AUDIO_CONTROL_POLICY_LOG="$policy_log" AUDIO_CONTROL_POLICY_STATE="$policy_state" \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-policy-settings" \
+  set unknown.audio.setting true >/dev/null 2>&1; then
+  fail "unknown audio policy accepted"
+fi
+if AUDIO_CONTROL_POLICY_LOG="$policy_log" AUDIO_CONTROL_POLICY_STATE="$policy_state" \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-policy-settings" \
+  set device.routes.default-source-volume 1.5 >/dev/null 2>&1; then
+  fail "out-of-range audio policy volume accepted"
+fi
+if AUDIO_CONTROL_POLICY_LOG="$policy_log" AUDIO_CONTROL_POLICY_STATE="$policy_state" \
+  AUDIO_CONTROL_POLICY_FAIL=linking.pause-playback PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-policy-settings" set linking.pause-playback false >/dev/null 2>&1; then
+  fail "failed audio policy write reported success"
+fi
+jq -e 'has("linking.pause-playback") | not' "$policy_state" >/dev/null ||
+  fail "failed audio policy write changed state"
+
+policy=$(AUDIO_CONTROL_POLICY_LOG="$policy_log" AUDIO_CONTROL_POLICY_STATE="$policy_state" \
+  AUDIO_CONTROL_POLICY_UNSUPPORTED=monitor.alsa.autodetect-hdmi-channels \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-policy-settings")
+jq -e 'has("monitor.alsa.autodetect-hdmi-channels") | not' <<<"$policy" >/dev/null ||
+  fail "unsupported audio policy exposed"
+echo "PASS: capability-aware audio safety policies"
+rm -f -- "$policy_log" "$policy_state"
 
 bluetooth_preference_log=$(mktemp)
 bluetooth_preference_state=$(mktemp)
@@ -445,7 +520,7 @@ echo "PASS: menu integration"
 jq -e '
   .schemaVersion == 1
   and .id == "ssupt.audio-control"
-  and .version == "0.4.0"
+  and .version == "0.5.0"
   and .author == "ssupt"
   and (.kinds | index("bar-widget") != null)
   and (.kinds | index("panel") != null)

--- a/test/mocks/wpctl
+++ b/test/mocks/wpctl
@@ -14,6 +14,51 @@ if [[ -n ${AUDIO_CONTROL_INPUT_DEFAULT_LOG:-} && $* == "set-default 52" ]]; then
   exit 0
 fi
 
+if [[ -n ${AUDIO_CONTROL_POLICY_STATE:-} ]]; then
+  state_file=$AUDIO_CONTROL_POLICY_STATE
+
+  policy_default() {
+    case "$1" in
+      node.features.audio.mono) printf '%s\n' false ;;
+      linking.pause-playback) printf '%s\n' true ;;
+      device.routes.mute-on-alsa-playback-removed) printf '%s\n' false ;;
+      device.routes.mute-on-bluetooth-playback-removed) printf '%s\n' false ;;
+      monitor.alsa.autodetect-hdmi-channels) printf '%s\n' false ;;
+      device.routes.default-sink-volume) printf '%s\n' 0.064 ;;
+      device.routes.default-source-volume) printf '%s\n' 1 ;;
+      node.stream.default-playback-volume) printf '%s\n' 1 ;;
+      node.stream.default-capture-volume) printf '%s\n' 1 ;;
+      *) return 1 ;;
+    esac
+  }
+
+  if [[ $1 == settings && ${2:-} == --save ]]; then
+    setting=${3:-}
+    value=${4:-}
+    policy_default "$setting" >/dev/null || exit 1
+    [[ -n ${AUDIO_CONTROL_POLICY_LOG:-} ]] &&
+      printf 'settings --save %s %s\n' "$setting" "$value" >>"$AUDIO_CONTROL_POLICY_LOG"
+    [[ ${AUDIO_CONTROL_POLICY_FAIL:-} == 1 || ${AUDIO_CONTROL_POLICY_FAIL:-} == "$setting" ]] && exit 1
+    temporary_file="${state_file}.tmp"
+    jq --arg setting "$setting" --argjson value "$value" \
+      '.[$setting] = $value' "$state_file" >"$temporary_file"
+    mv -f -- "$temporary_file" "$state_file"
+    exit 0
+  fi
+
+  if [[ $1 == settings && $# == 2 ]]; then
+    setting=$2
+    if [[ ,${AUDIO_CONTROL_POLICY_UNSUPPORTED:-}, == *,"$setting",* ]]; then
+      exit 1
+    fi
+    fallback=$(policy_default "$setting") || exit 1
+    value=$(jq -r --arg setting "$setting" --arg fallback "$fallback" \
+      'if has($setting) then .[$setting] else ($fallback | fromjson) end' "$state_file")
+    printf 'Value: %s\n' "$value"
+    exit 0
+  fi
+fi
+
 if [[ -n ${AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_LOG:-} ]]; then
   state_file=${AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_STATE:?}
   case "$*" in


### PR DESCRIPTION
## Summary
- add a capability-aware WirePlumber Policy tab with safety toggles and starting volumes
- add a persistent recording-app badge, app-aware tooltip, and middle-click microphone mute
- expand marketplace metadata and document the new controls

## Validation
- ./test/all
- qmllint -I /usr/share/omarchy/shell *.qml
- omarchy-plugin-validate .
- live Omarchy shell smoke test