### PR TITLE
feat: add microphone privacy tools, clipping indicators, and audio test

### DIFF
--- a/AdvancedAudio.qml
+++ b/AdvancedAudio.qml
@@ -34,6 +34,11 @@ Item {
   property bool policyResponseValid: false
   property var previousPolicySettings: ({})
   property string pendingPolicyKey: ""
+  property string microphoneTestState: "idle"
+  property string microphoneTestOperation: ""
+  property bool microphoneTestCancelled: false
+  property int microphoneTestSecondsRemaining: 0
+  property string microphoneTestError: ""
   property string profileLoadError: ""
   property string portLoadError: ""
   property string profileSetError: ""
@@ -53,8 +58,13 @@ Item {
   property bool profileMenuOpen: false
   property var pendingSharedProfile: null
   property var audioPreferences: Model.parseAudioPreferences("")
-  property var audioControlSettings: ({ version: 1, outputOverdrive: false })
+  property var audioControlSettings: ({
+    version: 1,
+    outputOverdrive: false,
+    captureNotifications: true
+  })
   property bool outputOverdrive: false
+  property bool captureNotifications: true
 
   readonly property color foreground: Color.foreground
   readonly property color background: Color.background
@@ -111,6 +121,11 @@ Item {
       description: "Let WirePlumber infer HDMI channel counts. Experimental; some receivers report them incorrectly."
     }
   ]
+  readonly property var captureNotificationDefinition: ({
+    key: "captureNotifications",
+    label: "Capture-start notifications",
+    description: "Notify when a new application begins using the microphone. Respects Do Not Disturb and ignores existing captures at shell startup."
+  })
   readonly property var availablePolicyCore: supportedPolicyDefinitions(policyCoreDefinitions)
   readonly property var availablePolicyVolumes: supportedPolicyDefinitions(policyVolumeDefinitions)
   readonly property var availablePolicyExperimental: supportedPolicyDefinitions(policyExperimentalDefinitions)
@@ -130,6 +145,8 @@ Item {
     return defaultOutputDevice
   }
   readonly property var inputDevice: Pipewire.defaultAudioSource
+  readonly property bool inputDeviceMuted: !inputDevice || !inputDevice.audio
+    || inputDevice.audio.muted
   readonly property bool outputBalanceAvailable: balanceAvailable(outputDevice)
   readonly property bool inputBalanceAvailable: balanceAvailable(inputDevice)
   readonly property int audioPortStartIndex: 1
@@ -138,13 +155,23 @@ Item {
   readonly property int outputBalanceIndex: outputBalanceAvailable ? balanceStartIndex : -1
   readonly property int inputBalanceIndex: inputBalanceAvailable
     ? balanceStartIndex + (outputBalanceAvailable ? 1 : 0) : -1
+  readonly property int deviceItemCount: balanceStartIndex
+    + (outputBalanceAvailable ? 1 : 0) + (inputBalanceAvailable ? 1 : 0)
+  readonly property int microphoneTestIndex: inputDevice ? deviceItemCount : -1
   readonly property int policyVolumeStartIndex: availablePolicyCore.length
   readonly property int policyExperimentalStartIndex: policyVolumeStartIndex + availablePolicyVolumes.length
-  readonly property int policyItemCount: policyExperimentalStartIndex + availablePolicyExperimental.length
+  readonly property int wireplumberPolicyItemCount: policyExperimentalStartIndex
+    + availablePolicyExperimental.length
+  readonly property int captureNotificationIndex: wireplumberPolicyItemCount
+  readonly property int policyItemCount: wireplumberPolicyItemCount + 1
   readonly property int itemCount: activeTab === 0
-    ? balanceStartIndex + (outputBalanceAvailable ? 1 : 0) + (inputBalanceAvailable ? 1 : 0)
+    ? deviceItemCount + (inputDevice ? 1 : 0)
     : (activeTab === 1 ? 2 + bluetoothCards.length : policyItemCount)
   readonly property bool audioMutationBusy: profileSetProc.running || portSetProc.running
+    || microphoneTestProc.running || microphoneTestStopProc.running
+  readonly property real microphoneTestLevel: inputDevice && inputDevice.audio
+    && !inputDevice.audio.muted
+    ? Math.max(0, Math.min(1, Number(microphoneTestPeakMonitor.peak || 0))) : 0
   readonly property color hoverFill: Style.hoverFillFor(foreground, Color.accent)
   readonly property string settingsPath: {
     var configHome = Quickshell.env("XDG_CONFIG_HOME")
@@ -157,6 +184,9 @@ Item {
     return configHome + "/omarchy/audio-preferences.json"
   }
   onDefaultOutputDeviceChanged: resolveVolumeSink()
+  onInputDeviceChanged: if (microphoneTestState !== "idle") discardMicrophoneTest()
+  onInputDeviceMutedChanged: if (inputDeviceMuted && microphoneTestState === "recording")
+    cancelMicrophoneTest()
 
   function pluginScript(name) {
     var url = String(Qt.resolvedUrl("scripts/" + name))
@@ -176,6 +206,7 @@ Item {
     bluetoothAutoSwitchLoaded = false
     bluetoothProfilePreferenceLoaded = false
     policySettingsLoaded = false
+    discardMicrophoneTest()
     if (windowRuleReady) showOnCurrentWorkspace()
     else if (!windowRuleProc.running) windowRuleProc.running = true
   }
@@ -205,12 +236,14 @@ Item {
     openRequested = false
     closingFromHost = true
     profileMenuOpen = false
+    discardMicrophoneTest()
     window.visible = false
     closingFromHost = false
   }
 
   function requestClose() {
     openRequested = false
+    discardMicrophoneTest()
     if (shell && typeof shell.hide === "function") shell.hide("ssupt.audio-control")
     else window.visible = false
   }
@@ -261,6 +294,7 @@ Item {
   function loadAudioControlSettings(raw) {
     audioControlSettings = Model.parseAudioControlSettings(raw)
     outputOverdrive = audioControlSettings.outputOverdrive
+    captureNotifications = audioControlSettings.captureNotifications
   }
 
   function supportedPolicyDefinitions(definitions) {
@@ -334,13 +368,91 @@ Item {
   }
 
   function setOutputOverdrive(enabled) {
+    setAudioControlSetting("outputOverdrive", enabled)
+  }
+
+  function setCaptureNotifications(enabled) {
+    setAudioControlSetting("captureNotifications", enabled)
+  }
+
+  function setAudioControlSetting(key, value) {
     var next = ({})
-    for (var key in audioControlSettings) next[key] = audioControlSettings[key]
+    for (var setting in audioControlSettings) next[setting] = audioControlSettings[setting]
     next.version = 1
-    next.outputOverdrive = enabled
+    next[key] = value
     audioControlSettings = next
-    outputOverdrive = enabled
+    if (key === "outputOverdrive") outputOverdrive = value
+    else if (key === "captureNotifications") captureNotifications = value
     settingsFile.setText(JSON.stringify(next, null, 2) + "\n")
+  }
+
+  function startMicrophoneTestRecording() {
+    if (!inputDevice || !inputDevice.name || inputDeviceMuted || microphoneTestProc.running
+        || microphoneTestStopProc.running) return
+    microphoneTestError = ""
+    microphoneTestCancelled = false
+    microphoneTestOperation = "record"
+    microphoneTestState = "recording"
+    microphoneTestSecondsRemaining = 5
+    microphoneTestProc.command = [
+      pluginScript("audio-microphone-test"),
+      "record",
+      String(inputDevice.name)
+    ]
+    microphoneTestProc.running = true
+    microphoneTestCountdown.restart()
+  }
+
+  function playMicrophoneTest() {
+    if (microphoneTestState !== "ready" || microphoneTestProc.running
+        || microphoneTestStopProc.running) return
+    microphoneTestError = ""
+    microphoneTestCancelled = false
+    microphoneTestOperation = "play"
+    microphoneTestState = "playing"
+    microphoneTestProc.command = [pluginScript("audio-microphone-test"), "play"]
+    microphoneTestProc.running = true
+  }
+
+  function stopMicrophoneTestRecording() {
+    if (microphoneTestState !== "recording" || !microphoneTestProc.running
+        || microphoneTestStopProc.running) return
+    microphoneTestError = ""
+    microphoneTestState = "stopping"
+    microphoneTestCountdown.stop()
+    microphoneTestSecondsRemaining = 0
+    microphoneTestStopProc.command = [pluginScript("audio-microphone-test"), "stop"]
+    microphoneTestStopProc.running = true
+  }
+
+  function cancelMicrophoneTest() {
+    if (!microphoneTestProc.running) return
+    var operation = microphoneTestOperation
+    microphoneTestCancelled = true
+    microphoneTestProc.running = false
+    microphoneTestCountdown.stop()
+    microphoneTestSecondsRemaining = 0
+    microphoneTestState = operation === "record" ? "idle" : "ready"
+    if (operation === "record")
+      Quickshell.execDetached([pluginScript("audio-microphone-test"), "clear"])
+  }
+
+  function discardMicrophoneTest() {
+    if (microphoneTestStopProc.running) microphoneTestStopProc.running = false
+    if (microphoneTestProc.running) cancelMicrophoneTest()
+    microphoneTestCountdown.stop()
+    microphoneTestSecondsRemaining = 0
+    microphoneTestState = "idle"
+    microphoneTestError = ""
+    Quickshell.execDetached([pluginScript("audio-microphone-test"), "clear"])
+  }
+
+  function activateMicrophoneTest() {
+    if (microphoneTestState === "stopping") return
+    if (microphoneTestState === "recording") stopMicrophoneTestRecording()
+    else if (microphoneTestProc.running) cancelMicrophoneTest()
+    else if (microphoneTestState === "ready") playMicrophoneTest()
+    else startMicrophoneTestRecording()
   }
 
   function profileOptions(card) {
@@ -448,6 +560,10 @@ Item {
   function activateCursor() {
     if (!cursorActive || itemCount === 0) return
     if (activeTab === 2) {
+      if (selectedIndex === captureNotificationIndex) {
+        setCaptureNotifications(!captureNotifications)
+        return
+      }
       var policyToggle = policyToggleAtCursor()
       if (policyToggle)
         setPolicySetting(policyToggle.key, policySettings[policyToggle.key] !== true)
@@ -467,6 +583,10 @@ Item {
         && selectedIndex < deviceProfileStartIndex) {
       var portRow = audioPortRepeater.itemAt(selectedIndex - audioPortStartIndex)
       if (portRow) portRow.togglePortMenu()
+      return
+    }
+    if (activeTab === 0 && selectedIndex === microphoneTestIndex) {
+      activateMicrophoneTest()
       return
     }
     if (activeTab === 1 && selectedIndex === 0) {
@@ -565,6 +685,12 @@ Item {
 
   PwObjectTracker { objects: root.outputDevice ? [root.outputDevice] : [] }
   PwObjectTracker { objects: root.inputDevice ? [root.inputDevice] : [] }
+
+  PwNodePeakMonitor {
+    id: microphoneTestPeakMonitor
+    node: root.inputDevice
+    enabled: window.visible && root.microphoneTestState === "recording" && !!root.inputDevice
+  }
 
   Process {
     id: profilesProc
@@ -698,11 +824,53 @@ Item {
     }
   }
 
+  Process {
+    id: microphoneTestProc
+    onExited: function(exitCode) {
+      var operation = root.microphoneTestOperation
+      microphoneTestCountdown.stop()
+      root.microphoneTestSecondsRemaining = 0
+      if (root.microphoneTestCancelled) {
+        root.microphoneTestCancelled = false
+        root.microphoneTestOperation = ""
+        return
+      }
+
+      if (operation === "record") {
+        if (exitCode === 0) {
+          root.microphoneTestState = "ready"
+          root.microphoneTestError = ""
+        }
+        else {
+          root.microphoneTestState = "idle"
+          root.microphoneTestError = "Could not record the microphone test"
+          Quickshell.execDetached([root.pluginScript("audio-microphone-test"), "clear"])
+        }
+      } else if (operation === "play") {
+        root.microphoneTestState = "ready"
+        if (exitCode !== 0) root.microphoneTestError = "Could not play the microphone test"
+      }
+      root.microphoneTestOperation = ""
+    }
+  }
+
+  Process {
+    id: microphoneTestStopProc
+  }
+
   Timer {
     id: profileRefreshTimer
     interval: 200
     repeat: false
     onTriggered: if (window.visible && !profilesProc.running) profilesProc.running = true
+  }
+
+  Timer {
+    id: microphoneTestCountdown
+    interval: 1000
+    repeat: true
+    onTriggered: if (root.microphoneTestState === "recording")
+      root.microphoneTestSecondsRemaining = Math.max(0, root.microphoneTestSecondsRemaining - 1)
   }
 
   Timer {
@@ -742,8 +910,11 @@ Item {
     minimumSize: Qt.size(520, 440)
 
     onVisibleChanged: {
-      if (!visible && !root.closingFromHost && root.shell && typeof root.shell.hide === "function")
-        root.shell.hide("ssupt.audio-control")
+      if (!visible && !root.closingFromHost) {
+        root.discardMicrophoneTest()
+        if (root.shell && typeof root.shell.hide === "function")
+          root.shell.hide("ssupt.audio-control")
+      }
     }
 
     FocusScope {
@@ -1144,7 +1315,7 @@ Item {
                 }
 
                 Text {
-                  visible: root.policySettingsLoaded && root.policyItemCount === 0
+                  visible: root.policySettingsLoaded && root.wireplumberPolicyItemCount === 0
                     && root.policyError === ""
                   width: parent.width
                   text: "This WirePlumber version does not expose the supported policy controls."
@@ -1155,9 +1326,9 @@ Item {
                 }
 
                 Text {
-                  visible: root.policySettingsLoaded && root.policyItemCount > 0
+                  visible: root.policySettingsLoaded && root.wireplumberPolicyItemCount > 0
                   width: parent.width
-                  text: "Changes apply system-wide and are saved by WirePlumber. Unsupported controls are hidden automatically."
+                  text: "WirePlumber policies apply system-wide and are saved immediately. Unsupported controls are hidden automatically."
                   color: Qt.darker(root.foreground, 1.35)
                   font.family: root.fontFamily
                   font.pixelSize: Style.font.bodySmall
@@ -1285,6 +1456,39 @@ Item {
                     }
                   }
                 }
+
+                PanelSeparator {
+                  visible: root.wireplumberPolicyItemCount > 0
+                  foreground: root.foreground
+                }
+
+                Column {
+                  width: parent.width
+                  spacing: Style.space(8)
+
+                  PanelSectionHeader {
+                    text: "MICROPHONE PRIVACY"
+                    foreground: root.foreground
+                    fontFamily: root.fontFamily
+                  }
+
+                  AudioPolicyToggleRow {
+                    id: captureNotificationRow
+                    width: parent.width
+                    definition: root.captureNotificationDefinition
+                    checked: root.captureNotifications
+                    enabled: true
+                    hasCursor: root.cursorActive && root.activeTab === 2
+                      && root.selectedIndex === root.captureNotificationIndex
+                    foreground: root.foreground
+                    fill: root.hoverFill
+                    fontFamily: root.fontFamily
+                    onHasCursorChanged: if (hasCursor)
+                      root.ensureCursorVisible(captureNotificationRow)
+                    onHovered: root.setCursor(root.captureNotificationIndex)
+                    onActivated: root.setCaptureNotifications(!root.captureNotifications)
+                  }
+                }
               }
 
               Column {
@@ -1393,6 +1597,45 @@ Item {
                     node: root.inputDevice
                     label: "Input"
                     rowIndex: root.inputBalanceIndex
+                  }
+                }
+
+                PanelSeparator {
+                  visible: root.activeTab === 0 && !!root.inputDevice
+                  foreground: root.foreground
+                }
+
+                Column {
+                  visible: root.activeTab === 0 && !!root.inputDevice
+                  width: parent.width
+                  spacing: Style.space(8)
+
+                  PanelSectionHeader {
+                    text: "MICROPHONE TEST"
+                    foreground: root.foreground
+                    fontFamily: root.fontFamily
+                  }
+
+                  MicrophoneTestRow {
+                    id: microphoneTestRow
+                    width: parent.width
+                    deviceLabel: root.nodeLabel(root.inputDevice)
+                    state: root.microphoneTestState
+                    secondsRemaining: root.microphoneTestSecondsRemaining
+                    level: root.microphoneTestLevel
+                    microphoneMuted: root.inputDeviceMuted
+                    error: root.microphoneTestError
+                    enabled: !profileSetProc.running && !portSetProc.running
+                    hasCursor: root.cursorActive && root.activeTab === 0
+                      && root.selectedIndex === root.microphoneTestIndex
+                    foreground: root.foreground
+                    fill: root.hoverFill
+                    urgent: root.urgent
+                    fontFamily: root.fontFamily
+                    onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(microphoneTestRow)
+                    onHovered: root.setCursor(root.microphoneTestIndex)
+                    onPrimaryActivated: root.activateMicrophoneTest()
+                    onDiscarded: root.discardMicrophoneTest()
                   }
                 }
 

--- a/AudioBarIcon.qml
+++ b/AudioBarIcon.qml
@@ -8,6 +8,7 @@ Item {
   property string outputGlyph: ""
   property int recordingCount: 0
   property bool microphoneMuted: false
+  property bool microphoneClipping: false
   property real iconSize: Style.bar.iconFont
   property color foreground: Color.foreground
   property color urgent: Color.urgent
@@ -42,7 +43,7 @@ Item {
     Text {
       id: badgeText
       anchors.centerIn: parent
-      text: root.recordingCount > 9 ? "9+" : String(root.recordingCount)
+      text: root.microphoneClipping ? "!" : (root.recordingCount > 9 ? "9+" : String(root.recordingCount))
       color: Color.background
       font.family: root.fontFamily
       font.pixelSize: Math.max(6, Math.round(parent.height * 0.62))

--- a/MicrophoneTestRow.qml
+++ b/MicrophoneTestRow.qml
@@ -1,0 +1,133 @@
+import QtQuick
+import qs.Ui
+import qs.Commons
+
+CursorSurface {
+  id: root
+
+  required property string deviceLabel
+  required property string state
+  required property int secondsRemaining
+  required property real level
+  required property bool microphoneMuted
+  required property string error
+  property string fontFamily: Style.font.family
+  property color urgent: Color.urgent
+
+  signal primaryActivated()
+  signal discarded()
+  signal hovered()
+
+  readonly property bool running: state === "recording" || state === "stopping"
+    || state === "playing"
+  readonly property bool ready: state === "ready"
+  readonly property bool primaryEnabled: state !== "stopping"
+    && (running || ready || !microphoneMuted)
+  readonly property string description: {
+    if (error !== "") return error
+    if (state === "recording")
+      return "Recording… " + Math.max(0, secondsRemaining) + " seconds remaining."
+    if (state === "stopping") return "Finishing the partial recording…"
+    if (state === "ready") return "Private test clip ready. Play it back or discard it."
+    if (state === "playing") return "Playing the private test clip through the current output."
+    if (microphoneMuted) return "Unmute the microphone before recording a test."
+    return "Record five seconds from the current input, then choose when to play it back."
+  }
+  readonly property string primaryIcon: running ? "󰓛" : (ready ? "󰐊" : "󰑊")
+  readonly property string primaryTooltip: state === "stopping" ? "Finishing microphone test"
+    : (running ? "Stop and keep microphone test"
+    : (ready ? "Play microphone test" : "Record five-second microphone test")
+    )
+
+  implicitHeight: content.implicitHeight + Style.space(18)
+  bordered: true
+
+  Column {
+    id: content
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.verticalCenter: parent.verticalCenter
+    anchors.leftMargin: Style.space(12)
+    anchors.rightMargin: Style.space(12)
+    spacing: Style.space(7)
+
+    Row {
+      width: parent.width
+      spacing: Style.space(10)
+
+      Column {
+        width: parent.width - actions.width - parent.spacing
+        spacing: Style.space(3)
+
+        Text {
+          width: parent.width
+          text: "Microphone test · " + root.deviceLabel
+          color: root.foreground
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.body
+          font.bold: true
+          elide: Text.ElideRight
+        }
+
+        Text {
+          width: parent.width
+          text: root.description
+          color: root.error !== "" ? root.urgent : Qt.darker(root.foreground, 1.35)
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.caption
+          wrapMode: Text.WordWrap
+        }
+      }
+
+      Row {
+        id: actions
+        anchors.verticalCenter: parent.verticalCenter
+        spacing: Style.space(4)
+
+        PanelActionButton {
+          iconText: root.primaryIcon
+          tooltipText: root.primaryTooltip
+          foreground: root.foreground
+          fontFamily: root.fontFamily
+          bordered: true
+          enabled: root.enabled && root.primaryEnabled
+          hasCursor: root.hasCursor
+          onClicked: root.primaryActivated()
+        }
+
+        PanelActionButton {
+          visible: root.ready && !root.running
+          iconText: "󰆴"
+          tooltipText: "Discard microphone test"
+          foreground: root.foreground
+          hoverColor: root.urgent
+          fontFamily: root.fontFamily
+          bordered: true
+          enabled: root.enabled
+          onClicked: root.discarded()
+        }
+      }
+    }
+
+    Rectangle {
+      width: parent.width
+      height: Math.max(Style.space(5), Style.spacing.xs)
+      color: Util.alpha(root.foreground, 0.18)
+      opacity: root.microphoneMuted ? 0.35 : 1
+
+      Rectangle {
+        height: parent.height
+        width: parent.width * Math.max(0, Math.min(1, root.level))
+        color: root.level >= 0.98 ? root.urgent : root.foreground
+        Behavior on width { NumberAnimation { duration: 70 } }
+      }
+    }
+  }
+
+  MouseArea {
+    anchors.fill: parent
+    acceptedButtons: Qt.NoButton
+    hoverEnabled: true
+    onContainsMouseChanged: if (containsMouse) root.hovered()
+  }
+}

--- a/Model.js
+++ b/Model.js
@@ -100,7 +100,8 @@ function parseAudioControlSettings(raw) {
   if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) parsed = {}
   return {
     version: 1,
-    outputOverdrive: parsed.outputOverdrive === true
+    outputOverdrive: parsed.outputOverdrive === true,
+    captureNotifications: parsed.captureNotifications !== false
   }
 }
 
@@ -601,6 +602,21 @@ function uniqueRecordingStreamLabels(streams) {
   return labels
 }
 
+function addedRecordingStreamLabels(previous, current) {
+  var before = Array.isArray(previous) ? previous : []
+  var now = Array.isArray(current) ? current : []
+  var previousKeys = []
+  var additions = []
+  var i
+  for (i = 0; i < before.length; i++) previousKeys.push(streamLabelKey(before[i]))
+  for (i = 0; i < now.length; i++) {
+    var label = String(now[i] || "").trim()
+    if (label !== "" && previousKeys.indexOf(streamLabelKey(label)) === -1)
+      additions.push(label)
+  }
+  return additions
+}
+
 function normalizeStreamIconName(name) {
   var value = String(name || "").trim()
   var aliases = {
@@ -695,6 +711,7 @@ if (typeof module !== "undefined") {
     streamLabel: streamLabel,
     recordingStreamLabel: recordingStreamLabel,
     uniqueRecordingStreamLabels: uniqueRecordingStreamLabels,
+    addedRecordingStreamLabels: addedRecordingStreamLabels,
     streamIconName: streamIconName,
     streamRepresentsPlayer: streamRepresentsPlayer
   }

--- a/Panel.qml
+++ b/Panel.qml
@@ -38,6 +38,11 @@ Panel {
   }
   property var audioPreferences: Model.parseAudioPreferences("")
   property bool outputOverdrive: false
+  property bool captureNotifications: true
+  property var observedRecordingLabels: []
+  property bool recordingObservationReady: false
+  property real inputPeakHold: 0
+  property bool inputClipping: false
   readonly property real outputVolumeMaximum: outputOverdrive ? 1.5 : 1.0
 
   readonly property var candidateSinks: {
@@ -69,7 +74,9 @@ Panel {
       if (!n || !n.isStream || !isPlaybackStream(n)) continue
       // A tuning's output is a playback stream too, but it is the processing
       // itself rather than an application, so it does not belong in the list.
-      if (String(n.name || "").indexOf("omarchy_speaker_tuning") === 0) continue
+      var nodeName = String(n.name || "")
+      if (nodeName.indexOf("omarchy_speaker_tuning") === 0
+          || nodeName.indexOf("omarchy_audio_test") === 0) continue
       list.push(n)
     }
     return list
@@ -82,7 +89,8 @@ Panel {
       if (!n || !isRecordingStream(n)) continue
       // The microphone peak meter creates its own capture stream while this
       // panel is open; it is instrumentation, not a recording application.
-      if (String(n.name || "").toLowerCase() === "quickshell") continue
+      var nodeName = String(n.name || "").toLowerCase()
+      if (nodeName === "quickshell" || nodeName.indexOf("omarchy_audio_test") === 0) continue
       list.push(n)
     }
     return list
@@ -112,6 +120,27 @@ Panel {
 
   function loadAudioPreferences(raw) {
     audioPreferences = Model.parseAudioPreferences(raw)
+  }
+
+  function observeRecordingApplications() {
+    var current = listSnapshot(activeRecordingLabels)
+    var additions = Model.addedRecordingStreamLabels(observedRecordingLabels, current)
+    observedRecordingLabels = current
+    if (!captureNotifications || additions.length === 0) return
+
+    var summary = "Microphone access started"
+    var body = additions.length === 1
+      ? additions[0] + " is now using the microphone."
+      : additions.length + " applications started using the microphone: " + additions.join(", ")
+    Quickshell.execDetached([
+      "notify-send",
+      "--app-name", "Advanced Audio Control",
+      "--icon", "audio-input-microphone-symbolic",
+      "--urgency", "normal",
+      "--expire-time", "8000",
+      summary,
+      body
+    ])
   }
 
   property var cachedAudioSinks: []
@@ -154,6 +183,8 @@ Panel {
 
   readonly property var activeRecordingLabels: Model.uniqueRecordingStreamLabels(recordingStreams)
   readonly property int recordingApplicationCount: activeRecordingLabels.length
+  readonly property real inputPeakLevel: inputMuted
+    ? 0 : Math.max(0, Math.min(1, Number(inputPeakMonitor.peak || 0)))
   readonly property color urgent: bar ? bar.urgent : Color.urgent
   readonly property string recordingTooltip: {
     var microphoneAction = hasInput
@@ -168,8 +199,27 @@ Panel {
       ? "Microphone access · " + activeRecordingLabels[0]
       : "Microphone access by " + recordingApplicationCount + " apps\n"
         + activeRecordingLabels.join(", ")
-    var state = inputMuted ? "Microphone muted" : "Microphone in use"
+    var state = inputMuted ? "Microphone muted"
+      : (inputClipping ? "Microphone clipping" : "Microphone in use")
     return access + "\n" + state + (microphoneAction === "" ? "" : " · " + microphoneAction)
+  }
+  onActiveRecordingLabelsChanged: {
+    if (recordingObservationReady) recordingChangeTimer.restart()
+    else observedRecordingLabels = listSnapshot(activeRecordingLabels)
+  }
+  onInputPeakLevelChanged: {
+    if (inputPeakLevel > inputPeakHold) {
+      inputPeakHold = inputPeakLevel
+      inputPeakHoldTimer.restart()
+    }
+    if (inputPeakLevel >= 0.98) {
+      inputClipping = true
+      inputClippingTimer.restart()
+    }
+  }
+  onInputMutedChanged: if (inputMuted) {
+    inputPeakHold = 0
+    inputClipping = false
   }
 
   // Feed Repeaters with panel-local snapshots instead of the live PipeWire
@@ -672,7 +722,9 @@ Panel {
   }
 
   function loadAudioControlSettings(raw) {
-    outputOverdrive = Model.parseAudioControlSettings(raw).outputOverdrive
+    var settings = Model.parseAudioControlSettings(raw)
+    outputOverdrive = settings.outputOverdrive
+    captureNotifications = settings.captureNotifications
     enforceOutputVolumeLimit()
   }
 
@@ -849,7 +901,7 @@ Panel {
   PwNodePeakMonitor {
     id: inputPeakMonitor
     node: root.source
-    enabled: root.opened && !!root.source
+    enabled: (root.opened || root.recordingApplicationCount > 0) && !!root.source
   }
 
   FileView {
@@ -972,6 +1024,37 @@ Panel {
 
   Timer {
     interval: 1500
+    running: !root.recordingObservationReady
+    repeat: false
+    onTriggered: {
+      root.observedRecordingLabels = root.listSnapshot(root.activeRecordingLabels)
+      root.recordingObservationReady = true
+    }
+  }
+
+  Timer {
+    id: recordingChangeTimer
+    interval: 150
+    repeat: false
+    onTriggered: root.observeRecordingApplications()
+  }
+
+  Timer {
+    id: inputPeakHoldTimer
+    interval: 1200
+    repeat: false
+    onTriggered: root.inputPeakHold = 0
+  }
+
+  Timer {
+    id: inputClippingTimer
+    interval: 2500
+    repeat: false
+    onTriggered: root.inputClipping = false
+  }
+
+  Timer {
+    interval: 1500
     running: root.opened && (root.displayAudioStreams.length > 0 || root.displayRecordingStreams.length > 0)
     repeat: true
     onTriggered: if (!root.streamOutputMenuOpen && !streamRouteSetProc.running)
@@ -990,6 +1073,7 @@ Panel {
           outputGlyph: root.outputIcon()
           recordingCount: root.recordingApplicationCount
           microphoneMuted: root.inputMuted
+          microphoneClipping: root.inputClipping
           foreground: root.barForeground
           urgent: root.urgent
           fontFamily: root.bar ? root.bar.fontFamily : Style.font.family
@@ -1288,8 +1372,10 @@ Panel {
 
               Text {
                 id: microphonePercent
-                text: Math.round((inputSlider.dragging ? inputSlider.liveValue : root.inputVolume) * 100) + "%"
-                color: Qt.darker(root.bar.foreground, 1.4)
+                text: root.inputClipping
+                  ? "CLIPPING"
+                  : Math.round((inputSlider.dragging ? inputSlider.liveValue : root.inputVolume) * 100) + "%"
+                color: root.inputClipping ? root.urgent : Qt.darker(root.bar.foreground, 1.4)
                 font.family: root.bar.fontFamily
                 font.pixelSize: Style.font.caption
                 font.bold: true
@@ -1340,9 +1426,19 @@ Panel {
 
                   Rectangle {
                     height: parent.height
-                    width: parent.width * Math.max(0, Math.min(1, inputPeakMonitor.peak))
-                    color: root.bar.foreground
+                    width: parent.width * root.inputPeakLevel
+                    color: root.inputClipping ? root.urgent : root.bar.foreground
                     Behavior on width { NumberAnimation { duration: 70 } }
+                  }
+
+                  Rectangle {
+                    visible: root.inputPeakHold > 0.02
+                    width: Math.max(1, Style.space(2))
+                    height: parent.height + Style.space(4)
+                    x: Math.max(0, Math.min(parent.width - width,
+                      parent.width * root.inputPeakHold - width / 2))
+                    anchors.verticalCenter: parent.verticalCenter
+                    color: root.inputPeakHold >= 0.98 ? root.urgent : root.bar.foreground
                   }
                 }
               }

--- a/README.md
+++ b/README.md
@@ -21,6 +21,12 @@ instead of introducing a separate mixer application.
 - Set safe starting volumes for new devices and playback or recording applications.
 - Keep microphone use visible on the bar, including the recording applications and
   a persistent app-count badge even while the microphone is muted.
+- Optionally notify when a new application starts capturing, while respecting
+  Omarchy's Do Not Disturb setting and suppressing shell-startup noise.
+- Show live microphone peak hold and a latched clipping warning in the quick mixer
+  and recording badge.
+- Record a private five-second microphone test, then explicitly play it back or
+  discard it; the temporary clip is removed when the Audio window closes.
 
 The bar audio icon uses left-click for the quick mixer, middle-click to mute or
 unmute the microphone, right-click to mute or unmute all audio, and the wheel to
@@ -37,7 +43,9 @@ More plugins by `ssupt`: [omarchy-plugins](https://github.com/ssupt/omarchy-plug
 ## Requirements
 
 - Omarchy Quattro
-- PipeWire with WirePlumber (`pactl`, `wpctl`, and `pw-metadata`)
+- PipeWire with WirePlumber (`pactl`, `wpctl`, `pw-metadata`, `pw-record`, and
+  `pw-play`)
+- `notify-send` for optional capture-start notifications
 - `jq`, `hyprctl`, `timeout`, and `flock`
 
 These commands are present in a standard Omarchy installation. The plugin does
@@ -53,6 +61,13 @@ The Policy tab discovers settings from the installed WirePlumber version, so it
 only shows controls the system supports. Changes use WirePlumber's persistent
 settings API. Starting-volume percentages are converted to its cubic storage
 scale before they are saved, keeping the displayed values perceptually accurate.
+
+Capture-start notifications can be disabled under **Policy > Microphone privacy**.
+Normal notification urgency lets Omarchy's notification service honor Do Not
+Disturb. The microphone test records only after an explicit action, stores its
+clip with private permissions in the user's runtime directory, never plays it
+automatically, and deletes it on discard or when the Audio window closes. Stopping
+before five seconds keeps the audio recorded so far and makes it ready to play.
 
 ## Installation
 

--- a/manifest.json
+++ b/manifest.json
@@ -2,9 +2,9 @@
   "schemaVersion": 1,
   "id": "ssupt.audio-control",
   "name": "Advanced Audio Control",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "author": "ssupt",
-  "description": "Advanced PipeWire and WirePlumber audio mixer for Omarchy: persistent per-application speaker/output and microphone/input routing; app volume, mute, icons, and live playback/recording meters; default device selection; ports and profiles; Bluetooth codecs, headset autoswitch, and quality/latency preference; 150% volume boost; stereo balance; mono audio; pause or mute protection when wired/Bluetooth devices disconnect; starting volumes for new devices and apps; HDMI channel detection; and a persistent microphone privacy/recording badge with app names and quick mute",
+  "description": "Advanced PipeWire and WirePlumber audio mixer for Omarchy: persistent per-application speaker/output and microphone/input routing; app volume, mute, icons, and live playback/recording meters; default device selection; ports and profiles; Bluetooth codecs, headset autoswitch, and quality/latency preference; 150% volume boost; stereo balance; mono audio; pause or mute protection when wired/Bluetooth devices disconnect; starting volumes for new devices and apps; HDMI channel detection; and persistent microphone privacy with a recording badge, app names and count, quick mute, Do Not Disturb-aware capture-start notifications, peak hold and clipping warnings, plus a private five-second record/playback test",
   "kinds": [
     "bar-widget",
     "panel"
@@ -15,7 +15,7 @@
   },
   "barWidget": {
     "displayName": "Advanced Audio Control",
-    "description": "Advanced PipeWire and WirePlumber audio mixer for Omarchy: persistent per-application speaker/output and microphone/input routing; app volume, mute, icons, and live playback/recording meters; default device selection; ports and profiles; Bluetooth codecs, headset autoswitch, and quality/latency preference; 150% volume boost; stereo balance; mono audio; pause or mute protection when wired/Bluetooth devices disconnect; starting volumes for new devices and apps; HDMI channel detection; and a persistent microphone privacy/recording badge with app names and quick mute",
+    "description": "Advanced PipeWire and WirePlumber audio mixer for Omarchy: persistent per-application speaker/output and microphone/input routing; app volume, mute, icons, and live playback/recording meters; default device selection; ports and profiles; Bluetooth codecs, headset autoswitch, and quality/latency preference; 150% volume boost; stereo balance; mono audio; pause or mute protection when wired/Bluetooth devices disconnect; starting volumes for new devices and apps; HDMI channel detection; and persistent microphone privacy with a recording badge, app names and count, quick mute, Do Not Disturb-aware capture-start notifications, peak hold and clipping warnings, plus a private five-second record/playback test",
     "category": "Audio",
     "allowMultiple": false
   },

--- a/scripts/audio-microphone-test
+++ b/scripts/audio-microphone-test
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+# omarchy:summary=Record, stop, play, or clear the private microphone test clip
+# omarchy:group=audio
+# omarchy:args=[status | record <source-name> | stop | play | clear]
+
+set -euo pipefail
+
+runtime_root=${XDG_RUNTIME_DIR:-/run/user/$UID}/omarchy/audio-control
+test_file=${AUDIO_CONTROL_MICROPHONE_TEST_FILE:-$runtime_root/microphone-test.raw}
+record_pid_file=${AUDIO_CONTROL_MICROPHONE_TEST_PID_FILE:-$test_file.pid}
+stop_request_file=${AUDIO_CONTROL_MICROPHONE_TEST_STOP_FILE:-$test_file.stop}
+action=${1:-status}
+sample_rate=48000
+channel_count=1
+sample_bytes=2
+maximum_samples=240000
+maximum_bytes=$((maximum_samples * channel_count * sample_bytes))
+
+usage() {
+  echo "Usage: audio-microphone-test [status | record <source-name> | stop | play | clear]" >&2
+  exit 1
+}
+
+recording_size() {
+  local path=$1
+  [[ -f $path && ! -L $path ]] || {
+    printf '%s\n' 0
+    return
+  }
+  stat -c '%s' "$path" 2>/dev/null || printf '%s\n' 0
+}
+
+case "$action" in
+  status)
+    (( $# == 0 || $# == 1 )) || usage
+    [[ -s $test_file && ! -L $test_file ]] && printf '%s\n' ready || printf '%s\n' empty
+    ;;
+  record)
+    (( $# == 2 )) || usage
+    source_name=$2
+    [[ -n $source_name ]] || usage
+    command -v pw-record >/dev/null
+
+    test_dir=$(dirname -- "$test_file")
+    umask 077
+    if [[ ! -d $test_dir ]]; then
+      mkdir -p -- "$test_dir"
+      chmod 700 "$test_dir"
+    fi
+    temporary_file=$(mktemp "$test_dir/.microphone-test.XXXXXX.raw")
+    record_pid=""
+    rm -f -- "$record_pid_file" "$stop_request_file"
+
+    cleanup_recording() {
+      local status=$1
+      trap - EXIT INT TERM HUP
+      if [[ -n $record_pid ]]; then
+        kill -KILL "$record_pid" 2>/dev/null || true
+        wait "$record_pid" 2>/dev/null || true
+      fi
+      rm -f -- "$temporary_file" "$record_pid_file" "$stop_request_file"
+      exit "$status"
+    }
+    trap 'cleanup_recording $?' EXIT
+    trap 'cleanup_recording 130' INT
+    trap 'cleanup_recording 143' TERM HUP
+
+    pw-record \
+      --target "$source_name" \
+      --media-category Capture \
+      --media-role Communication \
+      --properties '{"node.name":"omarchy_audio_test_record","application.name":"Advanced Audio Control","media.name":"Microphone test"}' \
+      --rate "$sample_rate" \
+      --channels "$channel_count" \
+      --format s16 \
+      --raw \
+      --sample-count "$maximum_samples" \
+      "$temporary_file" &
+    record_pid=$!
+    printf '%s\n' "$record_pid" >"$record_pid_file"
+    record_status=0
+    wait "$record_pid" 2>/dev/null || record_status=$?
+    record_pid=""
+    rm -f -- "$record_pid_file"
+
+    size=$(recording_size "$temporary_file")
+    stopped_early=false
+    [[ -f $stop_request_file && ! -L $stop_request_file ]] && stopped_early=true
+    if (( size < sample_bytes )) || { ! $stopped_early && (( size < maximum_bytes )); }; then
+      exit "$((record_status == 0 ? 1 : record_status))"
+    fi
+
+    # A hard stop can land between 16-bit samples. Drop that incomplete byte so
+    # pw-play never receives a malformed final frame.
+    aligned_size=$((size - size % sample_bytes))
+    (( aligned_size == size )) || truncate -s "$aligned_size" "$temporary_file"
+    mv -f -- "$temporary_file" "$test_file"
+    rm -f -- "$stop_request_file"
+    trap - EXIT INT TERM HUP
+    printf '%s\n' ready
+    ;;
+  stop)
+    (( $# == 1 )) || usage
+    test_dir=$(dirname -- "$test_file")
+    [[ -d $test_dir ]] || exit 1
+    umask 077
+    : >"$stop_request_file"
+
+    record_pid=""
+    for _attempt in {1..20}; do
+      if [[ -s $record_pid_file && ! -L $record_pid_file ]]; then
+        read -r record_pid <"$record_pid_file" || true
+        [[ $record_pid =~ ^[1-9][0-9]*$ ]] && break
+      fi
+      sleep 0.025
+    done
+    if [[ ! $record_pid =~ ^[1-9][0-9]*$ ]] || ! kill -0 "$record_pid" 2>/dev/null; then
+      rm -f -- "$stop_request_file"
+      exit 1
+    fi
+
+    # Raw PCM needs no container finalization, so an intentional hard stop is
+    # safe and deterministic even on pw-record builds that ignore TERM/INT.
+    kill -KILL "$record_pid" 2>/dev/null || true
+    ;;
+  play)
+    (( $# == 1 )) || usage
+    [[ -s $test_file && ! -L $test_file ]] || {
+      echo "No microphone test recording is ready" >&2
+      exit 1
+    }
+    command -v pw-play >/dev/null
+    exec pw-play \
+      --media-role Communication \
+      --properties '{"node.name":"omarchy_audio_test_playback","application.name":"Advanced Audio Control","media.name":"Microphone test playback"}' \
+      --volume 0.8 \
+      --rate "$sample_rate" \
+      --channels "$channel_count" \
+      --format s16 \
+      --raw \
+      "$test_file"
+    ;;
+  clear)
+    (( $# == 1 )) || usage
+    rm -f -- "$test_file" "$record_pid_file" "$stop_request_file"
+    ;;
+  *) usage ;;
+esac

--- a/test/all
+++ b/test/all
@@ -32,12 +32,15 @@ const cards = model.parseAudioProfiles(JSON.stringify([{
 
 assert.deepEqual(model.parseAudioControlSettings('{"outputOverdrive":true}'), {
   version: 1,
-  outputOverdrive: true
+  outputOverdrive: true,
+  captureNotifications: true
 })
 assert.deepEqual(model.parseAudioControlSettings('not json'), {
   version: 1,
-  outputOverdrive: false
+  outputOverdrive: false,
+  captureNotifications: true
 })
+assert.equal(model.parseAudioControlSettings('{"captureNotifications":false}').captureNotifications, false)
 assert.deepEqual(model.parseAudioPolicySettings(JSON.stringify({
   'node.features.audio.mono': true,
   'linking.pause-playback': 'true',
@@ -143,6 +146,8 @@ assert.deepEqual(model.uniqueRecordingStreamLabels([
   { ready: true, properties: { 'application.name': 'firefox' } },
   { ready: true, properties: { 'application.name': 'Discord' } }
 ]), ['Firefox', 'Discord'])
+assert.deepEqual(model.addedRecordingStreamLabels(
+  ['Firefox', 'OBS'], ['firefox', 'Discord', 'OBS Studio']), ['Discord', 'OBS Studio'])
 assert.equal(model.streamIconName({ ready: true, properties: { 'application.icon_name': 'firefox' } }, [], []), 'firefox')
 assert.equal(model.streamIconName({ ready: true, properties: { 'application.icon_name': 'chromium-browser' } }, [], []), 'chromium')
 assert.equal(model.streamIconName({ ready: true, properties: { 'application.id': 'org.example.App.desktop' } }, [], []), 'org.example.App')
@@ -356,6 +361,104 @@ jq -e 'has("monitor.alsa.autodetect-hdmi-channels") | not' <<<"$policy" >/dev/nu
 echo "PASS: capability-aware audio safety policies"
 rm -f -- "$policy_log" "$policy_state"
 
+microphone_test_dir=$(mktemp -d)
+microphone_test_log="$microphone_test_dir/commands.log"
+microphone_test_file="$microphone_test_dir/microphone-test.raw"
+trap 'rm -f "$route_log" "$input_default_log" "$port_log"; rm -rf "$microphone_test_dir"' EXIT
+
+microphone_test_status=$(AUDIO_CONTROL_MICROPHONE_TEST_FILE="$microphone_test_file" \
+  "$ROOT/scripts/audio-microphone-test" status)
+[[ $microphone_test_status == empty ]] || fail "empty microphone test status"
+
+microphone_test_status=$(AUDIO_CONTROL_MICROPHONE_TEST_FILE="$microphone_test_file" \
+  AUDIO_CONTROL_MICROPHONE_TEST_LOG="$microphone_test_log" \
+  AUDIO_CONTROL_MICROPHONE_TEST_RECORD_STATUS=1 PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-microphone-test" record test-source)
+[[ $microphone_test_status == ready && -s $microphone_test_file ]] ||
+  fail "microphone test recording"
+[[ $(stat -c '%a' "$microphone_test_file") == 600 ]] ||
+  fail "microphone test recording permissions"
+grep -q -- '--target test-source' "$microphone_test_log" ||
+  fail "microphone test selected source"
+grep -q -- 'node.name.*omarchy_audio_test_record' "$microphone_test_log" ||
+  fail "microphone test private stream identity"
+
+AUDIO_CONTROL_MICROPHONE_TEST_FILE="$microphone_test_file" \
+  AUDIO_CONTROL_MICROPHONE_TEST_LOG="$microphone_test_log" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-microphone-test" play
+grep -q '^pw-play .*--volume 0.8 ' "$microphone_test_log" ||
+  fail "microphone test playback"
+grep -q '^pw-play .*--raw ' "$microphone_test_log" ||
+  fail "microphone test raw playback format"
+
+AUDIO_CONTROL_MICROPHONE_TEST_FILE="$microphone_test_file" \
+  "$ROOT/scripts/audio-microphone-test" clear
+[[ ! -e $microphone_test_file ]] || fail "microphone test cleanup"
+
+if AUDIO_CONTROL_MICROPHONE_TEST_FILE="$microphone_test_file" \
+  AUDIO_CONTROL_MICROPHONE_TEST_LOG="$microphone_test_log" \
+  AUDIO_CONTROL_MICROPHONE_TEST_RECORD_FAIL=1 PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-microphone-test" record test-source >/dev/null 2>&1; then
+  fail "failed microphone test recording reported success"
+fi
+[[ ! -e $microphone_test_file ]] || fail "failed microphone test left a recording"
+
+: >"$microphone_test_log"
+microphone_test_output="$microphone_test_dir/record-output"
+AUDIO_CONTROL_MICROPHONE_TEST_FILE="$microphone_test_file" \
+  AUDIO_CONTROL_MICROPHONE_TEST_LOG="$microphone_test_log" \
+  AUDIO_CONTROL_MICROPHONE_TEST_RECORD_WAIT=1 PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-microphone-test" record test-source >"$microphone_test_output" &
+microphone_test_pid=$!
+for _attempt in {1..100}; do
+  [[ -s $microphone_test_file.pid ]] && break
+  kill -0 "$microphone_test_pid" 2>/dev/null || fail "microphone test stopped before early stop"
+  sleep 0.01
+done
+[[ -s $microphone_test_file.pid ]] || fail "microphone test early-stop setup"
+AUDIO_CONTROL_MICROPHONE_TEST_FILE="$microphone_test_file" \
+  "$ROOT/scripts/audio-microphone-test" stop
+microphone_test_exit=0
+wait "$microphone_test_pid" || microphone_test_exit=$?
+[[ $microphone_test_exit == 0 && $(<"$microphone_test_output") == ready ]] ||
+  fail "microphone test early-stop completion"
+[[ $(stat -c '%s' "$microphone_test_file") == 96000 ]] ||
+  fail "microphone test early-stop partial clip"
+[[ ! -e $microphone_test_file.pid && ! -e $microphone_test_file.stop ]] ||
+  fail "microphone test early-stop control cleanup"
+
+AUDIO_CONTROL_MICROPHONE_TEST_FILE="$microphone_test_file" \
+  AUDIO_CONTROL_MICROPHONE_TEST_LOG="$microphone_test_log" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-microphone-test" play
+grep -q '^pw-play .*--raw ' "$microphone_test_log" ||
+  fail "partial microphone test playback"
+AUDIO_CONTROL_MICROPHONE_TEST_FILE="$microphone_test_file" \
+  "$ROOT/scripts/audio-microphone-test" clear
+
+: >"$microphone_test_log"
+AUDIO_CONTROL_MICROPHONE_TEST_FILE="$microphone_test_file" \
+  AUDIO_CONTROL_MICROPHONE_TEST_LOG="$microphone_test_log" \
+  AUDIO_CONTROL_MICROPHONE_TEST_RECORD_WAIT=1 PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-microphone-test" record test-source >/dev/null &
+microphone_test_pid=$!
+for _attempt in {1..100}; do
+  [[ -s $microphone_test_file.pid ]] && break
+  kill -0 "$microphone_test_pid" 2>/dev/null || fail "microphone test stopped before cancellation"
+  sleep 0.01
+done
+[[ -s $microphone_test_file.pid ]] || fail "microphone test cancellation setup"
+kill -TERM "$microphone_test_pid"
+microphone_test_exit=0
+wait "$microphone_test_pid" || microphone_test_exit=$?
+[[ $microphone_test_exit == 143 ]] || fail "microphone test cancellation status"
+[[ ! -e $microphone_test_file ]] || fail "cancelled microphone test left a recording"
+[[ ! -e $microphone_test_file.pid && ! -e $microphone_test_file.stop ]] ||
+  fail "cancelled microphone test left a control file"
+[[ -z $(find "$microphone_test_dir" -type f -name '.microphone-test.*.raw' -print -quit) ]] ||
+  fail "cancelled microphone test left a temporary file"
+echo "PASS: private microphone record and playback test"
+rm -rf -- "$microphone_test_dir"
+
 bluetooth_preference_log=$(mktemp)
 bluetooth_preference_state=$(mktemp)
 trap 'rm -f "$route_log" "$input_default_log" "$port_log" "$bluetooth_preference_log" "$bluetooth_preference_state"' EXIT
@@ -520,7 +623,7 @@ echo "PASS: menu integration"
 jq -e '
   .schemaVersion == 1
   and .id == "ssupt.audio-control"
-  and .version == "0.5.0"
+  and .version == "0.5.1"
   and .author == "ssupt"
   and (.kinds | index("bar-widget") != null)
   and (.kinds | index("panel") != null)

--- a/test/mocks/pw-play
+++ b/test/mocks/pw-play
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+[[ -n ${AUDIO_CONTROL_MICROPHONE_TEST_LOG:-} ]] &&
+  printf 'pw-play %s\n' "$*" >>"$AUDIO_CONTROL_MICROPHONE_TEST_LOG"
+[[ ${AUDIO_CONTROL_MICROPHONE_TEST_PLAY_FAIL:-0} == 1 ]] && exit 1
+exit 0

--- a/test/mocks/pw-record
+++ b/test/mocks/pw-record
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+[[ -n ${AUDIO_CONTROL_MICROPHONE_TEST_LOG:-} ]] &&
+  printf 'pw-record %s\n' "$*" >>"$AUDIO_CONTROL_MICROPHONE_TEST_LOG"
+[[ ${AUDIO_CONTROL_MICROPHONE_TEST_RECORD_FAIL:-0} == 1 ]] && exit 1
+if [[ ${AUDIO_CONTROL_MICROPHONE_TEST_RECORD_WAIT:-0} == 1 ]]; then
+  truncate -s 96000 "${!#}"
+  while true; do sleep 0.05; done
+fi
+truncate -s "${AUDIO_CONTROL_MICROPHONE_TEST_RECORD_BYTES:-480000}" "${!#}"
+exit "${AUDIO_CONTROL_MICROPHONE_TEST_RECORD_STATUS:-0}"


### PR DESCRIPTION
- Add capture-start notifications respecting Do Not Disturb
- Add peak hold and clipping warning indicators to mixer and bar icon
- Add private 5-second microphone test with record/playback/discard controls
- Include audio-microphone-test helper script and unit tests