### PR TITLE
Refactor audio controllers and add native diagnostics

### DIFF
--- a/AdvancedAudio.qml
+++ b/AdvancedAudio.qml
@@ -29,11 +29,19 @@ Item {
       if (!success) root.showSceneStatus(rulesStore.error, true)
     }
   }
+  AudioDiagnosticsController {
+    id: diagnostics
+    diagnosticsPath: runtime.script("audio-diagnostics")
+    speakerTestPath: runtime.script("audio-speaker-test")
+    recoveryPath: runtime.script("audio-recovery")
+    sessionActive: window.visible && root.activeTab === 5
+  }
 
   property var shell: null
   property bool closingFromHost: false
   property bool openRequested: false
   property bool windowRuleReady: false
+  property bool recoveryConfirmOpen: false
   readonly property bool opened: window.visible
 
   property var audioCards: []
@@ -70,7 +78,9 @@ Item {
     for (var i = 0; i < errors.length; i++) if (errors[i] !== "") return errors[i]
     return ""
   }
-  property int activeTab: 0  // 0 = devices, 1 = Bluetooth, 2 = policy, 3 = scenes, 4 = routing
+  // 0 = devices, 1 = Bluetooth, 2 = policy, 3 = scenes, 4 = routing,
+  // 5 = diagnostics
+  property int activeTab: 0
   property bool cursorActive: false
   property int selectedIndex: 0
   property bool profileMenuOpen: false
@@ -131,13 +141,15 @@ Item {
     + availablePolicyExperimental.length
   readonly property int captureNotificationIndex: wireplumberPolicyItemCount
   readonly property int policyItemCount: wireplumberPolicyItemCount + 1
-  readonly property int itemCount: activeTab === 4
-    ? 2 + audioRules.appRules.length + managedDevices.length
-    : (activeTab === 3
-      ? 1 + audioScenes.length
-      : (activeTab === 0
-        ? deviceItemCount + (inputDevice ? 1 : 0)
-        : (activeTab === 1 ? 2 + bluetoothCards.length : policyItemCount)))
+  readonly property int itemCount: activeTab === 5
+    ? diagnosticsView.itemCount
+    : (activeTab === 4
+      ? 2 + audioRules.appRules.length + managedDevices.length
+      : (activeTab === 3
+        ? 1 + audioScenes.length
+        : (activeTab === 0
+          ? deviceItemCount + (inputDevice ? 1 : 0)
+          : (activeTab === 1 ? 2 + bluetoothCards.length : policyItemCount))))
   readonly property bool audioMutationBusy: profileSetProc.running || portSetProc.running
     || microphoneTest.busy
   readonly property color hoverFill: Style.hoverFillFor(foreground, Color.accent)
@@ -149,7 +161,8 @@ Item {
     activeTab = payload.tab === "bluetooth" ? 1
       : payload.tab === "policy" ? 2
       : payload.tab === "scenes" ? 3
-      : payload.tab === "routing" ? 4 : 0
+      : payload.tab === "routing" ? 4
+      : payload.tab === "diagnostics" ? 5 : 0
     openRequested = true
     closingFromHost = false
     cursorActive = false
@@ -158,6 +171,7 @@ Item {
     profilesLoaded = false
     bluetoothAutoSwitchLoaded = false
     bluetoothProfilePreferenceLoaded = false
+    recoveryConfirmOpen = false
     microphoneTest.discard()
     cancelAliasEdit()
     if (windowRuleReady) showOnCurrentWorkspace()
@@ -189,6 +203,7 @@ Item {
     openRequested = false
     closingFromHost = true
     profileMenuOpen = false
+    recoveryConfirmOpen = false
     microphoneTest.discard()
     window.visible = false
     closingFromHost = false
@@ -196,6 +211,7 @@ Item {
 
   function requestClose() {
     openRequested = false
+    recoveryConfirmOpen = false
     microphoneTest.discard()
     if (shell && typeof shell.hide === "function") shell.hide("ssupt.audio-control")
     else window.visible = false
@@ -370,7 +386,7 @@ Item {
   }
 
   function selectTab(index) {
-    var next = Math.max(0, Math.min(4, index))
+    var next = Math.max(0, Math.min(5, index))
     if (next === activeTab) return
     closeProfileMenus()
     cancelAliasEdit()
@@ -382,7 +398,7 @@ Item {
   }
 
   function switchTab(direction) {
-    selectTab((activeTab + (direction < 0 ? -1 : 1) + 5) % 5)
+    selectTab((activeTab + (direction < 0 ? -1 : 1) + 6) % 6)
   }
 
   function setCursor(index) {
@@ -394,6 +410,10 @@ Item {
 
   function activateCursor() {
     if (!cursorActive || itemCount === 0) return
+    if (activeTab === 5) {
+      diagnosticsView.activate(selectedIndex)
+      return
+    }
     if (activeTab === 4) {
       if (selectedIndex === 0) newRuleAppRow.toggleAppMenu()
       else if (selectedIndex === 1) newRuleDeviceRow.toggleDeviceMenu()
@@ -453,6 +473,23 @@ Item {
       ? deviceProfileRepeater.itemAt(selectedIndex - deviceProfileStartIndex)
       : bluetoothProfileRepeater.itemAt(selectedIndex - 2)
     if (row) row.toggleProfileMenu()
+  }
+
+  function requestRecovery() {
+    if (!diagnostics.snapshot.capabilities.recovery) return
+    recoveryConfirm.selectedIndex = 1
+    recoveryConfirmOpen = true
+  }
+
+  function cancelRecovery() {
+    recoveryConfirmOpen = false
+    Qt.callLater(function() { keyCatcher.forceActiveFocus() })
+  }
+
+  function confirmRecovery() {
+    recoveryConfirmOpen = false
+    diagnostics.runRecovery()
+    Qt.callLater(function() { keyCatcher.forceActiveFocus() })
   }
 
   // Mouse hovering claims the cursor without scrolling: the wheel and the
@@ -855,7 +892,7 @@ Item {
     color: root.background
     implicitWidth: 680
     implicitHeight: 560
-    minimumSize: Qt.size(520, 440)
+    minimumSize: Qt.size(640, 440)
 
     onVisibleChanged: {
       if (!visible && !root.closingFromHost) {
@@ -873,6 +910,10 @@ Item {
         anchors.fill: parent
         blocked: root.profileMenuOpen || root.aliasEditingDevice !== ""
           onMoveRequested: function(dx, dy) {
+            if (root.recoveryConfirmOpen) {
+              if (dx !== 0) recoveryConfirm.selectedIndex = recoveryConfirm.selectedIndex === 0 ? 1 : 0
+              return
+            }
             root.keyboardScrolling = true
             if (dx !== 0) {
               root.cursorActive = true
@@ -885,11 +926,23 @@ Item {
           if (dy !== 0) root.moveCursor(dy)
         }
         onTabRequested: function(direction) {
+          if (root.recoveryConfirmOpen) {
+            recoveryConfirm.selectedIndex = recoveryConfirm.selectedIndex === 0 ? 1 : 0
+            return
+          }
           root.keyboardScrolling = true
           root.switchTab(direction)
         }
-        onActivateRequested: root.activateCursor()
-        onCloseRequested: root.requestClose()
+        onActivateRequested: {
+          if (root.recoveryConfirmOpen) {
+            if (recoveryConfirm.selectedIndex === 0) root.cancelRecovery()
+            else root.confirmRecovery()
+          } else root.activateCursor()
+        }
+        onCloseRequested: {
+          if (root.recoveryConfirmOpen) root.cancelRecovery()
+          else root.requestClose()
+        }
 
         Column {
           id: frame
@@ -928,7 +981,7 @@ Item {
 
                 Text {
                   width: parent.width
-                  text: "Configure devices, Bluetooth behavior, and system-wide audio safety."
+                  text: "Configure devices, automation, safety, and live audio diagnostics."
                   color: Qt.darker(root.foreground, 1.35)
                   font.family: root.fontFamily
                   font.pixelSize: Style.font.bodySmall
@@ -945,12 +998,14 @@ Item {
                 { value: "bluetooth", label: "Bluetooth", icon: "󰂯" },
                 { value: "policy", label: "Policy", icon: "󰒃" },
                 { value: "scenes", label: "Scenes", icon: "󰌨" },
-                { value: "routing", label: "Routing", icon: "󰘮" }
+                { value: "routing", label: "Routing", icon: "󰘮" },
+                { value: "diagnostics", label: "Diagnostics", icon: "󰒓" }
               ]
               value: root.activeTab === 0 ? "devices"
                 : root.activeTab === 1 ? "bluetooth"
                 : root.activeTab === 2 ? "policy"
-                : root.activeTab === 3 ? "scenes" : "routing"
+                : root.activeTab === 3 ? "scenes"
+                : root.activeTab === 4 ? "routing" : "diagnostics"
               focusable: false
               foreground: root.foreground
               background: root.background
@@ -959,7 +1014,8 @@ Item {
                 root.selectTab(value === "bluetooth" ? 1
                   : value === "policy" ? 2
                   : value === "scenes" ? 3
-                  : value === "routing" ? 4 : 0)
+                  : value === "routing" ? 4
+                  : value === "diagnostics" ? 5 : 0)
               }
             }
           }
@@ -1822,6 +1878,23 @@ Item {
                 }
               }
 
+              AudioDiagnosticsView {
+                id: diagnosticsView
+                visible: root.activeTab === 5
+                width: parent.width
+                controller: diagnostics
+                tabActive: root.activeTab === 5
+                cursorActive: root.cursorActive
+                selectedIndex: root.selectedIndex
+                foreground: root.foreground
+                urgent: root.urgent
+                fill: root.hoverFill
+                fontFamily: root.fontFamily
+                onCursorRequested: function(index) { root.setCursor(index) }
+                onEnsureVisible: function(item) { root.ensureCursorVisible(item) }
+                onRecoveryRequested: root.requestRecovery()
+              }
+
               Column {
                 width: parent.width
                 spacing: Style.space(12)
@@ -2040,6 +2113,22 @@ Item {
               }
             }
           }
+        }
+
+        ConfirmDialog {
+          id: recoveryConfirm
+          anchors.fill: parent
+          opened: root.recoveryConfirmOpen
+          z: 20
+          message: "Restart PipeWire and WirePlumber with Omarchy audio recovery? Playback and recording will be interrupted, and a stuck USB device may require authorization to reset."
+          confirmText: "Restart audio"
+          background: root.background
+          foreground: root.foreground
+          selectedText: Color.accent
+          fontFamily: root.fontFamily
+          cornerRadius: Style.cornerRadius
+          onCanceled: root.cancelRecovery()
+          onConfirmed: root.confirmRecovery()
         }
       }
     }

--- a/AdvancedAudio.qml
+++ b/AdvancedAudio.qml
@@ -13,6 +13,23 @@ import "Model.js" as Model
 Item {
   id: root
 
+  AudioRuntime { id: runtime }
+  AudioPolicyController {
+    id: policy
+    scriptPath: runtime.script("audio-policy-settings")
+    onSettled: root.clampCursor()
+  }
+  AudioRulesController {
+    id: rulesStore
+    nodes: root.pipewireNodes
+    rulesPath: runtime.rulesPath
+    scriptPath: runtime.script("audio-app-rules")
+    onRulesChanged: root.clampCursor()
+    onWriteFinished: function(success) {
+      if (!success) root.showSceneStatus(rulesStore.error, true)
+    }
+  }
+
   property var shell: null
   property bool closingFromHost: false
   property bool openRequested: false
@@ -28,25 +45,12 @@ Item {
   property string bluetoothProfilePreference: "quality"
   property bool bluetoothProfilePreferenceLoaded: false
   property bool bluetoothProfilePreferenceMutation: false
-  property var policySettings: ({})
-  property bool policySettingsLoaded: false
-  property bool policyMutation: false
-  property bool policyResponseValid: false
-  property var previousPolicySettings: ({})
-  property string pendingPolicyKey: ""
-  property string microphoneTestState: "idle"
-  property string microphoneTestOperation: ""
-  property bool microphoneTestCancelled: false
-  property int microphoneTestSecondsRemaining: 0
-  property string microphoneTestError: ""
   property var audioScenes: []
   property bool scenesLoaded: false
-  property var audioRules: Model.parseAudioRules("")
+  readonly property var audioRules: rulesStore.rules
   property string newRuleApp: ""
-  property string newRuleDevice: ""
   property string aliasEditingDevice: ""
-  property bool routingMutation: false
-  property string routingError: ""
+  readonly property bool routingMutation: rulesStore.busy
   property var pendingSceneSave: null
   property string sceneStatus: ""
   property bool sceneStatusIsError: false
@@ -56,7 +60,10 @@ Item {
   property string portSetError: ""
   property string bluetoothAutoswitchError: ""
   property string bluetoothPreferenceError: ""
-  property string policyError: ""
+  readonly property var policySettings: policy.settings
+  readonly property bool policySettingsLoaded: policy.loaded
+  readonly property string pendingPolicyKey: policy.pendingKey
+  readonly property string policyError: policy.error
   readonly property string error: {
     var errors = [profileSetError, portSetError, bluetoothAutoswitchError,
       bluetoothPreferenceError, policyError, profileLoadError, portLoadError]
@@ -81,65 +88,14 @@ Item {
   readonly property color background: Color.background
   readonly property color urgent: Color.urgent
   readonly property string fontFamily: Style.font.family
-  readonly property var policyCoreDefinitions: [
-    {
-      key: "node.features.audio.mono",
-      label: "Mono audio",
-      description: "Mix left and right output channels so every sound is audible from either speaker."
-    },
-    {
-      key: "linking.pause-playback",
-      label: "Pause on output loss",
-      description: "Pause compatible media players when their active output device disappears."
-    },
-    {
-      key: "device.routes.mute-on-alsa-playback-removed",
-      label: "Mute after wired disconnect",
-      description: "Keep playback muted instead of unexpectedly moving it to another output."
-    },
-    {
-      key: "device.routes.mute-on-bluetooth-playback-removed",
-      label: "Mute after Bluetooth disconnect",
-      description: "Prevent private audio from jumping to speakers when Bluetooth drops."
-    }
-  ]
-  readonly property var policyVolumeDefinitions: [
-    {
-      key: "device.routes.default-sink-volume",
-      label: "New output devices",
-      description: "Starting level before WirePlumber has remembered a volume for the device."
-    },
-    {
-      key: "device.routes.default-source-volume",
-      label: "New input devices",
-      description: "Starting level before WirePlumber has remembered a volume for the microphone."
-    },
-    {
-      key: "node.stream.default-playback-volume",
-      label: "New playback apps",
-      description: "Starting level for applications that have not played audio before."
-    },
-    {
-      key: "node.stream.default-capture-volume",
-      label: "New recording apps",
-      description: "Starting level for applications that have not recorded before."
-    }
-  ]
-  readonly property var policyExperimentalDefinitions: [
-    {
-      key: "monitor.alsa.autodetect-hdmi-channels",
-      label: "Detect HDMI channel layout",
-      description: "Let WirePlumber infer HDMI channel counts. Experimental; some receivers report them incorrectly."
-    }
-  ]
   readonly property var captureNotificationDefinition: ({
     key: "captureNotifications",
     label: "Capture-start notifications",
     description: "Notify when a new application begins using the microphone. Respects Do Not Disturb and ignores existing captures at shell startup."
   })
-  readonly property var availablePolicyCore: supportedPolicyDefinitions(policyCoreDefinitions)
-  readonly property var availablePolicyVolumes: supportedPolicyDefinitions(policyVolumeDefinitions)
-  readonly property var availablePolicyExperimental: supportedPolicyDefinitions(policyExperimentalDefinitions)
+  readonly property var availablePolicyCore: policy.availableCore
+  readonly property var availablePolicyVolumes: policy.availableVolumes
+  readonly property var availablePolicyExperimental: policy.availableExperimental
   readonly property var bluetoothCards: Model.audioCardsByBluetooth(audioCards, true)
   readonly property var deviceCards: Model.audioCardsByBluetooth(audioCards, false)
   readonly property var pipewireNodes: Pipewire.nodes ? Pipewire.nodes.values : []
@@ -183,44 +139,9 @@ Item {
         ? deviceItemCount + (inputDevice ? 1 : 0)
         : (activeTab === 1 ? 2 + bluetoothCards.length : policyItemCount)))
   readonly property bool audioMutationBusy: profileSetProc.running || portSetProc.running
-    || microphoneTestProc.running || microphoneTestStopProc.running
-  readonly property real microphoneTestLevel: inputDevice && inputDevice.audio
-    && !inputDevice.audio.muted
-    ? Math.max(0, Math.min(1, Number(microphoneTestPeakMonitor.peak || 0))) : 0
+    || microphoneTest.busy
   readonly property color hoverFill: Style.hoverFillFor(foreground, Color.accent)
-  readonly property string settingsPath: {
-    var configHome = Quickshell.env("XDG_CONFIG_HOME")
-    if (!configHome) configHome = Quickshell.env("HOME") + "/.config"
-    return configHome + "/omarchy/audio-control.json"
-  }
-  readonly property string audioPreferencesPath: {
-    var configHome = Quickshell.env("XDG_CONFIG_HOME")
-    if (!configHome) configHome = Quickshell.env("HOME") + "/.config"
-    return configHome + "/omarchy/audio-preferences.json"
-  }
-  readonly property string scenesPath: {
-    var configHome = Quickshell.env("XDG_CONFIG_HOME")
-    if (!configHome) configHome = Quickshell.env("HOME") + "/.config"
-    return configHome + "/omarchy/audio-scenes.json"
-  }
-  readonly property string rulesPath: {
-    var configHome = Quickshell.env("XDG_CONFIG_HOME")
-    if (!configHome) configHome = Quickshell.env("HOME") + "/.config"
-    return configHome + "/omarchy/audio-rules.json"
-  }
-  readonly property string scriptsDir: {
-    var url = String(Qt.resolvedUrl("scripts/"))
-    return decodeURIComponent(url.replace(/^file:\/\//, ""))
-  }
   onDefaultOutputDeviceChanged: resolveVolumeSink()
-  onInputDeviceChanged: if (microphoneTestState !== "idle") discardMicrophoneTest()
-  onInputDeviceMutedChanged: if (inputDeviceMuted && microphoneTestState === "recording")
-    cancelMicrophoneTest()
-
-  function pluginScript(name) {
-    var url = String(Qt.resolvedUrl("scripts/" + name))
-    return decodeURIComponent(url.replace(/^file:\/\//, ""))
-  }
 
   function open(payloadJson) {
     var payload = ({})
@@ -237,8 +158,7 @@ Item {
     profilesLoaded = false
     bluetoothAutoSwitchLoaded = false
     bluetoothProfilePreferenceLoaded = false
-    policySettingsLoaded = false
-    discardMicrophoneTest()
+    microphoneTest.discard()
     cancelAliasEdit()
     if (windowRuleReady) showOnCurrentWorkspace()
     else if (!windowRuleProc.running) windowRuleProc.running = true
@@ -251,13 +171,13 @@ Item {
     portSetError = ""
     bluetoothAutoswitchError = ""
     bluetoothPreferenceError = ""
-    policyError = ""
+    policy.clearError()
   }
 
   function showOnCurrentWorkspace() {
     if (!openRequested) return
     window.visible = true
-    Quickshell.execDetached([pluginScript("place-advanced-window")])
+    Quickshell.execDetached([runtime.script("place-advanced-window")])
     Qt.callLater(function() {
       if (!window.visible) return
       keyCatcher.forceActiveFocus()
@@ -269,14 +189,14 @@ Item {
     openRequested = false
     closingFromHost = true
     profileMenuOpen = false
-    discardMicrophoneTest()
+    microphoneTest.discard()
     window.visible = false
     closingFromHost = false
   }
 
   function requestClose() {
     openRequested = false
-    discardMicrophoneTest()
+    microphoneTest.discard()
     if (shell && typeof shell.hide === "function") shell.hide("ssupt.audio-control")
     else window.visible = false
   }
@@ -286,22 +206,16 @@ Item {
     if (!profilesProc.running && !profileSetProc.running) profilesProc.running = true
     if (!bluetoothAutoswitchProc.running) {
       autoswitchMutation = false
-      bluetoothAutoswitchProc.command = [pluginScript("audio-bluetooth-autoswitch")]
+      bluetoothAutoswitchProc.command = [runtime.script("audio-bluetooth-autoswitch")]
       bluetoothAutoswitchProc.running = true
     }
     if (!bluetoothPreferenceProc.running) {
       bluetoothProfilePreferenceMutation = false
-      bluetoothPreferenceProc.command = [pluginScript("audio-bluetooth-profile-preference")]
+      bluetoothPreferenceProc.command = [runtime.script("audio-bluetooth-profile-preference")]
       bluetoothPreferenceProc.running = true
     }
     if (!portsProc.running && !portSetProc.running) portsProc.running = true
-    if (!policyProc.running) {
-      policyMutation = false
-      policyResponseValid = false
-      pendingPolicyKey = ""
-      policyProc.command = [pluginScript("audio-policy-settings")]
-      policyProc.running = true
-    }
+    policy.refresh()
     resolveVolumeSink()
   }
 
@@ -330,55 +244,6 @@ Item {
     captureNotifications = audioControlSettings.captureNotifications
   }
 
-  function supportedPolicyDefinitions(definitions) {
-    var supported = []
-    for (var i = 0; i < definitions.length; i++) {
-      var definition = definitions[i]
-      if (policySettings[definition.key] !== undefined) supported.push(definition)
-    }
-    return supported
-  }
-
-  function copyPolicySettings(source) {
-    var copy = ({})
-    for (var key in source) copy[key] = source[key]
-    return copy
-  }
-
-  function loadPolicySettings(raw) {
-    var response = Model.parseAudioPolicySettings(raw)
-    policyResponseValid = response.valid
-    if (!response.valid) return
-    policySettings = response.values
-    policySettingsLoaded = true
-    clampCursor()
-  }
-
-  function setPolicySetting(key, value) {
-    if (!policySettingsLoaded || policyProc.running || policySettings[key] === undefined) return
-    var current = policySettings[key]
-    var normalized
-    if (typeof current === "boolean") {
-      if (typeof value !== "boolean") return
-      normalized = value
-    } else {
-      normalized = Math.max(0, Math.min(1, Math.round(Number(value) * 20) / 20))
-      if (!isFinite(normalized)) return
-    }
-    if (normalized === current) return
-
-    policyError = ""
-    previousPolicySettings = copyPolicySettings(policySettings)
-    var next = copyPolicySettings(policySettings)
-    next[key] = normalized
-    policySettings = next
-    policyMutation = true
-    policyResponseValid = false
-    pendingPolicyKey = key
-    policyProc.command = [pluginScript("audio-policy-settings"), "set", key, String(normalized)]
-    policyProc.running = true
-  }
-
   function policyToggleAtCursor() {
     if (activeTab !== 2) return null
     if (selectedIndex < availablePolicyCore.length)
@@ -396,7 +261,7 @@ Item {
     var index = selectedIndex - policyVolumeStartIndex
     if (index < 0 || index >= availablePolicyVolumes.length) return false
     var definition = availablePolicyVolumes[index]
-    setPolicySetting(definition.key, Number(policySettings[definition.key]) + delta * 0.05)
+    policy.setSetting(definition.key, Number(policySettings[definition.key]) + delta * 0.05)
     return true
   }
 
@@ -417,75 +282,6 @@ Item {
     if (key === "outputOverdrive") outputOverdrive = value
     else if (key === "captureNotifications") captureNotifications = value
     settingsFile.setText(JSON.stringify(next, null, 2) + "\n")
-  }
-
-  function startMicrophoneTestRecording() {
-    if (!inputDevice || !inputDevice.name || inputDeviceMuted || microphoneTestProc.running
-        || microphoneTestStopProc.running) return
-    microphoneTestError = ""
-    microphoneTestCancelled = false
-    microphoneTestOperation = "record"
-    microphoneTestState = "recording"
-    microphoneTestSecondsRemaining = 5
-    microphoneTestProc.command = [
-      pluginScript("audio-microphone-test"),
-      "record",
-      String(inputDevice.name)
-    ]
-    microphoneTestProc.running = true
-    microphoneTestCountdown.restart()
-  }
-
-  function playMicrophoneTest() {
-    if (microphoneTestState !== "ready" || microphoneTestProc.running
-        || microphoneTestStopProc.running) return
-    microphoneTestError = ""
-    microphoneTestCancelled = false
-    microphoneTestOperation = "play"
-    microphoneTestState = "playing"
-    microphoneTestProc.command = [pluginScript("audio-microphone-test"), "play"]
-    microphoneTestProc.running = true
-  }
-
-  function stopMicrophoneTestRecording() {
-    if (microphoneTestState !== "recording" || !microphoneTestProc.running
-        || microphoneTestStopProc.running) return
-    microphoneTestError = ""
-    microphoneTestState = "stopping"
-    microphoneTestCountdown.stop()
-    microphoneTestSecondsRemaining = 0
-    microphoneTestStopProc.command = [pluginScript("audio-microphone-test"), "stop"]
-    microphoneTestStopProc.running = true
-  }
-
-  function cancelMicrophoneTest() {
-    if (!microphoneTestProc.running) return
-    var operation = microphoneTestOperation
-    microphoneTestCancelled = true
-    microphoneTestProc.running = false
-    microphoneTestCountdown.stop()
-    microphoneTestSecondsRemaining = 0
-    microphoneTestState = operation === "record" ? "idle" : "ready"
-    if (operation === "record")
-      Quickshell.execDetached([pluginScript("audio-microphone-test"), "clear"])
-  }
-
-  function discardMicrophoneTest() {
-    if (microphoneTestStopProc.running) microphoneTestStopProc.running = false
-    if (microphoneTestProc.running) cancelMicrophoneTest()
-    microphoneTestCountdown.stop()
-    microphoneTestSecondsRemaining = 0
-    microphoneTestState = "idle"
-    microphoneTestError = ""
-    Quickshell.execDetached([pluginScript("audio-microphone-test"), "clear"])
-  }
-
-  function activateMicrophoneTest() {
-    if (microphoneTestState === "stopping") return
-    if (microphoneTestState === "recording") stopMicrophoneTestRecording()
-    else if (microphoneTestProc.running) cancelMicrophoneTest()
-    else if (microphoneTestState === "ready") playMicrophoneTest()
-    else startMicrophoneTestRecording()
   }
 
   function profileOptions(card) {
@@ -622,7 +418,7 @@ Item {
       }
       var policyToggle = policyToggleAtCursor()
       if (policyToggle)
-        setPolicySetting(policyToggle.key, policySettings[policyToggle.key] !== true)
+        policy.setSetting(policyToggle.key, policySettings[policyToggle.key] !== true)
       return
     }
     if (activeTab === 0 && selectedIndex === 0) {
@@ -642,7 +438,7 @@ Item {
       return
     }
     if (activeTab === 0 && selectedIndex === microphoneTestIndex) {
-      activateMicrophoneTest()
+      microphoneTest.activate()
       return
     }
     if (activeTab === 1 && selectedIndex === 0) {
@@ -684,14 +480,14 @@ Item {
       address: String(card.address),
       profile: String(profile)
     } : null
-    profileSetProc.command = [pluginScript("audio-profile-set"), String(card.name), profile]
+    profileSetProc.command = [runtime.script("audio-profile-set"), String(card.name), profile]
     profileSetProc.running = true
   }
 
   function setAudioPort(port, value) {
     if (!port || !value || audioMutationBusy) return
     portSetError = ""
-    portSetProc.command = [pluginScript("audio-port-set"), port.direction, port.endpoint, value]
+    portSetProc.command = [runtime.script("audio-port-set"), port.direction, port.endpoint, value]
     portSetProc.running = true
   }
 
@@ -699,7 +495,7 @@ Item {
     if (!bluetoothAutoSwitchLoaded || bluetoothAutoswitchProc.running) return
     bluetoothAutoswitchError = ""
     autoswitchMutation = true
-    bluetoothAutoswitchProc.command = [pluginScript("audio-bluetooth-autoswitch"), enabled ? "on" : "off"]
+    bluetoothAutoswitchProc.command = [runtime.script("audio-bluetooth-autoswitch"), enabled ? "on" : "off"]
     bluetoothAutoswitchProc.running = true
   }
 
@@ -708,13 +504,13 @@ Item {
         || (value !== "quality" && value !== "latency")) return
     bluetoothPreferenceError = ""
     bluetoothProfilePreferenceMutation = true
-    bluetoothPreferenceProc.command = [pluginScript("audio-bluetooth-profile-preference"), value]
+    bluetoothPreferenceProc.command = [runtime.script("audio-bluetooth-profile-preference"), value]
     bluetoothPreferenceProc.running = true
   }
 
   Process {
     id: windowRuleProc
-    command: [root.pluginScript("prepare-advanced-window")]
+    command: [runtime.script("prepare-advanced-window")]
     onExited: function(_exitCode) {
       // The placement helper below remains a fallback if Hyprland rejected
       // the pre-map rule. Do not leave the settings inaccessible on another
@@ -726,7 +522,7 @@ Item {
 
   FileView {
     id: settingsFile
-    path: root.settingsPath
+    path: runtime.settingsPath
     watchChanges: true
     atomicWrites: true
     printErrors: false
@@ -736,7 +532,7 @@ Item {
   }
 
   FileView {
-    path: root.audioPreferencesPath
+    path: runtime.preferencesPath
     watchChanges: true
     printErrors: false
     onLoaded: root.loadAudioPreferences(text())
@@ -745,7 +541,7 @@ Item {
   }
 
   FileView {
-    path: root.scenesPath
+    path: runtime.scenesPath
     watchChanges: true
     printErrors: false
     onLoaded: function() {
@@ -761,42 +557,16 @@ Item {
     onFileChanged: reload()
   }
 
-  FileView {
-    path: root.rulesPath
-    watchChanges: true
-    printErrors: false
-    onLoaded: function() {
-      root.audioRules = Model.parseAudioRules(text())
-      root.clampCursor()
-    }
-    onLoadFailed: function() {
-      root.audioRules = Model.parseAudioRules("")
-      root.clampCursor()
-    }
-    onFileChanged: reload()
-  }
-
-  Process {
-    id: routingWriteProc
-    onExited: function(exitCode) {
-      root.routingMutation = false
-      if (exitCode !== 0) root.showSceneStatus("Could not update the audio rules", true)
-    }
-  }
-
   function runRuleWrite(args) {
-    if (routingMutation || routingWriteProc.running) return
-    routingMutation = true
-    routingWriteProc.command = [root.scriptsDir + "/audio-app-rules"].concat(args)
-    routingWriteProc.running = true
+    return rulesStore.write(args)
   }
 
   AudioSceneController {
     id: sceneController
-    scriptsDir: root.scriptsDir
+    scriptsDir: runtime.scriptsDir
     onCaptureFinished: function(scene) {
       root.pendingSceneSave = scene
-      sceneStoreProc.command = [root.scriptsDir + "/audio-scenes", "save", scene.name,
+      sceneStoreProc.command = [runtime.script("audio-scenes"), "save", scene.name,
         JSON.stringify(scene)]
       sceneStoreProc.running = true
     }
@@ -864,110 +634,34 @@ Item {
   function deleteSceneAt(index) {
     var scene = index >= 0 ? audioScenes[index] : null
     if (!scene || sceneController.busy || sceneStoreProc.running) return
-    sceneStoreProc.command = [root.scriptsDir + "/audio-scenes", "delete", scene.name]
+    sceneStoreProc.command = [runtime.script("audio-scenes"), "delete", scene.name]
     sceneStoreProc.running = true
   }
 
   // ---- Routing tab helpers ----
 
   function deviceAliasFor(name) {
-    return audioRules.devices.aliases[String(name || "")] || ""
+    return rulesStore.aliasFor(name)
   }
 
   function ruleDeviceLabel(name) {
-    if (!name) return ""
-    var alias = deviceAliasFor(name)
-    if (alias !== "") return alias
-    for (var i = 0; i < candidateSinks.length; i++)
-      if (candidateSinks[i] && candidateSinks[i].name === name) return Model.nodeLabel(candidateSinks[i])
-    for (var j = 0; j < candidateSources.length; j++)
-      if (candidateSources[j] && candidateSources[j].name === name) return Model.nodeLabel(candidateSources[j])
-    return name
+    return rulesStore.deviceLabel(name)
   }
 
   function ruleTargetLive(name) {
-    if (!name) return false
-    for (var i = 0; i < candidateSinks.length; i++)
-      if (candidateSinks[i] && candidateSinks[i].name === name) return true
-    for (var j = 0; j < candidateSources.length; j++)
-      if (candidateSources[j] && candidateSources[j].name === name) return true
-    return false
+    return rulesStore.targetIsLive(name)
   }
 
   function ruleTargetOptions(storedTarget) {
-    var options = [{ value: "", label: "Follow default output" }]
-    for (var i = 0; i < candidateSinks.length; i++) {
-      var sink = candidateSinks[i]
-      if (sink && sink.name && sink.name !== storedTarget)
-        options.push({ value: String(sink.name), label: ruleDeviceLabel(String(sink.name)) })
-    }
-    if (storedTarget !== "")
-      options.push({ value: storedTarget, label: ruleDeviceLabel(storedTarget) })
-    return options
+    return rulesStore.optionsFor("playback", storedTarget)
   }
 
   function recordingRuleTargetOptions(storedTarget) {
-    var options = [{ value: "", label: "Follow default input" }]
-    for (var i = 0; i < candidateSources.length; i++) {
-      var source = candidateSources[i]
-      if (source && source.name && source.name !== storedTarget)
-        options.push({ value: String(source.name), label: ruleDeviceLabel(String(source.name)) })
-    }
-    if (storedTarget !== "")
-      options.push({ value: storedTarget, label: ruleDeviceLabel(storedTarget) })
-    return options
+    return rulesStore.optionsFor("recording", storedTarget)
   }
 
-  readonly property var managedDevices: {
-    var out = []
-    var seen = ({})
-    function push(name, liveLabel) {
-      if (!name || seen[name]) return
-      seen[name] = true
-      out.push({
-        name: String(name),
-        title: deviceAliasFor(name) !== "" ? deviceAliasFor(name) : liveLabel,
-        favorite: audioRules.devices.favorites.indexOf(name) !== -1,
-        hidden: audioRules.devices.hidden.indexOf(name) !== -1
-      })
-    }
-    for (var i = 0; i < candidateSinks.length; i++)
-      push(candidateSinks[i] ? candidateSinks[i].name : "", Model.nodeLabel(candidateSinks[i]))
-    for (var j = 0; j < candidateSources.length; j++)
-      push(candidateSources[j] ? candidateSources[j].name : "", Model.nodeLabel(candidateSources[j]))
-    var storedNames = []
-    for (var f = 0; f < audioRules.devices.favorites.length; f++) storedNames.push(audioRules.devices.favorites[f])
-    for (var h = 0; h < audioRules.devices.hidden.length; h++) storedNames.push(audioRules.devices.hidden[h])
-    for (var alias in audioRules.devices.aliases) storedNames.push(alias)
-    for (var s = 0; s < storedNames.length; s++) push(storedNames[s], storedNames[s])
-    // Favorites first, then visible devices, then hidden ones.
-    out.sort(function(a, b) {
-      if (a.favorite !== b.favorite) return a.favorite ? -1 : 1
-      if (a.hidden !== b.hidden) return a.hidden ? 1 : -1
-      return 0
-    })
-    return out
-  }
-
-  readonly property var newRuleAppOptions: {
-    var options = []
-    var seen = ({})
-    function consider(node) {
-      if (!node || !node.audio || node.ready !== true) return
-      var key = String(Model.rawStreamLabel(node) || "").trim()
-      if (key === "" || seen[key.toLowerCase()]) return
-      seen[key.toLowerCase()] = true
-      options.push(key)
-    }
-    for (var i = 0; i < candidateStreams.length; i++) consider(candidateStreams[i])
-    for (var j = 0; j < candidateRecordingStreams.length; j++) consider(candidateRecordingStreams[j])
-    var ruled = ({})
-    for (var r = 0; r < audioRules.appRules.length; r++) ruled[audioRules.appRules[r].app] = true
-    var filtered = []
-    for (var o = 0; o < options.length; o++)
-      if (!ruled[options[o].toLowerCase()]) filtered.push(options[o])
-    return filtered
-  }
+  readonly property var managedDevices: rulesStore.managedDevices
+  readonly property var newRuleAppOptions: rulesStore.availableApplicationLabels
 
   function cancelAliasEdit() {
     aliasEditingDevice = ""
@@ -1006,67 +700,16 @@ Item {
   PwObjectTracker { objects: root.outputDevice ? [root.outputDevice] : [] }
   PwObjectTracker { objects: root.inputDevice ? [root.inputDevice] : [] }
 
-  // Live endpoint and stream lists power the Routing tab's pickers. The same
-  // instrumentation filtering as the quick mixer keeps test streams out.
-  readonly property var candidateSinks: {
-    var list = []
-    for (var i = 0; i < pipewireNodes.length; i++) {
-      var n = pipewireNodes[i]
-      if (n && n.isSink && !n.isStream) list.push(n)
-    }
-    return list
-  }
-  readonly property var candidateSources: {
-    var list = []
-    for (var j = 0; j < pipewireNodes.length; j++) {
-      var s = pipewireNodes[j]
-      if (s && !s.isSink && !s.isStream && Model.isAudioSource(s)) {
-        var lowerName = String(s.name || "").toLowerCase()
-        if (lowerName === "quickshell" || lowerName.indexOf("omarchy_audio_test") === 0) continue
-        list.push(s)
-      }
-    }
-    return list
-  }
-  readonly property var candidateStreams: {
-    var list = []
-    for (var k = 0; k < pipewireNodes.length; k++) {
-      var p = pipewireNodes[k]
-      if (!p || !p.isStream || !Model.isPlaybackStream(p)) continue
-      if (isInstrumentationNode(p.name)) continue
-      list.push(p)
-    }
-    return list
-  }
-  readonly property var candidateRecordingStreams: {
-    var list = []
-    for (var m = 0; m < pipewireNodes.length; m++) {
-      var r = pipewireNodes[m]
-      if (!r || !Model.isRecordingStream(r)) continue
-      if (isInstrumentationNode(r.name)) continue
-      list.push(r)
-    }
-    return list
-  }
-  function isInstrumentationNode(name) {
-    var lower = String(name || "").toLowerCase()
-    return lower === "quickshell" || lower.indexOf("omarchy_audio_test") === 0
-  }
-
-  PwObjectTracker { objects: root.candidateSinks }
-  PwObjectTracker { objects: root.candidateSources }
-  PwObjectTracker { objects: root.candidateStreams }
-  PwObjectTracker { objects: root.candidateRecordingStreams }
-
-  PwNodePeakMonitor {
-    id: microphoneTestPeakMonitor
-    node: root.inputDevice
-    enabled: window.visible && root.microphoneTestState === "recording" && !!root.inputDevice
+  AudioMicrophoneTestController {
+    id: microphoneTest
+    scriptPath: runtime.script("audio-microphone-test")
+    inputDevice: root.inputDevice
+    sessionActive: window.visible
   }
 
   Process {
     id: profilesProc
-    command: [root.pluginScript("audio-profiles")]
+    command: [runtime.script("audio-profiles")]
     stdout: StdioCollector {
       waitForEnd: true
       onStreamFinished: root.parseAudioProfiles(text)
@@ -1089,7 +732,7 @@ Item {
 
   Process {
     id: portsProc
-    command: [root.pluginScript("audio-ports")]
+    command: [runtime.script("audio-ports")]
     stdout: StdioCollector {
       waitForEnd: true
       onStreamFinished: root.parseAudioPorts(text)
@@ -1108,7 +751,7 @@ Item {
         root.profileSetError = ""
         if (root.pendingSharedProfile)
           Quickshell.execDetached([
-            root.pluginScript("audio-preferences"),
+            runtime.script("audio-preferences"),
             "set-profile",
             root.pendingSharedProfile.address,
             root.pendingSharedProfile.profile
@@ -1171,87 +814,11 @@ Item {
     }
   }
 
-  Process {
-    id: policyProc
-    stdout: StdioCollector {
-      waitForEnd: true
-      onStreamFinished: root.loadPolicySettings(text)
-    }
-    onExited: function(exitCode) {
-      var mutation = root.policyMutation
-      if (exitCode !== 0 || !root.policyResponseValid) {
-        if (mutation) root.policySettings = root.previousPolicySettings
-        else root.policySettings = ({})
-        root.policySettingsLoaded = true
-        root.policyError = mutation
-          ? "Could not change the audio safety policy"
-          : "Could not load audio safety policies"
-      } else {
-        root.policyError = ""
-      }
-      root.policyMutation = false
-      root.pendingPolicyKey = ""
-      root.previousPolicySettings = ({})
-      root.clampCursor()
-    }
-  }
-
-  Process {
-    id: microphoneTestProc
-    onExited: function(exitCode) {
-      var operation = root.microphoneTestOperation
-      microphoneTestCountdown.stop()
-      root.microphoneTestSecondsRemaining = 0
-      if (root.microphoneTestCancelled) {
-        root.microphoneTestCancelled = false
-        root.microphoneTestOperation = ""
-        return
-      }
-
-      if (operation === "record") {
-        if (exitCode === 0) {
-          root.microphoneTestState = "ready"
-          root.microphoneTestError = ""
-        }
-        else {
-          root.microphoneTestState = "idle"
-          root.microphoneTestError = "Could not record the microphone test"
-          Quickshell.execDetached([root.pluginScript("audio-microphone-test"), "clear"])
-        }
-      } else if (operation === "play") {
-        root.microphoneTestState = "ready"
-        if (exitCode !== 0) root.microphoneTestError = "Could not play the microphone test"
-      }
-      root.microphoneTestOperation = ""
-    }
-  }
-
-  Process {
-    id: microphoneTestStopProc
-    onExited: function(exitCode) {
-      // A failed stop request must not strand the row in the stopping state:
-      // if the recorder is still running, tear it down like a cancellation.
-      if (exitCode !== 0 && root.microphoneTestState === "stopping"
-          && root.microphoneTestProc.running) {
-        root.microphoneTestError = "Could not stop the microphone test"
-        root.cancelMicrophoneTest()
-      }
-    }
-  }
-
   Timer {
     id: profileRefreshTimer
     interval: 200
     repeat: false
     onTriggered: if (window.visible && !profilesProc.running) profilesProc.running = true
-  }
-
-  Timer {
-    id: microphoneTestCountdown
-    interval: 1000
-    repeat: true
-    onTriggered: if (root.microphoneTestState === "recording")
-      root.microphoneTestSecondsRemaining = Math.max(0, root.microphoneTestSecondsRemaining - 1)
   }
 
   Timer {
@@ -1292,7 +859,6 @@ Item {
 
     onVisibleChanged: {
       if (!visible && !root.closingFromHost) {
-        root.discardMicrophoneTest()
         if (root.shell && typeof root.shell.hide === "function")
           root.shell.hide("ssupt.audio-control")
       }
@@ -1702,8 +1268,8 @@ Item {
                       width: parent.width
                       definition: modelData
                       checked: root.policySettings[modelData.key] === true
-                      busy: policyProc.running && root.pendingPolicyKey === modelData.key
-                      enabled: root.policySettingsLoaded && !policyProc.running
+                      busy: policy.busy && root.pendingPolicyKey === modelData.key
+                      enabled: root.policySettingsLoaded && !policy.busy
                       opacity: enabled ? 1 : 0.6
                       hasCursor: root.cursorActive && root.activeTab === 2
                         && root.selectedIndex === index
@@ -1712,7 +1278,7 @@ Item {
                       fontFamily: root.fontFamily
                       onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(policyCoreRow)
                       onHovered: root.setCursor(index)
-                      onActivated: root.setPolicySetting(modelData.key, !checked)
+                      onActivated: policy.setSetting(modelData.key, !checked)
                     }
                   }
                 }
@@ -1746,7 +1312,7 @@ Item {
                       width: parent.width
                       definition: modelData
                       value: Number(root.policySettings[modelData.key])
-                      enabled: root.policySettingsLoaded && !policyProc.running
+                      enabled: root.policySettingsLoaded && !policy.busy
                       opacity: enabled ? 1 : 0.6
                       hasCursor: root.cursorActive && root.activeTab === 2
                         && root.selectedIndex === rowIndex
@@ -1755,7 +1321,7 @@ Item {
                       fontFamily: root.fontFamily
                       onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(policyVolumeRow)
                       onHovered: root.setCursor(rowIndex)
-                      onCommitted: function(value) { root.setPolicySetting(modelData.key, value) }
+                      onCommitted: function(value) { policy.setSetting(modelData.key, value) }
                     }
                   }
                 }
@@ -1788,8 +1354,8 @@ Item {
                       width: parent.width
                       definition: modelData
                       checked: root.policySettings[modelData.key] === true
-                      busy: policyProc.running && root.pendingPolicyKey === modelData.key
-                      enabled: root.policySettingsLoaded && !policyProc.running
+                      busy: policy.busy && root.pendingPolicyKey === modelData.key
+                      enabled: root.policySettingsLoaded && !policy.busy
                       opacity: enabled ? 1 : 0.6
                       hasCursor: root.cursorActive && root.activeTab === 2
                         && root.selectedIndex === rowIndex
@@ -1798,7 +1364,7 @@ Item {
                       fontFamily: root.fontFamily
                       onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(policyExperimentalRow)
                       onHovered: root.setCursor(rowIndex)
-                      onActivated: root.setPolicySetting(modelData.key, !checked)
+                      onActivated: policy.setSetting(modelData.key, !checked)
                     }
                   }
                 }
@@ -2102,7 +1668,7 @@ Item {
 
                       Text {
                         width: parent.width
-                        text: root.newRuleDevice !== "" ? root.ruleDeviceLabel(root.newRuleDevice) : "Outputs pin playback, inputs pin recording."
+                        text: "Outputs pin playback, inputs pin recording."
                         color: Qt.darker(root.foreground, 1.35)
                         font.family: root.fontFamily
                         font.pixelSize: Style.font.caption
@@ -2115,19 +1681,8 @@ Item {
                       width: parent.width - newDeviceLabels.width - parent.spacing
                       showLabel: false
                       popupDirection: "down"
-                      value: root.newRuleDevice
-                      options: {
-                        var arr = []
-                        for (var i = 0; i < root.candidateSinks.length; i++) {
-                          var sinkName = String(root.candidateSinks[i] ? root.candidateSinks[i].name || "" : "")
-                          if (sinkName !== "") arr.push({ value: sinkName, label: root.ruleDeviceLabel(sinkName) })
-                        }
-                        for (var j = 0; j < root.candidateSources.length; j++) {
-                          var sourceName = String(root.candidateSources[j] ? root.candidateSources[j].name || "" : "")
-                          if (sourceName !== "") arr.push({ value: sourceName, label: root.ruleDeviceLabel(sourceName) })
-                        }
-                        return arr
-                      }
+                      value: ""
+                      options: rulesStore.targetOptions
                       hasCursor: newRuleDeviceRow.hasCursor
                       enabled: root.newRuleApp !== ""
                       opacity: enabled ? 1 : 0.6
@@ -2138,13 +1693,11 @@ Item {
                       onHovered: function(on) { if (on) root.setCursor(1) }
                       onChanged: function(value) {
                         if (value === "") return
-                        var direction = "recording"
-                        for (var s = 0; s < root.candidateSinks.length; s++)
-                          if (root.candidateSinks[s] && root.candidateSinks[s].name === value) direction = "playback"
-                        root.runRuleWrite(["set-app", root.newRuleApp, direction, value])
+                        var direction = rulesStore.directionForTarget(value)
+                        if (direction === "" || !root.runRuleWrite(
+                            ["set-app", root.newRuleApp, direction, value])) return
                         root.showSceneStatus("Pinned '" + root.newRuleApp + "'", false)
                         root.newRuleApp = ""
-                        root.newRuleDevice = ""
                       }
                       onPopupOpenChanged: {
                         root.profileMenuOpen = popupOpen
@@ -2178,7 +1731,7 @@ Item {
                     options: routingRuleDelegate.direction === "recording"
                       ? root.recordingRuleTargetOptions(routingRuleDelegate.currentValue)
                       : root.ruleTargetOptions(routingRuleDelegate.currentValue)
-                    menuEnabled: !root.routingMutation && !routingWriteProc.running
+                    menuEnabled: !root.routingMutation
                     hasCursor: root.cursorActive && root.activeTab === 4
                       && root.selectedIndex === 2 + routingRuleDelegate.index
                     onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(routingRuleDelegate)
@@ -2236,7 +1789,7 @@ Item {
                       var alias = root.deviceAliasFor(managedDeviceDelegate.deviceName)
                       return alias !== "" ? alias : managedDeviceDelegate.title
                     }
-                    busy: root.routingMutation || routingWriteProc.running
+                    busy: root.routingMutation
                     hasCursor: root.cursorActive && root.activeTab === 4
                       && root.selectedIndex === 2 + root.audioRules.appRules.length + managedDeviceDelegate.index
                     onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(managedDeviceDelegate)
@@ -2456,11 +2009,11 @@ Item {
                     id: microphoneTestRow
                     width: parent.width
                     deviceLabel: root.nodeLabel(root.inputDevice)
-                    state: root.microphoneTestState
-                    secondsRemaining: root.microphoneTestSecondsRemaining
-                    level: root.microphoneTestLevel
+                    state: microphoneTest.testState
+                    secondsRemaining: microphoneTest.secondsRemaining
+                    level: microphoneTest.level
                     microphoneMuted: root.inputDeviceMuted
-                    error: root.microphoneTestError
+                    error: microphoneTest.error
                     enabled: !profileSetProc.running && !portSetProc.running
                     hasCursor: root.cursorActive && root.activeTab === 0
                       && root.selectedIndex === root.microphoneTestIndex
@@ -2470,8 +2023,8 @@ Item {
                     fontFamily: root.fontFamily
                     onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(microphoneTestRow)
                     onHovered: root.setCursor(root.microphoneTestIndex)
-                    onPrimaryActivated: root.activateMicrophoneTest()
-                    onDiscarded: root.discardMicrophoneTest()
+                    onPrimaryActivated: microphoneTest.activate()
+                    onDiscarded: microphoneTest.discard()
                   }
                 }
 

--- a/AudioDiagnosticActionRow.qml
+++ b/AudioDiagnosticActionRow.qml
@@ -1,0 +1,79 @@
+import QtQuick
+import qs.Ui
+import qs.Commons
+
+CursorSurface {
+  id: root
+
+  required property string title
+  required property string description
+  required property string icon
+  property bool actionEnabled: true
+  property bool busy: false
+  property bool urgentAction: false
+  property color urgent: Color.urgent
+  property string fontFamily: Style.font.family
+
+  signal activated()
+  signal hovered()
+
+  implicitHeight: content.implicitHeight + Style.space(18)
+  bordered: true
+  opacity: actionEnabled ? 1 : 0.55
+
+  Row {
+    id: content
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.verticalCenter: parent.verticalCenter
+    anchors.leftMargin: Style.space(12)
+    anchors.rightMargin: Style.space(12)
+    spacing: Style.space(10)
+
+    Column {
+      width: parent.width - action.width - parent.spacing
+      spacing: Style.space(3)
+
+      Text {
+        width: parent.width
+        text: root.title
+        color: root.urgentAction ? root.urgent : root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.body
+        font.bold: true
+        elide: Text.ElideRight
+      }
+
+      Text {
+        width: parent.width
+        text: root.description
+        color: Qt.darker(root.foreground, 1.35)
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.caption
+        wrapMode: Text.WordWrap
+      }
+    }
+
+    PanelActionButton {
+      id: action
+      iconText: root.busy ? "󰔟" : root.icon
+      tooltipText: root.title
+      foreground: root.foreground
+      hoverColor: root.urgentAction ? root.urgent : root.foreground
+      fontFamily: root.fontFamily
+      bordered: true
+      hasCursor: root.hasCursor
+      enabled: root.enabled && root.actionEnabled && !root.busy
+      anchors.verticalCenter: parent.verticalCenter
+      onClicked: root.activated()
+    }
+  }
+
+  MouseArea {
+    anchors.fill: parent
+    enabled: root.actionEnabled && !root.busy
+    acceptedButtons: Qt.NoButton
+    hoverEnabled: true
+    onContainsMouseChanged: if (containsMouse) root.hovered()
+  }
+}

--- a/AudioDiagnosticsController.qml
+++ b/AudioDiagnosticsController.qml
@@ -1,0 +1,163 @@
+import QtQuick
+import Quickshell.Io
+import "Model.js" as Model
+
+// Owns read-only health refreshes and the three explicit diagnostics actions.
+// Recovery is invoked only after the view's confirmation dialog; its helper
+// opens Omarchy's official command in a visible terminal rather than hiding a
+// possible USB-reset authorization prompt inside the shell.
+Item {
+  id: root
+
+  required property string diagnosticsPath
+  required property string speakerTestPath
+  required property string recoveryPath
+  property bool sessionActive: false
+
+  property var snapshot: Model.emptyAudioDiagnostics()
+  property bool loaded: false
+  property string error: ""
+  property string status: ""
+  property bool statusIsError: false
+  property bool snapshotValid: false
+  property bool speakerCancelled: false
+
+  readonly property bool refreshing: snapshotProc.running
+  readonly property bool copying: copyProc.running
+  readonly property bool speakerTesting: speakerProc.running
+  readonly property bool recovering: recoveryProc.running
+  readonly property bool busy: refreshing || copying || recovering
+
+  onSessionActiveChanged: {
+    if (sessionActive) refresh()
+    else stopSpeakerTest(false)
+  }
+
+  function showStatus(message, isError) {
+    status = String(message || "")
+    statusIsError = isError === true
+    if (status !== "") statusTimer.restart()
+  }
+
+  function clearMessages() {
+    error = ""
+    status = ""
+  }
+
+  function loadSnapshot(raw) {
+    var response = Model.parseAudioDiagnostics(raw)
+    snapshotValid = response.valid
+    if (!response.valid) return
+    snapshot = response.value
+    loaded = true
+  }
+
+  function refresh() {
+    if (snapshotProc.running) return
+    error = ""
+    snapshotValid = false
+    snapshotProc.command = [diagnosticsPath, "snapshot"]
+    snapshotProc.running = true
+  }
+
+  function copySupportReport() {
+    if (copyProc.running || !snapshot.capabilities.supportReport
+        || !snapshot.capabilities.clipboard) return
+    copyProc.command = [diagnosticsPath, "copy-report"]
+    copyProc.running = true
+  }
+
+  function toggleSpeakerTest() {
+    if (speakerProc.running) {
+      stopSpeakerTest(true)
+      return
+    }
+    var sink = snapshot.defaults ? String(snapshot.defaults.output || "") : ""
+    if (!snapshot.capabilities.speakerTest || sink === "") return
+    speakerCancelled = false
+    speakerProc.command = [speakerTestPath, sink]
+    speakerProc.running = true
+    showStatus("Testing each reported output channel…", false)
+  }
+
+  function stopSpeakerTest(showFeedback) {
+    if (!speakerProc.running) return
+    speakerCancelled = true
+    speakerProc.running = false
+    if (showFeedback) showStatus("Stopped the speaker test", false)
+  }
+
+  function runRecovery() {
+    if (recoveryProc.running || !snapshot.capabilities.recovery) return
+    stopSpeakerTest(false)
+    recoveryProc.command = [recoveryPath]
+    recoveryProc.running = true
+  }
+
+  Process {
+    id: snapshotProc
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: root.loadSnapshot(text)
+    }
+    onExited: function(exitCode) {
+      if (exitCode !== 0 || !root.snapshotValid) {
+        root.loaded = true
+        root.error = "Could not collect audio diagnostics"
+      } else {
+        root.error = ""
+      }
+    }
+  }
+
+  Process {
+    id: copyProc
+    onExited: function(exitCode) {
+      root.showStatus(exitCode === 0
+        ? "Copied the privacy-conscious support report"
+        : "Could not copy the support report", exitCode !== 0)
+    }
+  }
+
+  Process {
+    id: speakerProc
+    onExited: function(exitCode) {
+      if (root.speakerCancelled) {
+        root.speakerCancelled = false
+        return
+      }
+      root.showStatus(exitCode === 0
+        ? "Finished the speaker channel test"
+        : "Could not complete the speaker channel test", exitCode !== 0)
+    }
+  }
+
+  Process {
+    id: recoveryProc
+    onExited: function(exitCode) {
+      root.showStatus(exitCode === 0
+        ? "Opened Omarchy audio recovery in a terminal"
+        : "Could not open Omarchy audio recovery", exitCode !== 0)
+      if (exitCode === 0) recoveryRefresh.restart()
+    }
+  }
+
+  Timer {
+    interval: 5000
+    running: root.sessionActive
+    repeat: true
+    onTriggered: if (!root.busy) root.refresh()
+  }
+
+  Timer {
+    id: recoveryRefresh
+    interval: 4000
+    onTriggered: if (root.sessionActive) root.refresh()
+  }
+
+  Timer {
+    id: statusTimer
+    interval: 6000
+    onTriggered: root.status = ""
+  }
+}

--- a/AudioDiagnosticsView.qml
+++ b/AudioDiagnosticsView.qml
@@ -1,0 +1,449 @@
+import QtQuick
+import qs.Ui
+import qs.Commons
+
+Column {
+  id: root
+
+  required property var controller
+  required property bool tabActive
+  required property bool cursorActive
+  required property int selectedIndex
+  property color foreground: Color.foreground
+  property color urgent: Color.urgent
+  property color fill: Style.hoverFillFor(foreground, Color.accent)
+  property string fontFamily: Style.font.family
+
+  signal cursorRequested(int index)
+  signal ensureVisible(var item)
+  signal recoveryRequested()
+
+  readonly property var snapshot: controller.snapshot
+  readonly property int itemCount: 4
+  readonly property var defaultOutput: {
+    var values = snapshot.devices || []
+    for (var i = 0; i < values.length; i++)
+      if (values[i].direction === "output" && values[i].default) return values[i]
+    return null
+  }
+
+  width: parent ? parent.width : 0
+  spacing: Style.space(18)
+
+  function activate(index) {
+    if (index === 0) controller.refresh()
+    else if (index === 1) controller.toggleSpeakerTest()
+    else if (index === 2) controller.copySupportReport()
+    else if (index === 3 && snapshot.capabilities.recovery) recoveryRequested()
+  }
+
+  function graphDescription() {
+    if (!snapshot.graph.available) return "Graph timing is unavailable"
+    var details = []
+    if (snapshot.graph.rate > 0) details.push(snapshot.graph.rate + " Hz")
+    if (snapshot.graph.quantum > 0) details.push(snapshot.graph.quantum + " samples")
+    if (snapshot.graph.latencyMs > 0) details.push(snapshot.graph.latencyMs + " ms per cycle")
+    if (details.length === 0) return "No graph timing reported"
+    return (snapshot.graph.source === "active" ? "Active graph" : "Configured graph")
+      + " · " + details.join(" · ")
+  }
+
+  function graphLoadDescription() {
+    var load = snapshot.graph.loadPercent >= 0
+      ? (Math.round(snapshot.graph.loadPercent * 10) / 10) + "% peak DSP load"
+      : (snapshot.graph.active ? "DSP load unavailable" : "Graph currently idle")
+    return load + " · " + snapshot.graph.errors + " XRUN/error"
+      + (snapshot.graph.errors === 1 ? "" : "s")
+  }
+
+  function deviceDetails(device) {
+    var details = []
+    if (device.format) details.push(device.format)
+    if (device.channelMap) details.push(device.channelMap)
+    if (device.profile) details.push(device.profile)
+    if (device.codec) details.push("codec " + device.codec)
+    if (device.port) details.push(device.port)
+    details.push(device.state || "unknown")
+    return details.join(" · ")
+  }
+
+  Text {
+    width: parent.width
+    text: "Inspect the live audio graph without changing it. Support reports omit logs, account details, configuration files, and internal device identifiers."
+    color: Qt.darker(root.foreground, 1.35)
+    font.family: root.fontFamily
+    font.pixelSize: Style.font.bodySmall
+    wrapMode: Text.WordWrap
+  }
+
+  Column {
+    width: parent.width
+    spacing: Style.space(8)
+
+    PanelSectionHeader {
+      text: "SYSTEM HEALTH"
+      foreground: root.foreground
+      fontFamily: root.fontFamily
+    }
+
+    BorderSurface {
+      width: parent.width
+      implicitHeight: healthContent.implicitHeight + Style.space(20)
+      color: "transparent"
+      borderSpec: Border.controlSpec("normal", root.foreground, Color.accent)
+      radius: Style.cornerRadius
+
+      Column {
+        id: healthContent
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.leftMargin: Style.space(12)
+        anchors.rightMargin: Style.space(12)
+        spacing: Style.space(8)
+
+        Row {
+          width: parent.width
+          spacing: Style.space(8)
+
+          Text {
+            text: root.controller.refreshing ? "󰔟" : (root.snapshot.healthy ? "󰄬" : "󰀦")
+            color: root.snapshot.healthy ? root.foreground : root.urgent
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.iconLarge
+            anchors.verticalCenter: parent.verticalCenter
+          }
+
+          Column {
+            width: parent.width - parent.children[0].width - parent.spacing
+            spacing: Style.space(2)
+
+            Text {
+              width: parent.width
+              text: root.controller.refreshing ? "Checking audio services…"
+                : (root.snapshot.healthy ? "Audio services are healthy" : "Audio needs attention")
+              color: root.snapshot.healthy ? root.foreground : root.urgent
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.body
+              font.bold: true
+              elide: Text.ElideRight
+            }
+
+            Text {
+              width: parent.width
+              text: "PipeWire " + (root.snapshot.versions.pipewire || "unknown")
+                + " · WirePlumber " + (root.snapshot.versions.wireplumber || "unknown")
+              color: Qt.darker(root.foreground, 1.35)
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.caption
+              elide: Text.ElideRight
+            }
+          }
+        }
+
+        Repeater {
+          model: root.snapshot.services
+
+          Row {
+            required property var modelData
+            width: healthContent.width
+            spacing: Style.space(7)
+
+            Rectangle {
+              width: Style.space(6)
+              height: width
+              radius: width / 2
+              color: modelData.active ? root.foreground : root.urgent
+              anchors.verticalCenter: parent.verticalCenter
+            }
+
+            Text {
+              width: parent.width - parent.children[0].width - stateText.width - parent.spacing * 2
+              text: modelData.label
+              color: root.foreground
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.caption
+              elide: Text.ElideRight
+            }
+
+            Text {
+              id: stateText
+              text: modelData.active ? "running"
+                : modelData.activeState + "/" + modelData.subState
+              color: modelData.active ? Qt.darker(root.foreground, 1.35) : root.urgent
+              font.family: root.fontFamily
+              font.pixelSize: Style.font.caption
+            }
+          }
+        }
+      }
+    }
+  }
+
+  Column {
+    width: parent.width
+    spacing: Style.space(8)
+
+    PanelSectionHeader {
+      text: "PIPEWIRE GRAPH"
+      foreground: root.foreground
+      fontFamily: root.fontFamily
+    }
+
+    BorderSurface {
+      width: parent.width
+      implicitHeight: graphContent.implicitHeight + Style.space(20)
+      color: "transparent"
+      borderSpec: Border.controlSpec("normal", root.foreground, Color.accent)
+      radius: Style.cornerRadius
+
+      Column {
+        id: graphContent
+        anchors.left: parent.left
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        anchors.leftMargin: Style.space(12)
+        anchors.rightMargin: Style.space(12)
+        spacing: Style.space(4)
+
+        Text {
+          width: parent.width
+          text: root.graphDescription()
+          color: root.foreground
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.body
+          font.bold: true
+          wrapMode: Text.WordWrap
+        }
+
+        Text {
+          width: parent.width
+          text: root.graphLoadDescription()
+          color: root.snapshot.graph.errors > 0 ? root.urgent : Qt.darker(root.foreground, 1.35)
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.caption
+          wrapMode: Text.WordWrap
+        }
+      }
+    }
+
+    Repeater {
+      model: root.snapshot.warnings
+
+      Text {
+        required property string modelData
+        width: parent.width
+        text: "󰀦  " + modelData
+        color: root.urgent
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.caption
+        wrapMode: Text.WordWrap
+      }
+    }
+  }
+
+  Column {
+    width: parent.width
+    spacing: Style.space(8)
+
+    PanelSectionHeader {
+      text: "NEGOTIATED DEVICE FORMATS"
+      foreground: root.foreground
+      fontFamily: root.fontFamily
+    }
+
+    Repeater {
+      model: root.snapshot.devices
+
+      BorderSurface {
+        required property var modelData
+        width: parent.width
+        implicitHeight: deviceContent.implicitHeight + Style.space(18)
+        color: "transparent"
+        borderSpec: Border.controlSpec("normal", root.foreground, Color.accent)
+        radius: Style.cornerRadius
+
+        Column {
+          id: deviceContent
+          anchors.left: parent.left
+          anchors.right: parent.right
+          anchors.verticalCenter: parent.verticalCenter
+          anchors.leftMargin: Style.space(12)
+          anchors.rightMargin: Style.space(12)
+          spacing: Style.space(3)
+
+          Text {
+            width: parent.width
+            text: (modelData.direction === "output" ? "󰓃  " : "󰍬  ")
+              + modelData.label + (modelData.default ? " · default" : "")
+            color: root.foreground
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.body
+            font.bold: modelData.default
+            elide: Text.ElideRight
+          }
+
+          Text {
+            width: parent.width
+            text: root.deviceDetails(modelData)
+            color: Qt.darker(root.foreground, 1.35)
+            font.family: root.fontFamily
+            font.pixelSize: Style.font.caption
+            wrapMode: Text.WordWrap
+          }
+        }
+      }
+    }
+
+    Text {
+      visible: root.controller.loaded && root.snapshot.devices.length === 0
+      width: parent.width
+      text: "No playback or recording device is currently available."
+      color: Qt.darker(root.foreground, 1.35)
+      font.family: root.fontFamily
+      font.pixelSize: Style.font.bodySmall
+      wrapMode: Text.WordWrap
+    }
+  }
+
+  Column {
+    width: parent.width
+    spacing: Style.space(8)
+
+    PanelSectionHeader {
+      text: "ACTIVE ROUTES"
+      foreground: root.foreground
+      fontFamily: root.fontFamily
+    }
+
+    Repeater {
+      model: root.snapshot.routes
+
+      Text {
+        required property var modelData
+        width: parent.width
+        text: (modelData.direction === "recording" ? "󰍬  " : "󰐊  ")
+          + modelData.labels.join("  →  ")
+        color: root.foreground
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.bodySmall
+        wrapMode: Text.WordWrap
+      }
+    }
+
+    Text {
+      visible: root.controller.loaded && root.snapshot.routes.length === 0
+      width: parent.width
+      text: root.snapshot.capabilities.topology
+        ? "No application audio route is active."
+        : "Active route topology is unavailable."
+      color: Qt.darker(root.foreground, 1.35)
+      font.family: root.fontFamily
+      font.pixelSize: Style.font.bodySmall
+      wrapMode: Text.WordWrap
+    }
+  }
+
+  Column {
+    width: parent.width
+    spacing: Style.space(8)
+
+    PanelSectionHeader {
+      text: "DIAGNOSTIC ACTIONS"
+      foreground: root.foreground
+      fontFamily: root.fontFamily
+    }
+
+    AudioDiagnosticActionRow {
+      id: refreshRow
+      width: parent.width
+      title: "Refresh diagnostics"
+      description: root.controller.refreshing ? "Collecting a new read-only snapshot…"
+        : "Recheck services, graph statistics, devices, formats, and routes."
+      icon: "󰑐"
+      busy: root.controller.refreshing
+      hasCursor: root.tabActive && root.cursorActive && root.selectedIndex === 0
+      foreground: root.foreground
+      fill: root.fill
+      fontFamily: root.fontFamily
+      onHasCursorChanged: if (hasCursor) root.ensureVisible(refreshRow)
+      onHovered: root.cursorRequested(0)
+      onActivated: root.controller.refresh()
+    }
+
+    AudioDiagnosticActionRow {
+      id: speakerRow
+      width: parent.width
+      title: root.controller.speakerTesting ? "Stop speaker test" : "Test speaker channels"
+      description: root.controller.speakerTesting
+        ? "Channel identification is playing on the default output."
+        : (root.snapshot.capabilities.speakerTest
+          ? "Identify " + (root.defaultOutput ? root.defaultOutput.channels : 0)
+            + " reported channel" + (root.defaultOutput && root.defaultOutput.channels === 1 ? "" : "s")
+            + " on " + (root.defaultOutput ? root.defaultOutput.label : "the default output")
+            + " at a conservative level."
+          : "No testable default output or speaker-test command is available.")
+      icon: root.controller.speakerTesting ? "󰓛" : "󰓃"
+      actionEnabled: root.controller.speakerTesting || root.snapshot.capabilities.speakerTest
+      hasCursor: root.tabActive && root.cursorActive && root.selectedIndex === 1
+      foreground: root.foreground
+      fill: root.fill
+      fontFamily: root.fontFamily
+      onHasCursorChanged: if (hasCursor) root.ensureVisible(speakerRow)
+      onHovered: root.cursorRequested(1)
+      onActivated: root.controller.toggleSpeakerTest()
+    }
+
+    AudioDiagnosticActionRow {
+      id: copyRow
+      width: parent.width
+      title: "Copy support report"
+      description: root.controller.copying ? "Building the report…"
+        : (root.snapshot.capabilities.clipboard
+          ? "Copy a sanitized snapshot suitable for an issue report."
+          : "A Wayland clipboard command is not available.")
+      icon: "󰆏"
+      busy: root.controller.copying
+      actionEnabled: root.snapshot.capabilities.supportReport
+        && root.snapshot.capabilities.clipboard
+      hasCursor: root.tabActive && root.cursorActive && root.selectedIndex === 2
+      foreground: root.foreground
+      fill: root.fill
+      fontFamily: root.fontFamily
+      onHasCursorChanged: if (hasCursor) root.ensureVisible(copyRow)
+      onHovered: root.cursorRequested(2)
+      onActivated: root.controller.copySupportReport()
+    }
+
+    AudioDiagnosticActionRow {
+      id: recoveryRow
+      width: parent.width
+      title: "Run Omarchy audio recovery"
+      description: root.snapshot.capabilities.recovery
+        ? "After confirmation, open omarchy-restart-audio in a visible terminal. Audio will be interrupted."
+        : "Omarchy's recovery command or terminal launcher is not available."
+      icon: "󰑓"
+      actionEnabled: root.snapshot.capabilities.recovery
+      urgentAction: true
+      hasCursor: root.tabActive && root.cursorActive && root.selectedIndex === 3
+      foreground: root.foreground
+      fill: root.fill
+      urgent: root.urgent
+      fontFamily: root.fontFamily
+      onHasCursorChanged: if (hasCursor) root.ensureVisible(recoveryRow)
+      onHovered: root.cursorRequested(3)
+      onActivated: root.recoveryRequested()
+    }
+
+    Text {
+      visible: root.controller.error !== "" || root.controller.status !== ""
+      width: parent.width
+      text: root.controller.error !== "" ? root.controller.error : root.controller.status
+      color: root.controller.error !== "" || root.controller.statusIsError
+        ? root.urgent : root.foreground
+      font.family: root.fontFamily
+      font.pixelSize: Style.font.bodySmall
+      wrapMode: Text.WordWrap
+    }
+  }
+}

--- a/AudioMicrophoneTestController.qml
+++ b/AudioMicrophoneTestController.qml
@@ -1,0 +1,152 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import Quickshell.Services.Pipewire
+
+// Owns the complete lifecycle of the private record/playback probe. The
+// advanced window only renders this state, which keeps process cancellation
+// and temporary-file cleanup independent from tab and cursor code.
+Item {
+  id: root
+
+  required property string scriptPath
+  property var inputDevice: null
+  property bool sessionActive: false
+
+  property string testState: "idle"
+  property string operation: ""
+  property bool cancelled: false
+  property int secondsRemaining: 0
+  property string error: ""
+
+  readonly property bool microphoneMuted: !inputDevice || !inputDevice.audio
+    || inputDevice.audio.muted
+  readonly property bool busy: testProc.running || stopProc.running
+  readonly property real level: inputDevice && inputDevice.audio && !inputDevice.audio.muted
+    ? Math.max(0, Math.min(1, Number(peakMonitor.peak || 0))) : 0
+
+  onInputDeviceChanged: if (testState !== "idle") discard()
+  onMicrophoneMutedChanged: if (microphoneMuted && testState === "recording") cancel()
+  onSessionActiveChanged: if (!sessionActive && testState !== "idle") discard()
+
+  function clearClip() {
+    Quickshell.execDetached([scriptPath, "clear"])
+  }
+
+  function startRecording() {
+    if (!inputDevice || !inputDevice.name || microphoneMuted || busy) return
+    error = ""
+    cancelled = false
+    operation = "record"
+    testState = "recording"
+    secondsRemaining = 5
+    testProc.command = [scriptPath, "record", String(inputDevice.name)]
+    testProc.running = true
+    countdown.restart()
+  }
+
+  function play() {
+    if (testState !== "ready" || busy) return
+    error = ""
+    cancelled = false
+    operation = "play"
+    testState = "playing"
+    testProc.command = [scriptPath, "play"]
+    testProc.running = true
+  }
+
+  function stopRecording() {
+    if (testState !== "recording" || !testProc.running || stopProc.running) return
+    error = ""
+    testState = "stopping"
+    countdown.stop()
+    secondsRemaining = 0
+    stopProc.command = [scriptPath, "stop"]
+    stopProc.running = true
+  }
+
+  function cancel() {
+    if (!testProc.running) return
+    var cancelledOperation = operation
+    cancelled = true
+    testProc.running = false
+    countdown.stop()
+    secondsRemaining = 0
+    testState = cancelledOperation === "record" ? "idle" : "ready"
+    if (cancelledOperation === "record") clearClip()
+  }
+
+  function discard() {
+    if (stopProc.running) stopProc.running = false
+    if (testProc.running) cancel()
+    countdown.stop()
+    secondsRemaining = 0
+    testState = "idle"
+    error = ""
+    clearClip()
+  }
+
+  function activate() {
+    if (testState === "stopping") return
+    if (testState === "recording") stopRecording()
+    else if (testProc.running) cancel()
+    else if (testState === "ready") play()
+    else startRecording()
+  }
+
+  PwNodePeakMonitor {
+    id: peakMonitor
+    node: root.inputDevice
+    enabled: root.sessionActive && root.testState === "recording" && !!root.inputDevice
+  }
+
+  Process {
+    id: testProc
+
+    onExited: function(exitCode) {
+      var completedOperation = root.operation
+      countdown.stop()
+      root.secondsRemaining = 0
+      if (root.cancelled) {
+        root.cancelled = false
+        root.operation = ""
+        return
+      }
+
+      if (completedOperation === "record") {
+        if (exitCode === 0) {
+          root.testState = "ready"
+          root.error = ""
+        } else {
+          root.testState = "idle"
+          root.error = "Could not record the microphone test"
+          root.clearClip()
+        }
+      } else if (completedOperation === "play") {
+        root.testState = "ready"
+        if (exitCode !== 0) root.error = "Could not play the microphone test"
+      }
+      root.operation = ""
+    }
+  }
+
+  Process {
+    id: stopProc
+
+    onExited: function(exitCode) {
+      // A failed stop request must not strand the UI in the stopping state.
+      if (exitCode !== 0 && root.testState === "stopping" && testProc.running) {
+        root.error = "Could not stop the microphone test"
+        root.cancel()
+      }
+    }
+  }
+
+  Timer {
+    id: countdown
+    interval: 1000
+    repeat: true
+    onTriggered: if (root.testState === "recording")
+      root.secondsRemaining = Math.max(0, root.secondsRemaining - 1)
+  }
+}

--- a/AudioPolicyController.qml
+++ b/AudioPolicyController.qml
@@ -1,0 +1,166 @@
+import QtQuick
+import Quickshell.Io
+import "Model.js" as Model
+
+// Capability discovery and optimistic WirePlumber policy mutation. The view
+// consumes only the supported definitions and does not need to coordinate
+// parsing, rollback, or Process state.
+Item {
+  id: root
+
+  required property string scriptPath
+
+  property var settings: ({})
+  property bool loaded: false
+  property string error: ""
+  property string pendingKey: ""
+  readonly property bool busy: policyProc.running
+
+  property bool mutation: false
+  property bool responseValid: false
+  property var previousSettings: ({})
+
+  readonly property var coreDefinitions: [
+    {
+      key: "node.features.audio.mono",
+      label: "Mono audio",
+      description: "Mix left and right output channels so every sound is audible from either speaker."
+    },
+    {
+      key: "linking.pause-playback",
+      label: "Pause on output loss",
+      description: "Pause compatible media players when their active output device disappears."
+    },
+    {
+      key: "device.routes.mute-on-alsa-playback-removed",
+      label: "Mute after wired disconnect",
+      description: "Keep playback muted instead of unexpectedly moving it to another output."
+    },
+    {
+      key: "device.routes.mute-on-bluetooth-playback-removed",
+      label: "Mute after Bluetooth disconnect",
+      description: "Prevent private audio from jumping to speakers when Bluetooth drops."
+    }
+  ]
+  readonly property var volumeDefinitions: [
+    {
+      key: "device.routes.default-sink-volume",
+      label: "New output devices",
+      description: "Starting level before WirePlumber has remembered a volume for the device."
+    },
+    {
+      key: "device.routes.default-source-volume",
+      label: "New input devices",
+      description: "Starting level before WirePlumber has remembered a volume for the microphone."
+    },
+    {
+      key: "node.stream.default-playback-volume",
+      label: "New playback apps",
+      description: "Starting level for applications that have not played audio before."
+    },
+    {
+      key: "node.stream.default-capture-volume",
+      label: "New recording apps",
+      description: "Starting level for applications that have not recorded before."
+    }
+  ]
+  readonly property var experimentalDefinitions: [
+    {
+      key: "monitor.alsa.autodetect-hdmi-channels",
+      label: "Detect HDMI channel layout",
+      description: "Let WirePlumber infer HDMI channel counts. Experimental; some receivers report them incorrectly."
+    }
+  ]
+
+  readonly property var availableCore: supportedDefinitions(coreDefinitions)
+  readonly property var availableVolumes: supportedDefinitions(volumeDefinitions)
+  readonly property var availableExperimental: supportedDefinitions(experimentalDefinitions)
+
+  signal settled()
+
+  function supportedDefinitions(definitions) {
+    var supported = []
+    for (var i = 0; i < definitions.length; i++) {
+      var definition = definitions[i]
+      if (settings[definition.key] !== undefined) supported.push(definition)
+    }
+    return supported
+  }
+
+  function copySettings(source) {
+    var copy = ({})
+    for (var key in source) copy[key] = source[key]
+    return copy
+  }
+
+  function loadResponse(raw) {
+    var response = Model.parseAudioPolicySettings(raw)
+    responseValid = response.valid
+    if (!response.valid) return
+    settings = response.values
+    loaded = true
+  }
+
+  function refresh() {
+    loaded = false
+    if (busy) return
+    mutation = false
+    responseValid = false
+    pendingKey = ""
+    policyProc.command = [scriptPath]
+    policyProc.running = true
+  }
+
+  function clearError() {
+    error = ""
+  }
+
+  function setSetting(key, value) {
+    if (!loaded || busy || settings[key] === undefined) return
+    var current = settings[key]
+    var normalized
+    if (typeof current === "boolean") {
+      if (typeof value !== "boolean") return
+      normalized = value
+    } else {
+      normalized = Math.max(0, Math.min(1, Math.round(Number(value) * 20) / 20))
+      if (!isFinite(normalized)) return
+    }
+    if (normalized === current) return
+
+    error = ""
+    previousSettings = copySettings(settings)
+    var next = copySettings(settings)
+    next[key] = normalized
+    settings = next
+    mutation = true
+    responseValid = false
+    pendingKey = key
+    policyProc.command = [scriptPath, "set", key, String(normalized)]
+    policyProc.running = true
+  }
+
+  Process {
+    id: policyProc
+    stdout: StdioCollector {
+      waitForEnd: true
+      onStreamFinished: root.loadResponse(text)
+    }
+    onExited: function(exitCode) {
+      var wasMutation = root.mutation
+      if (exitCode !== 0 || !root.responseValid) {
+        root.settings = wasMutation ? root.previousSettings : ({})
+        root.loaded = true
+        root.error = wasMutation
+          ? "Could not change the audio safety policy"
+          : "Could not load audio safety policies"
+      } else {
+        root.error = ""
+      }
+      root.mutation = false
+      root.pendingKey = ""
+      root.previousSettings = ({})
+      root.settled()
+    }
+  }
+}

--- a/AudioRulesController.qml
+++ b/AudioRulesController.qml
@@ -1,0 +1,178 @@
+import QtQuick
+import Quickshell.Io
+import Quickshell.Services.Pipewire
+import "Model.js" as Model
+
+// Shared saved-rule registry and live routing catalog. Both plugin surfaces
+// observe the same store through this component, so filtering, aliases, and
+// offline device presentation cannot drift apart again.
+Item {
+  id: root
+
+  required property string rulesPath
+  required property string scriptPath
+  required property var nodes
+
+  property var rules: Model.parseAudioRules("")
+  property bool loaded: false
+  property string error: ""
+  readonly property bool busy: writeProc.running
+
+  readonly property var nodeGroups: Model.classifyAudioNodes(nodes)
+  readonly property var sinks: nodeGroups.sinks
+  readonly property var sources: nodeGroups.sources
+  readonly property var playbackStreams: nodeGroups.playbackStreams
+  readonly property var recordingStreams: nodeGroups.recordingStreams
+  readonly property var availableApplicationLabels: Model.availableRuleApplicationLabels(
+    playbackStreams, recordingStreams, rules.appRules)
+  readonly property var targetOptions: buildTargetOptions()
+  readonly property var managedDevices: buildManagedDevices()
+
+  signal writeFinished(bool success)
+
+  function aliasFor(name) {
+    return rules.devices.aliases[String(name || "")] || ""
+  }
+
+  function isHidden(name) {
+    return rules.devices.hidden.indexOf(String(name || "")) !== -1
+  }
+
+  function deviceLabel(name) {
+    var target = String(name || "")
+    if (target === "") return ""
+    var alias = aliasFor(target)
+    if (alias !== "") return alias
+    var groups = [sinks, sources]
+    for (var g = 0; g < groups.length; g++) {
+      for (var i = 0; i < groups[g].length; i++) {
+        var node = groups[g][i]
+        if (node && String(node.name || "") === target) return Model.nodeLabel(node)
+      }
+    }
+    return target
+  }
+
+  function targetIsLive(name) {
+    var target = String(name || "")
+    if (target === "") return false
+    for (var i = 0; i < sinks.length; i++)
+      if (sinks[i] && String(sinks[i].name || "") === target) return true
+    for (var j = 0; j < sources.length; j++)
+      if (sources[j] && String(sources[j].name || "") === target) return true
+    return false
+  }
+
+  function optionsFor(direction, storedTarget) {
+    var recording = direction === "recording"
+    var devices = recording ? sources : sinks
+    var options = [{
+      value: "",
+      label: recording ? "Follow default input" : "Follow default output"
+    }]
+    var stored = String(storedTarget || "")
+    for (var i = 0; i < devices.length; i++) {
+      var name = String(devices[i] ? devices[i].name || "" : "")
+      if (name !== "" && name !== stored)
+        options.push({ value: name, label: deviceLabel(name) })
+    }
+    if (stored !== "") options.push({ value: stored, label: deviceLabel(stored) })
+    return options
+  }
+
+  function buildTargetOptions() {
+    var options = []
+    var seen = []
+    var groups = [sinks, sources]
+    for (var g = 0; g < groups.length; g++) {
+      for (var i = 0; i < groups[g].length; i++) {
+        var name = String(groups[g][i] ? groups[g][i].name || "" : "")
+        if (name === "" || seen.indexOf(name) !== -1) continue
+        seen.push(name)
+        options.push({ value: name, label: deviceLabel(name) })
+      }
+    }
+    return options
+  }
+
+  function directionForTarget(name) {
+    var target = String(name || "")
+    for (var i = 0; i < sinks.length; i++)
+      if (sinks[i] && String(sinks[i].name || "") === target) return "playback"
+    for (var j = 0; j < sources.length; j++)
+      if (sources[j] && String(sources[j].name || "") === target) return "recording"
+    return ""
+  }
+
+  function buildManagedDevices() {
+    var devices = []
+    var seen = []
+
+    function push(name, liveLabel) {
+      var key = String(name || "")
+      if (key === "" || seen.indexOf(key) !== -1) return
+      seen.push(key)
+      var alias = root.aliasFor(key)
+      devices.push({
+        name: key,
+        title: alias !== "" ? alias : liveLabel,
+        favorite: root.rules.devices.favorites.indexOf(key) !== -1,
+        hidden: root.rules.devices.hidden.indexOf(key) !== -1
+      })
+    }
+
+    var i
+    for (i = 0; i < sinks.length; i++)
+      push(sinks[i] ? sinks[i].name : "", Model.nodeLabel(sinks[i]))
+    for (i = 0; i < sources.length; i++)
+      push(sources[i] ? sources[i].name : "", Model.nodeLabel(sources[i]))
+    for (i = 0; i < rules.devices.favorites.length; i++)
+      push(rules.devices.favorites[i], rules.devices.favorites[i])
+    for (i = 0; i < rules.devices.hidden.length; i++)
+      push(rules.devices.hidden[i], rules.devices.hidden[i])
+    for (var aliasName in rules.devices.aliases) push(aliasName, aliasName)
+
+    devices.sort(function(a, b) {
+      if (a.favorite !== b.favorite) return a.favorite ? -1 : 1
+      if (a.hidden !== b.hidden) return a.hidden ? 1 : -1
+      return 0
+    })
+    return devices
+  }
+
+  function write(args) {
+    if (busy) return false
+    error = ""
+    writeProc.command = [scriptPath].concat(args)
+    writeProc.running = true
+    return true
+  }
+
+  FileView {
+    path: root.rulesPath
+    watchChanges: true
+    printErrors: false
+    onLoaded: {
+      root.rules = Model.parseAudioRules(text())
+      root.loaded = true
+    }
+    onLoadFailed: {
+      root.rules = Model.parseAudioRules("")
+      root.loaded = true
+    }
+    onFileChanged: reload()
+  }
+
+  Process {
+    id: writeProc
+    onExited: function(exitCode) {
+      root.error = exitCode === 0 ? "" : "Could not update the audio rules"
+      root.writeFinished(exitCode === 0)
+    }
+  }
+
+  PwObjectTracker { objects: root.sinks }
+  PwObjectTracker { objects: root.sources }
+  PwObjectTracker { objects: root.playbackStreams }
+  PwObjectTracker { objects: root.recordingStreams }
+}

--- a/AudioRuntime.qml
+++ b/AudioRuntime.qml
@@ -1,0 +1,27 @@
+import QtQuick
+import Quickshell
+
+// Shared filesystem contract for both plugin entry points and their domain
+// controllers. Keeping it here prevents new tabs from inventing another copy
+// of the XDG fallback or URL-to-path conversion.
+QtObject {
+  id: root
+
+  readonly property string configHome: {
+    var configured = Quickshell.env("XDG_CONFIG_HOME")
+    return configured || Quickshell.env("HOME") + "/.config"
+  }
+  readonly property string settingsPath: configHome + "/omarchy/audio-control.json"
+  readonly property string preferencesPath: configHome + "/omarchy/audio-preferences.json"
+  readonly property string scenesPath: configHome + "/omarchy/audio-scenes.json"
+  readonly property string rulesPath: configHome + "/omarchy/audio-rules.json"
+  readonly property string scriptsDir: localPath(Qt.resolvedUrl("scripts/"))
+
+  function localPath(url) {
+    return decodeURIComponent(String(url).replace(/^file:\/\//, ""))
+  }
+
+  function script(name) {
+    return scriptsDir + "/" + String(name || "")
+  }
+}

--- a/AudioSceneController.qml
+++ b/AudioSceneController.qml
@@ -49,6 +49,7 @@ Item {
     for (var i = 0; i < nodes.length; i++) {
       var node = nodes[i]
       if (node && !node.isStream && !node.isSink && Model.isAudioSource(node)
+          && !Model.isInternalAudioNode(node.name) && !Model.isMonitorSource(node)
           && String(node.name || "") === target)
         return node
     }
@@ -57,15 +58,6 @@ Item {
 
   function findDevice(direction, name) {
     return direction === "input" ? findSource(name) : findSink(name)
-  }
-
-  function isInstrumentation(name) {
-    var lower = String(name || "").toLowerCase()
-    return lower === "quickshell" || lower.indexOf("omarchy_audio_test") === 0
-  }
-
-  function isMonitorSource(node) {
-    return String(node && node.name || "").toLowerCase().endsWith(".monitor")
   }
 
   function stereoIndices(node) {
@@ -213,9 +205,10 @@ Item {
     var devices = []
     for (var i = 0; i < nodes.length; i++) {
       var node = nodes[i]
-      if (!node || node.isStream || !node.audio || isInstrumentation(node.name)) continue
+      if (!node || node.ready !== true || node.isStream || !node.audio
+          || Model.isInternalAudioNode(node.name)) continue
       var direction = node.isSink ? "output" : (Model.isAudioSource(node) ? "input" : "")
-      if (direction === "" || isMonitorSource(node)) continue
+      if (direction === "" || Model.isMonitorSource(node)) continue
       devices.push({
         name: String(node.name || ""),
         direction: direction,
@@ -240,7 +233,7 @@ Item {
     var profiles = []
     var cards = Model.parseAudioProfiles(captureProfilesRaw)
     for (var k = 0; k < cards.length; k++) {
-      if (cards[k].activeProfile === "") continue
+      if (cards[k].activeProfile === "" || cards[k].activeProfile === "off") continue
       profiles.push({ card: cards[k].name, profile: cards[k].activeProfile })
     }
 
@@ -248,20 +241,21 @@ Item {
     var defaultSource = Pipewire.defaultAudioSource
     // A monitor source is not a microphone; storing it as the scene's
     // default input would only produce a skipped entry later.
-    captureFinished({
+    var capturedScene = Model.sanitizeSceneEntry({
       version: 1,
       name: captureName,
       savedAt: new Date().toISOString(),
       defaults: {
         output: Pipewire.defaultAudioSink && Pipewire.defaultAudioSink.name
           ? String(Pipewire.defaultAudioSink.name) : "",
-        input: defaultSource && defaultSource.name && !isMonitorSource(defaultSource)
+        input: defaultSource && defaultSource.name && !Model.isMonitorSource(defaultSource)
           ? String(defaultSource.name) : ""
       },
       devices: devices,
       ports: ports,
       profiles: profiles
     })
+    if (capturedScene) captureFinished(capturedScene)
   }
 
   Process {

--- a/Model.js
+++ b/Model.js
@@ -28,6 +28,43 @@ function isAudioSource(node) {
     || mediaClass.indexOf("Source") !== -1
 }
 
+function isInternalAudioNode(name) {
+  var value = String(name || "").trim().toLowerCase()
+  return value === "quickshell"
+    || value.indexOf("omarchy_audio_test") === 0
+    || value.indexOf("omarchy_speaker_tuning") === 0
+}
+
+function isMonitorSource(node) {
+  if (!node) return false
+  var name = String(node.name || "").toLowerCase()
+  var properties = nodeProps(node)
+  return name.endsWith(".monitor")
+    || String(properties["device.class"] || "").toLowerCase() === "monitor"
+}
+
+// Keep PipeWire classification in one place so every surface excludes the
+// plugin's own streams and monitor sources consistently. QML list properties
+// are array-like rather than true Arrays, hence the length-based input check.
+function classifyAudioNodes(nodes) {
+  var values = nodes && typeof nodes.length === "number" ? nodes : []
+  var result = { sinks: [], sources: [], playbackStreams: [], recordingStreams: [] }
+  for (var i = 0; i < values.length; i++) {
+    var node = values[i]
+    if (!node) continue
+    if (node.isStream) {
+      if (isInternalAudioNode(node.name)) continue
+      if (isPlaybackStream(node)) result.playbackStreams.push(node)
+      else if (isRecordingStream(node)) result.recordingStreams.push(node)
+      continue
+    }
+    if (node.isSink === true) result.sinks.push(node)
+    else if (isAudioSource(node) && !isInternalAudioNode(node.name) && !isMonitorSource(node))
+      result.sources.push(node)
+  }
+  return result
+}
+
 function listSnapshot(list) {
   return list && list.slice ? list.slice() : []
 }
@@ -265,7 +302,7 @@ function parseAudioRules(raw) {
     var rawList = Array.isArray(value) ? value : []
     for (var j = 0; j < rawList.length && out.length < maximum; j++) {
       var entry = sanitizeSceneString(rawList[j], "", 160)
-      if (entry !== "") out.push(entry)
+      if (entry !== "" && out.indexOf(entry) === -1) out.push(entry)
     }
     return out
   }
@@ -292,13 +329,53 @@ function findAppRule(rules, direction, appKey) {
   return null
 }
 
+function availableRuleApplicationLabels(playbackStreams, recordingStreams, rules) {
+  var candidates = []
+
+  function consider(node, direction) {
+    if (!node || node.ready !== true || !node.audio) return
+    var label = String(rawStreamLabel(node) || "").trim()
+    if (label === "") return
+    var key = label.toLowerCase()
+    var candidate = null
+    for (var i = 0; i < candidates.length; i++) {
+      if (candidates[i].key === key) {
+        candidate = candidates[i]
+        break
+      }
+    }
+    if (!candidate) {
+      candidate = { key: key, label: label, playback: false, recording: false }
+      candidates.push(candidate)
+    }
+    candidate[direction] = true
+  }
+
+  var playback = playbackStreams && typeof playbackStreams.length === "number"
+    ? playbackStreams : []
+  var recording = recordingStreams && typeof recordingStreams.length === "number"
+    ? recordingStreams : []
+  var i
+  for (i = 0; i < playback.length; i++) consider(playback[i], "playback")
+  for (i = 0; i < recording.length; i++) consider(recording[i], "recording")
+
+  var available = []
+  for (i = 0; i < candidates.length; i++) {
+    var value = candidates[i]
+    if ((value.playback && !findAppRule(rules, "playback", value.key))
+        || (value.recording && !findAppRule(rules, "recording", value.key)))
+      available.push(value.label)
+  }
+  return available
+}
+
 function deviceSortComparator(favorites) {
-  var ranks = {}
   var values = Array.isArray(favorites) ? favorites : []
-  for (var i = 0; i < values.length; i++) ranks[values[i]] = i
   return function(a, b) {
-    var ra = ranks.hasOwnProperty(a) ? ranks[a] : -1
-    var rb = ranks.hasOwnProperty(b) ? ranks[b] : -1
+    var aKey = String(a && typeof a === "object" ? a.name || "" : a || "")
+    var bKey = String(b && typeof b === "object" ? b.name || "" : b || "")
+    var ra = values.indexOf(aKey)
+    var rb = values.indexOf(bKey)
     var fa = ra >= 0 ? 0 : 1
     var fb = rb >= 0 ? 0 : 1
     if (fa !== fb) return fa - fb
@@ -565,54 +642,43 @@ function nodeSerial(node) {
   return serial === undefined || serial === null ? "" : String(serial)
 }
 
-function streamOutputOptions(outputs, defaultOutput, labelFor) {
+function deviceRouteOptions(devices, defaultDevice, followLabel, overridePrefix, labelFor) {
   labelFor = labelFor || nodeLabel
-  var values = Array.isArray(outputs) ? outputs : []
+  var values = Array.isArray(devices) ? devices : []
   var options = []
-  var defaultSerial = nodeSerial(defaultOutput)
+  var defaultSerial = nodeSerial(defaultDevice)
+  if (defaultSerial !== "")
+    options.push({ value: "default:" + defaultSerial, label: followLabel })
 
+  var seen = []
   for (var i = 0; i < values.length; i++) {
-    var candidate = values[i]
-    var serial = nodeSerial(candidate)
-    if (serial !== "" && serial === defaultSerial) {
-      options.push({ value: "default:" + serial, label: "Follow default output" })
-      options.push({ value: "override:" + serial, label: "Always use " + labelFor(candidate) })
-      break
-    }
+    var defaultCandidate = values[i]
+    if (nodeSerial(defaultCandidate) !== defaultSerial || defaultSerial === "") continue
+    seen.push(defaultSerial)
+    options.push({
+      value: "override:" + defaultSerial,
+      label: overridePrefix + labelFor(defaultCandidate)
+    })
+    break
   }
-
-  for (var j = 0; j < values.length; j++) {
-    var output = values[j]
-    var outputSerial = nodeSerial(output)
-    if (outputSerial === "" || outputSerial === defaultSerial) continue
-    options.push({ value: "override:" + outputSerial, label: "Always use " + labelFor(output) })
+  for (i = 0; i < values.length; i++) {
+    var device = values[i]
+    var serial = nodeSerial(device)
+    if (serial === "" || seen.indexOf(serial) !== -1) continue
+    seen.push(serial)
+    options.push({ value: "override:" + serial, label: overridePrefix + labelFor(device) })
   }
   return options
 }
 
+function streamOutputOptions(outputs, defaultOutput, labelFor) {
+  return deviceRouteOptions(outputs, defaultOutput,
+    "Follow default output", "Always use ", labelFor)
+}
+
 function recordingInputOptions(inputs, defaultInput, labelFor) {
-  labelFor = labelFor || nodeLabel
-  var values = Array.isArray(inputs) ? inputs : []
-  var options = []
-  var defaultSerial = nodeSerial(defaultInput)
-
-  for (var i = 0; i < values.length; i++) {
-    var candidate = values[i]
-    var serial = nodeSerial(candidate)
-    if (serial !== "" && serial === defaultSerial) {
-      options.push({ value: "default:" + serial, label: "Follow default input" })
-      options.push({ value: "override:" + serial, label: "Always use " + labelFor(candidate) })
-      break
-    }
-  }
-
-  for (var j = 0; j < values.length; j++) {
-    var input = values[j]
-    var inputSerial = nodeSerial(input)
-    if (inputSerial === "" || inputSerial === defaultSerial) continue
-    options.push({ value: "override:" + inputSerial, label: "Always use " + labelFor(input) })
-  }
-  return options
+  return deviceRouteOptions(inputs, defaultInput,
+    "Follow default input", "Always use ", labelFor)
 }
 
 function parseStreamOutputOption(value) {
@@ -874,6 +940,9 @@ if (typeof module !== "undefined") {
     isPlaybackStream: isPlaybackStream,
     isRecordingStream: isRecordingStream,
     isAudioSource: isAudioSource,
+    isInternalAudioNode: isInternalAudioNode,
+    isMonitorSource: isMonitorSource,
+    classifyAudioNodes: classifyAudioNodes,
     listSnapshot: listSnapshot,
     normalizedBluetoothAddress: normalizedBluetoothAddress,
     parseAudioPreferences: parseAudioPreferences,
@@ -885,6 +954,7 @@ if (typeof module !== "undefined") {
     sceneSummary: sceneSummary,
     parseAudioRules: parseAudioRules,
     findAppRule: findAppRule,
+    availableRuleApplicationLabels: availableRuleApplicationLabels,
     deviceSortComparator: deviceSortComparator,
     parseAudioPolicySettings: parseAudioPolicySettings,
     balanceValue: balanceValue,

--- a/Model.js
+++ b/Model.js
@@ -28,11 +28,13 @@ function isAudioSource(node) {
     || mediaClass.indexOf("Source") !== -1
 }
 
-function isInternalAudioNode(name) {
+function isInternalAudioNode(name, properties) {
   var value = String(name || "").trim().toLowerCase()
+  var props = properties && typeof properties === "object" ? properties : {}
   return value === "quickshell"
     || value.indexOf("omarchy_audio_test") === 0
     || value.indexOf("omarchy_speaker_tuning") === 0
+    || String(props["application.id"] || "") === "ssupt.audio-control"
 }
 
 function isMonitorSource(node) {
@@ -53,7 +55,7 @@ function classifyAudioNodes(nodes) {
     var node = values[i]
     if (!node) continue
     if (node.isStream) {
-      if (isInternalAudioNode(node.name)) continue
+      if (isInternalAudioNode(node.name, nodeProps(node))) continue
       if (isPlaybackStream(node)) result.playbackStreams.push(node)
       else if (isRecordingStream(node)) result.recordingStreams.push(node)
       continue
@@ -420,6 +422,160 @@ function parseAudioPolicySettings(raw) {
       values[volumeKey] = volume
   }
   return { valid: true, values: values }
+}
+
+function emptyAudioDiagnostics() {
+  return {
+    version: 1,
+    generatedAt: "",
+    healthy: false,
+    versions: { plugin: "", pipewire: "", wireplumber: "" },
+    graph: {
+      available: false,
+      active: false,
+      source: "configured",
+      rate: 0,
+      quantum: 0,
+      latencyMs: 0,
+      loadPercent: -1,
+      errors: 0,
+      activeNodes: 0
+    },
+    defaults: { output: "", input: "" },
+    services: [],
+    devices: [],
+    routes: [],
+    capabilities: {
+      speakerTest: false,
+      supportReport: false,
+      clipboard: false,
+      recovery: false,
+      topology: false
+    },
+    warnings: []
+  }
+}
+
+function parseAudioDiagnostics(raw) {
+  var parsed
+  try {
+    parsed = JSON.parse(String(raw || ""))
+  } catch (e) {
+    return { valid: false, value: emptyAudioDiagnostics() }
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)
+      || parsed.version !== 1 || !parsed.graph || typeof parsed.graph !== "object"
+      || !Array.isArray(parsed.services) || !Array.isArray(parsed.devices)
+      || !Array.isArray(parsed.routes) || !Array.isArray(parsed.warnings))
+    return { valid: false, value: emptyAudioDiagnostics() }
+
+  var value = emptyAudioDiagnostics()
+  value.generatedAt = sanitizeSceneString(parsed.generatedAt, "", 64)
+  value.healthy = parsed.healthy === true
+
+  var versions = parsed.versions && typeof parsed.versions === "object"
+    ? parsed.versions : {}
+  value.versions = {
+    plugin: sanitizeSceneString(versions.plugin, "", 32),
+    pipewire: sanitizeSceneString(versions.pipewire, "", 32),
+    wireplumber: sanitizeSceneString(versions.wireplumber, "", 32)
+  }
+
+  var graph = parsed.graph && typeof parsed.graph === "object" ? parsed.graph : {}
+  value.graph = {
+    available: graph.available === true,
+    active: graph.active === true,
+    source: graph.source === "active" ? "active" : "configured",
+    rate: Math.round(clampNumber(graph.rate, 0, 0, 768000)),
+    quantum: Math.round(clampNumber(graph.quantum, 0, 0, 1048576)),
+    latencyMs: clampNumber(graph.latencyMs, 0, 0, 60000),
+    loadPercent: clampNumber(graph.loadPercent, -1, -1, 100000),
+    errors: Math.round(clampNumber(graph.errors, 0, 0, 1000000000)),
+    activeNodes: Math.round(clampNumber(graph.activeNodes, 0, 0, 1000000))
+  }
+
+  var defaults = parsed.defaults && typeof parsed.defaults === "object"
+    ? parsed.defaults : {}
+  value.defaults = {
+    output: sanitizeSceneString(defaults.output, "", 240),
+    input: sanitizeSceneString(defaults.input, "", 240)
+  }
+
+  var rawServices = Array.isArray(parsed.services) ? parsed.services : []
+  for (var i = 0; i < rawServices.length && value.services.length < 8; i++) {
+    var service = rawServices[i]
+    if (!service || typeof service !== "object") continue
+    var serviceName = sanitizeSceneString(service.name, "", 80)
+    if (serviceName === "") continue
+    value.services.push({
+      name: serviceName,
+      label: sanitizeSceneString(service.label, serviceName, 80),
+      loadState: sanitizeSceneString(service.loadState, "unknown", 32),
+      activeState: sanitizeSceneString(service.activeState, "unknown", 32),
+      subState: sanitizeSceneString(service.subState, "unknown", 32),
+      active: service.active === true,
+      restarts: Math.round(clampNumber(service.restarts, 0, 0, 1000000))
+    })
+  }
+
+  var rawDevices = Array.isArray(parsed.devices) ? parsed.devices : []
+  for (var j = 0; j < rawDevices.length && value.devices.length < 64; j++) {
+    var device = rawDevices[j]
+    if (!device || typeof device !== "object") continue
+    var deviceName = sanitizeSceneString(device.name, "", 240)
+    var label = sanitizeSceneString(device.label, deviceName, 160)
+    if (deviceName === "" || label === "") continue
+    value.devices.push({
+      direction: device.direction === "input" ? "input" : "output",
+      name: deviceName,
+      label: label,
+      state: sanitizeSceneString(device.state, "unknown", 32),
+      format: sanitizeSceneString(device.format, "", 96),
+      channelMap: sanitizeSceneString(device.channelMap, "", 240),
+      channels: Math.round(clampNumber(device.channels, 0, 0, 64)),
+      port: sanitizeSceneString(device.port, "", 160),
+      profile: sanitizeSceneString(device.profile, "", 160),
+      codec: sanitizeSceneString(device.codec, "", 64),
+      bluetooth: device.bluetooth === true,
+      default: device.default === true
+    })
+  }
+
+  var rawRoutes = Array.isArray(parsed.routes) ? parsed.routes : []
+  for (var k = 0; k < rawRoutes.length && value.routes.length < 64; k++) {
+    var route = rawRoutes[k]
+    if (!route || typeof route !== "object" || !Array.isArray(route.labels)) continue
+    var labels = []
+    for (var l = 0; l < route.labels.length && labels.length < 16; l++) {
+      var routeLabel = sanitizeSceneString(route.labels[l], "", 160)
+      if (routeLabel !== "" && labels[labels.length - 1] !== routeLabel)
+        labels.push(routeLabel)
+    }
+    if (labels.length < 2) continue
+    value.routes.push({
+      direction: route.direction === "recording" ? "recording" : "playback",
+      labels: labels
+    })
+  }
+
+  var capabilities = parsed.capabilities && typeof parsed.capabilities === "object"
+    ? parsed.capabilities : {}
+  value.capabilities = {
+    speakerTest: capabilities.speakerTest === true,
+    supportReport: capabilities.supportReport === true,
+    clipboard: capabilities.clipboard === true,
+    recovery: capabilities.recovery === true,
+    topology: capabilities.topology === true
+  }
+
+  var rawWarnings = Array.isArray(parsed.warnings) ? parsed.warnings : []
+  for (var m = 0; m < rawWarnings.length && value.warnings.length < 32; m++) {
+    var warning = sanitizeSceneString(rawWarnings[m], "", 240)
+    if (warning !== "" && value.warnings.indexOf(warning) === -1)
+      value.warnings.push(warning)
+  }
+
+  return { valid: true, value: value }
 }
 
 function balanceValue(left, right) {
@@ -957,6 +1113,8 @@ if (typeof module !== "undefined") {
     availableRuleApplicationLabels: availableRuleApplicationLabels,
     deviceSortComparator: deviceSortComparator,
     parseAudioPolicySettings: parseAudioPolicySettings,
+    emptyAudioDiagnostics: emptyAudioDiagnostics,
+    parseAudioDiagnostics: parseAudioDiagnostics,
     balanceValue: balanceValue,
     applyBalance: applyBalance,
     audioMeterLevel: audioMeterLevel,

--- a/Panel.qml
+++ b/Panel.qml
@@ -13,51 +13,30 @@ Panel {
   moduleName: "omarchy.audio"
   ipcTarget: "omarchy.audio"
 
-  function pluginScript(name) {
-    var url = String(Qt.resolvedUrl("scripts/" + name))
-    return decodeURIComponent(url.replace(/^file:\/\//, ""))
-  }
+  AudioRuntime { id: runtime }
 
   readonly property var sink: Pipewire.defaultAudioSink
   readonly property var source: Pipewire.defaultAudioSource
   readonly property var nodes: Pipewire.nodes ? Pipewire.nodes.values : []
+  AudioRulesController {
+    id: rulesStore
+    nodes: root.nodes
+    rulesPath: runtime.rulesPath
+    scriptPath: runtime.script("audio-app-rules")
+    onRulesChanged: Qt.callLater(root.enforceRoutingRules)
+  }
   readonly property var mprisPlayers: Mpris.players ? Mpris.players.values : []
   readonly property var appLibrary: bar && bar.shell ? bar.shell.appLibrary : null
   readonly property var mediaService: bar && bar.shell
     ? bar.shell.firstPartyServiceFor("omarchy.media") : null
   readonly property var activeMediaPlayer: mediaService ? mediaService.activePlayer : null
-  readonly property string settingsPath: {
-    var configHome = Quickshell.env("XDG_CONFIG_HOME")
-    if (!configHome) configHome = Quickshell.env("HOME") + "/.config"
-    return configHome + "/omarchy/audio-control.json"
-  }
-  readonly property string audioPreferencesPath: {
-    var configHome = Quickshell.env("XDG_CONFIG_HOME")
-    if (!configHome) configHome = Quickshell.env("HOME") + "/.config"
-    return configHome + "/omarchy/audio-preferences.json"
-  }
-  readonly property string scenesPath: {
-    var configHome = Quickshell.env("XDG_CONFIG_HOME")
-    if (!configHome) configHome = Quickshell.env("HOME") + "/.config"
-    return configHome + "/omarchy/audio-scenes.json"
-  }
-  readonly property string rulesPath: {
-    var configHome = Quickshell.env("XDG_CONFIG_HOME")
-    if (!configHome) configHome = Quickshell.env("HOME") + "/.config"
-    return configHome + "/omarchy/audio-rules.json"
-  }
-  readonly property string scriptsDir: {
-    var url = String(Qt.resolvedUrl("scripts/"))
-    return decodeURIComponent(url.replace(/^file:\/\//, ""))
-  }
   property var audioPreferences: Model.parseAudioPreferences("")
   property bool outputOverdrive: false
   property bool captureNotifications: true
   property bool notificationsAvailable: false
   property var audioScenes: []
-  property bool scenesLoaded: false
-  property var audioRules: Model.parseAudioRules("")
-  property bool rulesLoaded: false
+  readonly property var audioRules: rulesStore.rules
+  readonly property bool rulesLoaded: rulesStore.loaded
   property string sceneFeedback: ""
   property bool sceneFeedbackIsError: false
   property var observedRecordingLabels: []
@@ -66,79 +45,13 @@ Panel {
   property bool inputClipping: false
   readonly property real outputVolumeMaximum: outputOverdrive ? 1.5 : 1.0
 
-  readonly property var candidateSinks: {
-    var list = []
-    for (var i = 0; i < nodes.length; i++) {
-      var n = nodes[i]
-      if (n && n.isSink && !n.isStream && !deviceHidden(n.name)) list.push(n)
-    }
-    return list
-  }
-
-  readonly property var candidateSources: {
-    var list = []
-    for (var i = 0; i < nodes.length; i++) {
-      var n = nodes[i]
-      if (n && !n.isSink && !n.isStream && isAudioSource(n)) {
-        var name = String(n.name || "").toLowerCase()
-        if (name === "quickshell") continue
-        if (deviceHidden(n.name)) continue
-        list.push(n)
-      }
-    }
-    return list
-  }
-
-  readonly property var candidateStreams: {
-    var list = []
-    for (var i = 0; i < nodes.length; i++) {
-      var n = nodes[i]
-      if (!n || !n.isStream || !isPlaybackStream(n)) continue
-      // A tuning's output is a playback stream too, but it is the processing
-      // itself rather than an application, so it does not belong in the list.
-      var nodeName = String(n.name || "")
-      if (nodeName.indexOf("omarchy_speaker_tuning") === 0
-          || nodeName.indexOf("omarchy_audio_test") === 0) continue
-      list.push(n)
-    }
-    return list
-  }
-
-  readonly property var candidateRecordingStreams: {
-    var list = []
-    for (var i = 0; i < nodes.length; i++) {
-      var n = nodes[i]
-      if (!n || !isRecordingStream(n)) continue
-      // The microphone peak meter creates its own capture stream while this
-      // panel is open; it is instrumentation, not a recording application.
-      var nodeName = String(n.name || "").toLowerCase()
-      if (nodeName === "quickshell" || nodeName.indexOf("omarchy_audio_test") === 0) continue
-      list.push(n)
-    }
-    return list
-  }
+  readonly property var candidateSinks: rulesStore.sinks
+  readonly property var candidateSources: rulesStore.sources
+  readonly property var candidateStreams: rulesStore.playbackStreams
+  readonly property var candidateRecordingStreams: rulesStore.recordingStreams
 
   property var sinkAvailability: ({})
   property bool sinkAvailabilityLoaded: false
-
-  // Identify true playback streams without reading node.properties here:
-  // PwNode.properties is invalid until the node is bound, and reading it while
-  // capture streams are appearing (for example, when Voxtype starts recording)
-  // can destabilize Quickshell's Pipewire service. Quickshell versions differ
-  // in how `type` is exposed (media.class, enum name, or numeric enum), but
-  // playback streams consistently accept audio input from clients and publish
-  // `isSink: true`; capture streams publish as stream sources.
-  function isPlaybackStream(node) {
-    return Model.isPlaybackStream(node)
-  }
-
-  function isRecordingStream(node) {
-    return Model.isRecordingStream(node)
-  }
-
-  function isAudioSource(node) {
-    return Model.isAudioSource(node)
-  }
 
   function loadAudioPreferences(raw) {
     audioPreferences = Model.parseAudioPreferences(raw)
@@ -171,23 +84,39 @@ Panel {
   readonly property var rawAudioSinks: {
     var list = []
     for (var i = 0; i < candidateSinks.length; i++)
-      if (sinkAvailable(candidateSinks[i])) list.push(candidateSinks[i])
-    if (sink && list.indexOf(sink) < 0) list.unshift(sink)
+      if (sinkAvailable(candidateSinks[i]) && !deviceHidden(candidateSinks[i].name))
+        list.push(candidateSinks[i])
+    if (sink && !deviceHidden(sink.name) && list.indexOf(sink) < 0) list.unshift(sink)
     var sorted = list.slice()
     sorted.sort(Model.deviceSortComparator(audioRules.devices.favorites))
     return sorted
   }
 
   readonly property var rawAudioSources: {
-    var list = candidateSources.slice()
-    if (source && list.indexOf(source) < 0) list.unshift(source)
+    var list = []
+    for (var i = 0; i < candidateSources.length; i++)
+      if (!deviceHidden(candidateSources[i].name)) list.push(candidateSources[i])
+    if (source && !Model.isMonitorSource(source) && !deviceHidden(source.name)
+        && list.indexOf(source) < 0) list.unshift(source)
     var sorted = list.slice()
     sorted.sort(Model.deviceSortComparator(audioRules.devices.favorites))
     return sorted
   }
 
-  readonly property var audioSinks: rawAudioSinks.length > 0 ? rawAudioSinks : cachedAudioSinks
-  readonly property var audioSources: rawAudioSources.length > 0 ? rawAudioSources : cachedAudioSources
+  readonly property var cachedVisibleAudioSinks: cachedAudioSinks.filter(function(node) {
+    return node && !deviceHidden(node.name)
+  })
+  readonly property var cachedVisibleAudioSources: cachedAudioSources.filter(function(node) {
+    return node && !deviceHidden(node.name) && !Model.isMonitorSource(node)
+  })
+  readonly property var audioSinks: rawAudioSinks.length > 0
+    ? rawAudioSinks : cachedVisibleAudioSinks
+  readonly property var audioSources: rawAudioSources.length > 0
+    ? rawAudioSources : cachedVisibleAudioSources
+  readonly property var routingSinks: candidateSinks.filter(function(node) {
+    return root.sinkAvailable(node)
+  })
+  readonly property var routingSources: candidateSources
   readonly property string preferredOutputName: Model.preferredAudioNodeName(
     audioPreferences, "output", sink, audioSinks)
   readonly property string preferredInputName: Model.preferredAudioNodeName(
@@ -713,7 +642,7 @@ Panel {
       mode: route.mode
     }
     streamRouteSetProc.command = [
-      pluginScript("audio-stream-route-set"),
+      runtime.script("audio-stream-route-set"),
       direction,
       streamSerialValue,
       route.sink,
@@ -736,8 +665,8 @@ Panel {
   // application starts while the mixer is closed. A per-stream cache keeps
   // a satisfied rule from issuing repeated moves.
   readonly property var enforceableGroups: [
-    { nodes: audioStreams, direction: "playback", devices: audioSinks },
-    { nodes: recordingStreams, direction: "recording", devices: audioSources }
+    { nodes: audioStreams, direction: "playback", devices: routingSinks },
+    { nodes: recordingStreams, direction: "recording", devices: routingSources }
   ]
   property var enforcedStreamRoutes: ({})
 
@@ -768,7 +697,7 @@ Panel {
 
         enforcedStreamRoutes[cacheKey] = rule.target
         streamRouteSetProc.command = [
-          pluginScript("audio-stream-route-set"),
+          runtime.script("audio-stream-route-set"),
           group.direction,
           serial,
           Model.nodeSerial(targetNode),
@@ -907,7 +836,7 @@ Panel {
     Pipewire.preferredDefaultAudioSink = node
     defaultOutputError = ""
     defaultSinkProc.command = [
-      pluginScript("audio-output-set-default"),
+      runtime.script("audio-output-set-default"),
       String(node.id),
       String(node.name),
       previousSinkName
@@ -922,7 +851,7 @@ Panel {
     Pipewire.preferredDefaultAudioSource = node
     defaultInputError = ""
     defaultSourceProc.command = [
-      pluginScript("audio-input-set-default"),
+      runtime.script("audio-input-set-default"),
       String(node.id),
       String(node.name),
       previousSourceName
@@ -946,13 +875,11 @@ Panel {
   }
 
   function deviceAlias(name) {
-    var key = String(name || "")
-    if (key === "") return ""
-    return audioRules.devices.aliases[key] || ""
+    return rulesStore.aliasFor(name)
   }
 
   function deviceHidden(name) {
-    return audioRules.devices.hidden.indexOf(String(name || "")) !== -1
+    return rulesStore.isHidden(name)
   }
 
   function nodeLabel(node) {
@@ -1049,11 +976,6 @@ Panel {
   implicitWidth: button.implicitWidth
   implicitHeight: button.implicitHeight
 
-  PwObjectTracker { objects: root.candidateSinks }
-  PwObjectTracker { objects: root.candidateSources }
-  PwObjectTracker { objects: root.audioStreams }
-  PwObjectTracker { objects: root.recordingStreams }
-
   PwNodePeakMonitor {
     id: inputPeakMonitor
     node: root.source
@@ -1062,7 +984,7 @@ Panel {
 
   FileView {
     id: settingsFile
-    path: root.settingsPath
+    path: runtime.settingsPath
     watchChanges: true
     printErrors: false
     onLoaded: root.loadAudioControlSettings(text())
@@ -1071,7 +993,7 @@ Panel {
   }
 
   FileView {
-    path: root.audioPreferencesPath
+    path: runtime.preferencesPath
     watchChanges: true
     printErrors: false
     onLoaded: root.loadAudioPreferences(text())
@@ -1080,40 +1002,21 @@ Panel {
   }
 
   FileView {
-    path: root.scenesPath
+    path: runtime.scenesPath
     watchChanges: true
     printErrors: false
     onLoaded: function() {
       root.audioScenes = Model.parseAudioScenes(text()).scenes
-      root.scenesLoaded = true
     }
     onLoadFailed: function() {
       root.audioScenes = []
-      root.scenesLoaded = true
-    }
-    onFileChanged: reload()
-  }
-
-  FileView {
-    path: root.rulesPath
-    watchChanges: true
-    printErrors: false
-    onLoaded: function() {
-      root.audioRules = Model.parseAudioRules(text())
-      root.rulesLoaded = true
-      Qt.callLater(root.enforceRoutingRules)
-    }
-    onLoadFailed: function() {
-      root.audioRules = Model.parseAudioRules("")
-      root.rulesLoaded = true
-      Qt.callLater(root.enforceRoutingRules)
     }
     onFileChanged: reload()
   }
 
   AudioSceneController {
     id: sceneController
-    scriptsDir: root.scriptsDir
+    scriptsDir: runtime.scriptsDir
     onApplyFinished: function(result) {
       var text = "Applied scene '" + result.name + "'"
       if (result.errors.length > 0)
@@ -1196,7 +1099,7 @@ Panel {
 
   Process {
     id: streamRoutesProc
-    command: [root.pluginScript("audio-stream-routes")]
+    command: [runtime.script("audio-stream-routes")]
     stdout: StdioCollector {
       waitForEnd: true
       onStreamFinished: root.updateStreamRoutes(text)
@@ -1221,8 +1124,8 @@ Panel {
       root.lastManualRouteSync = null
       if (exitCode === 0 && sync) {
         var args = sync.target === ""
-          ? [root.pluginScript("audio-app-rules"), "del-app", sync.app, sync.direction]
-          : [root.pluginScript("audio-app-rules"), "set-app", sync.app, sync.direction, sync.target]
+          ? [runtime.script("audio-app-rules"), "del-app", sync.app, sync.direction]
+          : [runtime.script("audio-app-rules"), "set-app", sync.app, sync.direction, sync.target]
         Quickshell.execDetached(args)
       }
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,13 @@ plugin code before enabling it.
 omarchy-plugin-validate .
 ```
 
+The two entry points own presentation and keyboard navigation. Shared behavior
+stays outside them: `Model.js` contains pure, Node-tested transformations;
+`AudioRuntime.qml` owns paths; focused controllers own policy, saved-rule,
+scene, and microphone-test lifecycles; and `scripts/` contains the guarded
+system mutations. Keep new diagnostics and recovery work behind the same
+controller boundary so it can be tested without growing either main view.
+
 Advanced Audio Control is derived from Omarchy's built-in audio widget and is
 distributed under the same MIT license.
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ instead of introducing a separate mixer application.
   whenever the application starts and the device is present.
 - Rename devices with aliases, mark favorites so they sort first, and hide
   devices everywhere.
+- Inspect PipeWire and WirePlumber health from a Diagnostics tab: graph rate,
+  quantum-derived scheduling latency, DSP load, XRUN/error counters, service
+  state, negotiated device formats and channel maps, and active routes through
+  filters to hardware.
+- Identify every reported speaker channel at a conservative level, copy a
+  privacy-conscious support report, and launch Omarchy's official audio
+  recovery behind an explicit confirmation.
 
 The bar audio icon uses left-click for the quick mixer, middle-click to mute or
 unmute the microphone, right-click to mute or unmute all audio, and the wheel to
@@ -51,13 +58,16 @@ More plugins by `ssupt`: [omarchy-plugins](https://github.com/ssupt/omarchy-plug
 ## Requirements
 
 - Omarchy Quattro
-- PipeWire with WirePlumber (`pactl`, `wpctl`, `pw-metadata`, `pw-record`, and
-  `pw-play`)
+- PipeWire with WirePlumber (`pactl`, `wpctl`, `pw-metadata`, `pw-dump`,
+  `pw-top`, `pw-record`, and `pw-play`)
+- ALSA utilities (`speaker-test`) and systemd user services (`systemctl`)
 - `notify-send` for optional capture-start notifications
-- `jq`, `hyprctl`, `timeout`, and `flock`
+- `jq`, `hyprctl`, `timeout`, `flock`, and `wl-copy`
 
-These commands are present in a standard Omarchy installation. The plugin does
-not require `sudo` or install a background service.
+These commands are present in a standard Omarchy installation. Routine controls
+do not require `sudo`, and the plugin does not install a background service.
+Omarchy recovery may request authorization only when it needs to reset a stuck
+USB audio device.
 
 Application routes use WirePlumber's native stream-target restoration. Choosing
 **Follow default output** removes the remembered target; choosing **Always use**
@@ -82,6 +92,15 @@ preferences in `~/.config/omarchy/audio-rules.json`; both are plugin-owned and
 edited through the **Scenes** and **Routing** tabs. Manual route changes on a
 pinned application update its rule, and choosing follow-default deletes it.
 Hidden devices disappear from the mixer until shown again in the Routing tab.
+
+The Diagnostics tab refreshes only while it is visible. Its support report
+contains versions, health counters, human-readable device formats, service
+states, and active route labels; it excludes logs, usernames, hostnames,
+configuration files, and internal device names. The speaker test performs one
+finite channel-identification pass on the current default output and can be
+stopped immediately. Recovery never runs silently: after confirmation it opens
+`omarchy-restart-audio` in Omarchy's visible presentation terminal so USB-reset
+messages or authorization requests cannot be hidden by the shell.
 
 ## Installation
 
@@ -126,9 +145,9 @@ omarchy-plugin-validate .
 The two entry points own presentation and keyboard navigation. Shared behavior
 stays outside them: `Model.js` contains pure, Node-tested transformations;
 `AudioRuntime.qml` owns paths; focused controllers own policy, saved-rule,
-scene, and microphone-test lifecycles; and `scripts/` contains the guarded
-system mutations. Keep new diagnostics and recovery work behind the same
-controller boundary so it can be tested without growing either main view.
+scene, microphone-test, and diagnostics lifecycles; and `scripts/` contains
+the guarded system interactions. Diagnostics remain read-only until a user
+chooses a finite speaker test or confirms the official Omarchy recovery.
 
 Advanced Audio Control is derived from Omarchy's built-in audio widget and is
 distributed under the same MIT license.

--- a/manifest.json
+++ b/manifest.json
@@ -2,9 +2,9 @@
   "schemaVersion": 1,
   "id": "ssupt.audio-control",
   "name": "Advanced Audio Control",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "author": "ssupt",
-  "description": "Advanced PipeWire and WirePlumber audio mixer for Omarchy: persistent per-application output and input routing with live meters; default devices, ports, profiles, Bluetooth codecs and autoswitch; volume boost and balance; safety policies; microphone privacy with recording badge and private mic test; audio scenes; offline per-application routing rules; device aliases, favorites, and hidden devices",
+  "description": "Advanced PipeWire and WirePlumber audio mixer for Omarchy: devices, Bluetooth codecs, safety policies, microphone privacy, audio scenes, persistent routing rules, graph and service diagnostics, channel tests, support reports, and guarded recovery",
   "kinds": [
     "bar-widget",
     "panel"
@@ -15,7 +15,7 @@
   },
   "barWidget": {
     "displayName": "Advanced Audio Control",
-    "description": "Advanced PipeWire and WirePlumber audio mixer for Omarchy: persistent per-application output and input routing with live meters; default devices, ports, profiles, Bluetooth codecs and autoswitch; volume boost and balance; safety policies; microphone privacy with recording badge and private mic test; audio scenes; offline per-application routing rules; device aliases, favorites, and hidden devices",
+    "description": "Advanced PipeWire and WirePlumber audio mixer for Omarchy: devices, Bluetooth codecs, safety policies, microphone privacy, audio scenes, persistent routing rules, graph and service diagnostics, channel tests, support reports, and guarded recovery",
     "category": "Audio",
     "allowMultiple": false
   },

--- a/scripts/audio-app-rules
+++ b/scripts/audio-app-rules
@@ -25,6 +25,9 @@ read_rules() {
       .version = 1
       | .appRules = (if (.appRules | type) == "array" then .appRules else [] end)
       | .devices = (if (.devices | type) == "object" then .devices else {} end)
+      | .devices.aliases = (if (.devices.aliases | type) == "object" then .devices.aliases else {} end)
+      | .devices.favorites = (if (.devices.favorites | type) == "array" then .devices.favorites else [] end)
+      | .devices.hidden = (if (.devices.hidden | type) == "array" then .devices.hidden else [] end)
     ' "$rules_file"
   else
     echo "Audio rules contain invalid JSON; refusing to overwrite them" >&2
@@ -96,7 +99,7 @@ case "$action" in
       write_rules '.version = 1 | .devices.aliases[$node] = $label' \
         --arg node "$node" --arg label "$label"
     else
-      write_rules '.version = 1 | .devices.aliases |= (delpaths([[$node]]))' \
+      write_rules '.version = 1 | .devices.aliases |= del(.[$node])' \
         --arg node "$node"
     fi
     ;;

--- a/scripts/audio-diagnostics
+++ b/scripts/audio-diagnostics
@@ -1,0 +1,470 @@
+#!/bin/bash
+
+# omarchy:summary=Inspect PipeWire health or copy a privacy-conscious support report
+# omarchy:group=audio
+# omarchy:args=[snapshot | report | copy-report]
+
+set -euo pipefail
+
+export LC_ALL=C
+
+action=${1:-snapshot}
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+fixture_dir=${AUDIO_CONTROL_DIAGNOSTICS_FIXTURE_DIR:-}
+recovery_command=${AUDIO_CONTROL_RECOVERY_COMMAND:-omarchy-restart-audio}
+recovery_launcher=${AUDIO_CONTROL_RECOVERY_LAUNCHER:-omarchy-launch-floating-terminal-with-presentation}
+speaker_command=${AUDIO_CONTROL_SPEAKER_TEST_COMMAND:-speaker-test}
+clipboard_command=${AUDIO_CONTROL_CLIPBOARD_COMMAND:-wl-copy}
+
+usage() {
+  echo "Usage: audio-diagnostics [snapshot | report | copy-report]" >&2
+  exit 1
+}
+
+(( $# <= 1 )) || usage
+case "$action" in
+  snapshot|report|copy-report) ;;
+  *) usage ;;
+esac
+
+command -v jq >/dev/null || {
+  echo "audio-diagnostics requires jq" >&2
+  exit 1
+}
+
+work_dir=$(mktemp -d)
+trap 'rm -rf -- "$work_dir"' EXIT
+warnings_file="$work_dir/warnings"
+: >"$warnings_file"
+
+warn() {
+  printf '%s\n' "$1" >>"$warnings_file"
+}
+
+capture() {
+  local key=$1
+  shift
+  local destination="$work_dir/$key"
+  local fixture="${fixture_dir:+$fixture_dir/$key}"
+
+  if [[ -n $fixture && -f $fixture && ! -L $fixture ]]; then
+    cp -- "$fixture" "$destination"
+    return 0
+  fi
+
+  if timeout 4s "$@" >"$destination" 2>"$destination.error"; then
+    return 0
+  fi
+
+  : >"$destination"
+  return 1
+}
+
+metadata_value() {
+  local key=$1
+  sed -n "s/.*key:'$key' value:'\\([^']*\\)'.*/\\1/p" "$work_dir/metadata.txt" |
+    head -n 1
+}
+
+numeric_or_zero() {
+  local value=$1
+  [[ $value =~ ^[0-9]+$ ]] && printf '%s\n' "$value" || printf '%s\n' 0
+}
+
+version_from() {
+  grep -Eo '[0-9]+([.][0-9]+)+' "$1" 2>/dev/null | head -n 1 || true
+}
+
+service_snapshot() {
+  local unit=$1
+  local label=$2
+  local output active sub_state load_state restarts
+
+  if output=$(timeout 3s systemctl --user show "$unit" \
+      --property=LoadState,ActiveState,SubState,NRestarts --no-pager 2>/dev/null); then
+    load_state=$(sed -n 's/^LoadState=//p' <<<"$output")
+    active=$(sed -n 's/^ActiveState=//p' <<<"$output")
+    sub_state=$(sed -n 's/^SubState=//p' <<<"$output")
+    restarts=$(numeric_or_zero "$(sed -n 's/^NRestarts=//p' <<<"$output")")
+  else
+    load_state=unavailable
+    active=unknown
+    sub_state=unknown
+    restarts=0
+  fi
+
+  jq -nc --arg name "$unit" --arg label "$label" --arg loadState "$load_state" \
+    --arg activeState "$active" --arg subState "$sub_state" --argjson restarts "$restarts" '
+      {
+        name: $name,
+        label: $label,
+        loadState: $loadState,
+        activeState: $activeState,
+        subState: $subState,
+        active: ($activeState == "active" and $subState == "running"),
+        restarts: $restarts
+      }
+    '
+}
+
+build_routes() {
+  jq '
+    def props: (.info.props // {});
+    [ .[]
+      | select(.type == "PipeWire:Interface:Node")
+      | {
+          id: .id,
+          class: (props["media.class"] // ""),
+          internal: ((props["application.id"] // "") == "ssupt.audio-control"),
+          # Media titles and raw node names can contain private content or
+          # hardware identifiers. A route needs roles, not those identifiers.
+          label: ((props["application.name"] // props["node.description"]
+            // props["node.nick"]
+            // (if ((props["media.class"] // "") | startswith("Stream/"))
+              then "Audio application" else "Audio node" end)) | tostring)
+        }
+    ] as $nodes
+    | [ .[]
+        | select(.type == "PipeWire:Interface:Link"
+          and (.info.state == "active" or .info.state == "paused"))
+        | { from: .info["output-node-id"], to: .info["input-node-id"] }
+      ] | unique_by([.from, .to]) as $links
+    | def node_label($id):
+        first($nodes[] | select(.id == $id) | .label) // "Unavailable audio node";
+      def neighbours($id; $reverse):
+        if $reverse then
+          [ $links[] | select(.to == $id) | .from ]
+        else
+          [ $links[] | select(.from == $id) | .to ]
+        end;
+      def walk($id; $reverse; $seen):
+        if ($seen | index($id)) != null or ($seen | length) >= 15 then [$id]
+        else
+          neighbours($id; $reverse) as $next
+          | if ($next | length) == 0 then [$id]
+            else $next[] as $candidate
+              | [$id] + walk($candidate; $reverse; $seen + [$id])
+            end
+        end;
+      ([ $nodes[]
+         | select(.class == "Stream/Output/Audio" and (.internal | not))
+         | .id as $start
+         | { direction: "playback", ids: walk($start; false; []) }
+       ]
+       +
+       [ $nodes[]
+         | select(.class == "Stream/Input/Audio" and (.internal | not))
+         | .id as $start
+         | { direction: "recording", ids: walk($start; true; []) }
+       ])
+    | map(. + { labels: [ .ids[] | node_label(.) ] } | del(.ids))
+    | map(select((.labels | length) > 1))
+    | unique_by(.direction + ":" + (.labels | join(" > ")))
+    | .[:64]
+  ' "$work_dir/dump.json" 2>/dev/null || printf '[]\n'
+}
+
+build_snapshot() {
+  local metadata_ok=false top_ok=false sinks_ok=false sources_ok=false endpoints_ok=false dump_ok=false
+  local plugin_version pipewire_version wireplumber_version configured_rate configured_quantum
+  local default_sink default_source recovery_path recovery_launcher_path speaker_path clipboard_path
+
+  capture metadata.txt pw-metadata -n settings 0 && metadata_ok=true ||
+    warn "PipeWire graph settings could not be read."
+  capture pw-top.txt pw-top -b -n 1 && top_ok=true ||
+    warn "Live PipeWire processing statistics could not be read."
+  capture sinks.json pactl -f json list sinks && sinks_ok=true || {
+    printf '[]\n' >"$work_dir/sinks.json"
+    warn "Playback devices could not be inspected."
+  }
+  capture sources.json pactl -f json list sources && sources_ok=true || {
+    printf '[]\n' >"$work_dir/sources.json"
+    warn "Recording devices could not be inspected."
+  }
+  if $sinks_ok && $sources_ok &&
+      jq -e 'type == "array"' "$work_dir/sinks.json" >/dev/null 2>&1 &&
+      jq -e 'type == "array"' "$work_dir/sources.json" >/dev/null 2>&1; then
+    endpoints_ok=true
+  else
+    printf '[]\n' >"$work_dir/sinks.json"
+    printf '[]\n' >"$work_dir/sources.json"
+    if $sinks_ok && $sources_ok; then
+      warn "PipeWire returned malformed endpoint information."
+    fi
+  fi
+  capture pactl-info.txt pactl info || :
+  if capture dump.json pw-dump; then
+    if jq -e 'type == "array"' "$work_dir/dump.json" >/dev/null 2>&1; then
+      dump_ok=true
+    else
+      printf '[]\n' >"$work_dir/dump.json"
+      warn "PipeWire returned a malformed graph snapshot."
+    fi
+  else
+    printf '[]\n' >"$work_dir/dump.json"
+    warn "The active PipeWire route graph could not be inspected."
+  fi
+
+  if ! capture pipewire-version.txt pw-top --version; then
+    capture pipewire-version.txt pw-top -V || :
+  fi
+  capture wireplumber-version.txt wireplumber --version || :
+  plugin_version=$(jq -r '
+    if (.version | type) == "string" then .version else "" end
+  ' "$script_dir/../manifest.json" 2>/dev/null || true)
+  pipewire_version=$(version_from "$work_dir/pipewire-version.txt")
+  wireplumber_version=$(version_from "$work_dir/wireplumber-version.txt")
+
+  configured_rate=$(numeric_or_zero "$(metadata_value clock.rate)")
+  configured_quantum=$(numeric_or_zero "$(metadata_value clock.quantum)")
+
+  jq -r '
+    .[]
+    | select(.type == "PipeWire:Interface:Node")
+    | select(((.info.props["media.class"] // "") | contains("Audio")))
+    | .id
+  ' "$work_dir/dump.json" 2>/dev/null >"$work_dir/audio-node-ids.txt" ||
+    : >"$work_dir/audio-node-ids.txt"
+
+  awk '
+    BEGIN { load = -1; errors = 0; active = 0; rate = 0; quantum = 0; audioCount = 0 }
+    FILENAME == ARGV[1] {
+      if ($1 ~ /^[0-9]+$/) { audio[$1] = 1; audioCount++ }
+      next
+    }
+    FNR > 1 && $2 ~ /^[0-9]+$/ {
+      if (audioCount > 0 && !($2 in audio)) next
+      if ($1 ~ /^[RrTt]$/) active++
+      if ($7 ~ /^[0-9]+([.][0-9]+)?$/ && ($7 + 0) > load) load = $7 + 0
+      if ($9 ~ /^[0-9]+$/) errors += $9
+      if (rate == 0 && $1 ~ /^[RrTt]$/ && $3 ~ /^[1-9][0-9]*$/ && $4 ~ /^[1-9][0-9]*$/) {
+        quantum = $3 + 0
+        rate = $4 + 0
+      }
+    }
+    END {
+      printf "{\"activeRate\":%d,\"activeQuantum\":%d,\"loadPercent\":%.2f,\"errors\":%d,\"activeNodes\":%d}\n", rate, quantum, load < 0 ? -1 : load * 100, errors, active
+    }
+  ' "$work_dir/audio-node-ids.txt" "$work_dir/pw-top.txt" >"$work_dir/top.json"
+
+  if [[ -n $fixture_dir && -f $fixture_dir/services.json && ! -L $fixture_dir/services.json ]]; then
+    cp -- "$fixture_dir/services.json" "$work_dir/services.json"
+  else
+    {
+      service_snapshot pipewire.service PipeWire
+      service_snapshot wireplumber.service WirePlumber
+      service_snapshot pipewire-pulse.service "PipeWire Pulse"
+    } | jq -s '.' >"$work_dir/services.json"
+  fi
+  jq -e 'type == "array"' "$work_dir/services.json" >/dev/null 2>&1 ||
+    printf '[]\n' >"$work_dir/services.json"
+
+  if ! jq -e 'length == 3 and all(.[]; .active == true)' "$work_dir/services.json" >/dev/null; then
+    warn "One or more audio services are not running normally."
+  fi
+
+  default_sink=$(sed -n 's/^Default Sink:[[:space:]]*//p' "$work_dir/pactl-info.txt" | head -n 1)
+  default_source=$(sed -n 's/^Default Source:[[:space:]]*//p' "$work_dir/pactl-info.txt" | head -n 1)
+  if [[ -n $default_source ]] && jq -e --arg source "$default_source" '
+      any(.[]; .name == $source and ((.monitor_source // "") != ""
+        or (.properties["device.class"] // "") == "monitor"))
+    ' "$work_dir/sources.json" >/dev/null; then
+    default_source=""
+  fi
+
+  jq --arg defaultSink "$default_sink" '
+    def channel_count:
+      try ((.sample_specification // "")
+        | capture("(?<count>[0-9]+)ch").count | tonumber) catch 0;
+    [ .[] | {
+        direction: "output",
+        name: ((.name // "") | tostring),
+        label: ((.description // .name // "Unknown output") | tostring),
+        state: ((.state // "unknown") | ascii_downcase),
+        format: ((.sample_specification // "") | tostring),
+        channelMap: ((.channel_map // "") | tostring),
+        channels: channel_count,
+        port: (if (.active_port | type) == "object"
+          then ((.active_port.description // .active_port.name // "") | tostring)
+          else ((.active_port // "") | tostring) end),
+        profile: ((.properties["device.profile.description"]
+          // .properties["device.profile.name"] // "") | tostring),
+        codec: ((.properties["bluetooth.codec"] // .properties["api.bluez5.codec"]
+          // .properties["bluez5.codec"] // "") | tostring),
+        bluetooth: ((.properties["device.bus"] // "") == "bluetooth"
+          or ((.name // "") | startswith("bluez_"))),
+        default: ((.name // "") == $defaultSink)
+      } ]
+  ' "$work_dir/sinks.json" >"$work_dir/output-devices.json"
+
+  jq --arg defaultSource "$default_source" '
+    def channel_count:
+      try ((.sample_specification // "")
+        | capture("(?<count>[0-9]+)ch").count | tonumber) catch 0;
+    [ .[]
+      | select((.monitor_source // "") == ""
+        and (.properties["device.class"] // "") != "monitor")
+      | {
+          direction: "input",
+          name: ((.name // "") | tostring),
+          label: ((.description // .name // "Unknown input") | tostring),
+          state: ((.state // "unknown") | ascii_downcase),
+          format: ((.sample_specification // "") | tostring),
+          channelMap: ((.channel_map // "") | tostring),
+          channels: channel_count,
+          port: (if (.active_port | type) == "object"
+            then ((.active_port.description // .active_port.name // "") | tostring)
+            else ((.active_port // "") | tostring) end),
+          profile: ((.properties["device.profile.description"]
+            // .properties["device.profile.name"] // "") | tostring),
+          codec: ((.properties["bluetooth.codec"] // .properties["api.bluez5.codec"]
+            // .properties["bluez5.codec"] // "") | tostring),
+          bluetooth: ((.properties["device.bus"] // "") == "bluetooth"
+            or ((.name // "") | startswith("bluez_"))),
+          default: ((.name // "") == $defaultSource)
+        }
+    ]
+  ' "$work_dir/sources.json" >"$work_dir/input-devices.json"
+
+  jq -s 'add | sort_by(.direction, (.default | not), (.label | ascii_downcase))' \
+    "$work_dir/output-devices.json" "$work_dir/input-devices.json" >"$work_dir/devices.json"
+  build_routes >"$work_dir/routes.json"
+
+  recovery_path=$(command -v "$recovery_command" 2>/dev/null || true)
+  recovery_launcher_path=$(command -v "$recovery_launcher" 2>/dev/null || true)
+  speaker_path=$(command -v "$speaker_command" 2>/dev/null || true)
+  clipboard_path=$(command -v "$clipboard_command" 2>/dev/null || true)
+  [[ -n $default_sink ]] || warn "No default playback device is currently available."
+
+  if jq -e '.errors > 0' "$work_dir/top.json" >/dev/null; then
+    warn "PipeWire reports XRUNs or processing errors in the current graph."
+  fi
+
+  jq -Rsc 'split("\n") | map(select(length > 0)) | unique' \
+    "$warnings_file" >"$work_dir/warnings.json"
+
+  jq -n \
+    --arg generatedAt "$(date --iso-8601=seconds)" \
+    --arg pluginVersion "$plugin_version" \
+    --arg pipewireVersion "$pipewire_version" \
+    --arg wireplumberVersion "$wireplumber_version" \
+    --arg defaultOutput "$default_sink" \
+    --arg defaultInput "$default_source" \
+    --argjson configuredRate "$configured_rate" \
+    --argjson configuredQuantum "$configured_quantum" \
+    --argjson metadataAvailable "$metadata_ok" \
+    --argjson topAvailable "$top_ok" \
+    --argjson endpointsAvailable "$endpoints_ok" \
+    --argjson topologyAvailable "$dump_ok" \
+    --argjson speakerAvailable "$([[ -n $speaker_path && -n $default_sink ]] && echo true || echo false)" \
+    --argjson clipboardAvailable "$([[ -n $clipboard_path ]] && echo true || echo false)" \
+    --argjson recoveryAvailable "$([[ -n $recovery_path && -n $recovery_launcher_path ]] && echo true || echo false)" \
+    --slurpfile top "$work_dir/top.json" \
+    --slurpfile services "$work_dir/services.json" \
+    --slurpfile devices "$work_dir/devices.json" \
+    --slurpfile routes "$work_dir/routes.json" \
+    --slurpfile warnings "$work_dir/warnings.json" '
+      ($top[0] // {}) as $stats
+      | (($stats.activeRate // 0) | if . > 0 then . else $configuredRate end) as $rate
+      | (($stats.activeQuantum // 0) | if . > 0 then . else $configuredQuantum end) as $quantum
+      | {
+          version: 1,
+          generatedAt: $generatedAt,
+          healthy: (($services[0] | length) == 3
+            and all($services[0][]; .active == true)
+            and $endpointsAvailable),
+          versions: {
+            plugin: $pluginVersion,
+            pipewire: $pipewireVersion,
+            wireplumber: $wireplumberVersion
+          },
+          graph: {
+            available: ($metadataAvailable or $topAvailable),
+            active: (($stats.activeNodes // 0) > 0),
+            source: (if ($stats.activeRate // 0) > 0 then "active" else "configured" end),
+            rate: $rate,
+            quantum: $quantum,
+            latencyMs: (if $rate > 0 and $quantum > 0
+              then (($quantum * 10000 / $rate | round) / 10) else 0 end),
+            loadPercent: ($stats.loadPercent // -1),
+            errors: ($stats.errors // 0),
+            activeNodes: ($stats.activeNodes // 0)
+          },
+          defaults: { output: $defaultOutput, input: $defaultInput },
+          services: ($services[0] // []),
+          devices: ($devices[0] // []),
+          routes: ($routes[0] // []),
+          capabilities: {
+            speakerTest: $speakerAvailable,
+            supportReport: true,
+            clipboard: $clipboardAvailable,
+            recovery: $recoveryAvailable,
+            topology: $topologyAvailable
+          },
+          warnings: ($warnings[0] // [])
+        }
+    '
+}
+
+print_report() {
+  jq -r '
+    def shown($value): if ($value // "") == "" then "unknown" else $value end;
+    def safe: tostring
+      | gsub("([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}"; "[redacted-address]");
+    def load:
+      if .graph.loadPercent >= 0 then ((.graph.loadPercent * 10 | round) / 10 | tostring) + "%"
+      else "idle/unavailable" end;
+    [
+      "Advanced Audio Control support report",
+      "Generated: " + shown(.generatedAt),
+      "",
+      "Versions",
+      "  Advanced Audio Control: " + shown(.versions.plugin),
+      "  PipeWire: " + shown(.versions.pipewire),
+      "  WirePlumber: " + shown(.versions.wireplumber),
+      "",
+      "Graph",
+      "  Health: " + (if .healthy then "healthy" else "attention required" end),
+      "  Rate / quantum (" + .graph.source + "): " + (.graph.rate | tostring)
+        + " Hz / " + (.graph.quantum | tostring),
+      "  Scheduling latency: " + (.graph.latencyMs | tostring) + " ms",
+      "  Peak DSP load: " + load,
+      "  XRUNs/errors: " + (.graph.errors | tostring),
+      "",
+      "Services",
+      (.services[]? | "  " + .label + ": " + .activeState + "/" + .subState
+        + " (restarts " + (.restarts | tostring) + ")"),
+      "",
+      "Devices",
+      (.devices[]? | "  " + (if .direction == "output" then "Output" else "Input" end)
+        + (if .default then " [default]" else "" end) + ": " + (.label | safe)
+        + " · " + shown(.format) + " · " + shown(.channelMap)
+        + (if .profile != "" then " · " + .profile else "" end)
+        + (if .codec != "" then " · codec " + .codec else "" end)),
+      "",
+      "Active routes",
+      (if (.routes | length) == 0 then "  None reported"
+        else (.routes[] | "  " + .direction + ": " + ([.labels[] | safe] | join(" -> "))) end),
+      "",
+      "Warnings",
+      (if (.warnings | length) == 0 then "  None"
+        else (.warnings[] | "  " + .) end),
+      "",
+      "This report omits logs, usernames, hostnames, configuration files and internal device identifiers."
+    ] | .[]
+  '
+}
+
+snapshot=$(build_snapshot)
+case "$action" in
+  snapshot) printf '%s\n' "$snapshot" ;;
+  report) print_report <<<"$snapshot" ;;
+  copy-report)
+    clipboard_path=$(command -v "$clipboard_command" 2>/dev/null || true)
+    [[ -n $clipboard_path ]] || {
+      echo "No Wayland clipboard command is available" >&2
+      exit 1
+    }
+    print_report <<<"$snapshot" | "$clipboard_path"
+    ;;
+esac

--- a/scripts/audio-microphone-test
+++ b/scripts/audio-microphone-test
@@ -70,7 +70,7 @@ case "$action" in
       --target "$source_name" \
       --media-category Capture \
       --media-role Communication \
-      --properties '{"node.name":"omarchy_audio_test_record","application.name":"Advanced Audio Control","media.name":"Microphone test"}' \
+      --properties '{"node.name":"omarchy_audio_test_record","application.id":"ssupt.audio-control","application.name":"Advanced Audio Control","media.name":"Microphone test"}' \
       --rate "$sample_rate" \
       --channels "$channel_count" \
       --format s16 \
@@ -133,7 +133,7 @@ case "$action" in
     command -v pw-play >/dev/null
     exec pw-play \
       --media-role Communication \
-      --properties '{"node.name":"omarchy_audio_test_playback","application.name":"Advanced Audio Control","media.name":"Microphone test playback"}' \
+      --properties '{"node.name":"omarchy_audio_test_playback","application.id":"ssupt.audio-control","application.name":"Advanced Audio Control","media.name":"Microphone test playback"}' \
       --volume 0.8 \
       --rate "$sample_rate" \
       --channels "$channel_count" \

--- a/scripts/audio-recovery
+++ b/scripts/audio-recovery
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# omarchy:summary=Open Omarchy's official audio recovery in a visible terminal
+# omarchy:group=audio
+
+set -euo pipefail
+
+(( $# == 0 )) || {
+  echo "Usage: audio-recovery" >&2
+  exit 1
+}
+
+recovery_command=${AUDIO_CONTROL_RECOVERY_COMMAND:-omarchy-restart-audio}
+recovery_launcher=${AUDIO_CONTROL_RECOVERY_LAUNCHER:-omarchy-launch-floating-terminal-with-presentation}
+recovery_path=$(command -v "$recovery_command")
+launcher_path=$(command -v "$recovery_launcher")
+
+# The official recovery may need to explain a stuck USB device or request
+# authorization for usbreset. Never hide that interaction inside the shell.
+"$launcher_path" "$recovery_path" >/dev/null 2>&1 &

--- a/scripts/audio-scenes
+++ b/scripts/audio-scenes
@@ -77,6 +77,23 @@ case "$action" in
         exit 1
       }
     fi
+    # The command argument is authoritative, and safety invariants belong in
+    # the store as well as in the QML parser. This keeps hand-written/imported
+    # scenes from persisting output mutes or card power-off profiles.
+    scene_json=$(jq -c --arg name "$name" '
+      .name = $name
+      | .devices = (
+          if (.devices | type) == "array" then
+            [.devices[] | if type == "object" and .direction == "output"
+              then .muted = false else . end]
+          else [] end
+        )
+      | .profiles = (
+          if (.profiles | type) == "array" then
+            [.profiles[] | select(type != "object" or (.profile? // "") != "off")]
+          else [] end
+        )
+    ' <<<"$scene_json") || exit 1
     write_scenes '
       .version = 1
       | .scenes = (

--- a/scripts/audio-speaker-test
+++ b/scripts/audio-speaker-test
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# omarchy:summary=Play one guarded channel-identification pass on an audio output
+# omarchy:group=audio
+# omarchy:args=<sink-name>
+
+set -euo pipefail
+
+(( $# == 1 )) || {
+  echo "Usage: audio-speaker-test <sink-name>" >&2
+  exit 1
+}
+
+sink_name=$1
+speaker_command=${AUDIO_CONTROL_SPEAKER_TEST_COMMAND:-speaker-test}
+[[ -n $sink_name && $sink_name != *.monitor ]] || exit 1
+command -v jq >/dev/null
+speaker_path=$(command -v "$speaker_command")
+
+sink=$(pactl -f json list sinks | jq -cer --arg sink "$sink_name" '
+  first(.[] | select(.name == $sink))
+') || {
+  echo "The selected output is no longer available" >&2
+  exit 2
+}
+
+channels=$(jq -er '
+  try ((.sample_specification // "")
+    | capture("(?<count>[0-9]+)ch").count | tonumber) catch 0
+' <<<"$sink")
+[[ $channels =~ ^[1-9][0-9]*$ ]] || {
+  echo "The selected output does not report a testable channel layout" >&2
+  exit 2
+}
+
+# This core diagnostic deliberately caps the test at 7.1. Larger mappings
+# belong to the optional studio plugin, where remapping is explicit.
+(( channels > 8 )) && channels=8
+
+export PULSE_SINK=$sink_name
+export PULSE_PROP="application.id=ssupt.audio-control application.name='Advanced Audio Control' media.name='Speaker channel test'"
+exec "$speaker_path" -D pulse -c "$channels" -t wav -l 1 -S 35

--- a/test/all
+++ b/test/all
@@ -169,6 +169,56 @@ assert.deepEqual(model.recordingInputOptions([defaultInput, headsetInput], defau
   { value: 'override:20', label: 'Always use Desk Microphone' },
   { value: 'override:21', label: 'Always use Headset Microphone' }
 ])
+// Following the default remains available when that device is hidden from the
+// picker; only the explicit "Always use" choice disappears.
+assert.deepEqual(model.streamOutputOptions([headphones], defaultOutput), [
+  { value: 'default:10', label: 'Follow default output' },
+  { value: 'override:11', label: 'Always use Headphones' }
+])
+
+const playbackStream = {
+  name: 'firefox', isStream: true, isSink: true, ready: true, audio: {},
+  properties: { 'application.name': 'Firefox' }
+}
+const recordingStream = {
+  name: 'firefox-capture', isStream: true, isSink: false, ready: true, audio: {},
+  properties: { 'application.name': 'Firefox' }
+}
+const vlcStream = {
+  name: 'vlc', isStream: true, isSink: true, ready: true, audio: {},
+  properties: { 'application.name': 'VLC' }
+}
+const obsStream = {
+  name: 'obs', isStream: true, isSink: false, ready: true, audio: {},
+  properties: { 'application.name': 'OBS' }
+}
+const classified = model.classifyAudioNodes([
+  { name: 'speakers', isStream: false, isSink: true },
+  { name: 'microphone', isStream: false, isSink: false, ready: true, audio: {} },
+  { name: 'speakers.monitor', isStream: false, isSink: false, ready: true, audio: {} },
+  playbackStream,
+  recordingStream,
+  { name: 'omarchy_speaker_tuning_output', isStream: true, isSink: true },
+  { name: 'omarchy_audio_test_record', isStream: true, isSink: false }
+])
+assert.deepEqual(classified.sinks.map(node => node.name), ['speakers'])
+assert.deepEqual(classified.sources.map(node => node.name), ['microphone'])
+assert.deepEqual(classified.playbackStreams.map(node => node.name), ['firefox'])
+assert.deepEqual(classified.recordingStreams.map(node => node.name), ['firefox-capture'])
+
+assert.deepEqual(model.availableRuleApplicationLabels(
+  [playbackStream, vlcStream], [recordingStream, obsStream], [
+    { app: 'firefox', direction: 'playback', target: 'speakers' },
+    { app: 'obs', direction: 'recording', target: 'microphone' }
+  ]
+), ['Firefox', 'VLC'])
+assert.deepEqual(model.parseAudioRules(JSON.stringify({
+  devices: { favorites: ['speakers', 'speakers'], hidden: ['mic', 'mic'] }
+})).devices, { aliases: {}, favorites: ['speakers'], hidden: ['mic'] })
+assert.deepEqual(['other', 'hasOwnProperty'].sort(
+  model.deviceSortComparator(['hasOwnProperty'])), ['hasOwnProperty', 'other'])
+assert.deepEqual([{ name: 'speakers' }, { name: 'headphones' }].sort(
+  model.deviceSortComparator(['headphones'])).map(node => node.name), ['headphones', 'speakers'])
 assert.equal(model.isRecordingStream({ isStream: true, isSink: false }), true)
 assert.equal(model.isRecordingStream({ isStream: true, isSink: true }), false)
 assert.deepEqual(model.uniqueRecordingStreamLabels([
@@ -413,6 +463,18 @@ printf '%s\n' "$scene_one" | OMARCHY_AUDIO_SCENES_FILE="$scenes_file" PATH="$TES
 [[ $(stat -c '%a' "$scenes_file") == 600 ]] || fail "audio scene store permissions"
 jq -e '.scenes[0].name == "Desk" and .scenes[0].defaults.output == "speakers"' "$scenes_file" >/dev/null ||
   fail "audio scene content"
+unsafe_scene='{"name":"Wrong name","devices":[{"name":"speakers","direction":"output","muted":true},{"name":"mic","direction":"input","muted":true}],"profiles":[{"card":"card.live","profile":"stereo"},{"card":"card.off","profile":"off"}]}'
+OMARCHY_AUDIO_SCENES_FILE="$scenes_file" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-scenes" save SafeName "$unsafe_scene" >/dev/null
+jq -e '
+  ([.scenes[] | select(.name == "SafeName")][0]) as $scene
+  | $scene.devices[0].muted == false
+    and $scene.devices[1].muted == true
+    and $scene.profiles == [{"card":"card.live","profile":"stereo"}]
+    and ([.scenes[].name] | index("Wrong name") | not)
+' "$scenes_file" >/dev/null || fail "audio scene storage safety normalization"
+OMARCHY_AUDIO_SCENES_FILE="$scenes_file" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-scenes" delete SafeName >/dev/null
 scene_replacement='{"name":"Desk","defaults":{"output":"line-out","input":"mic"},"devices":[],"ports":[],"profiles":[]}'
 printf '%s\n' "$scene_two" | OMARCHY_AUDIO_SCENES_FILE="$scenes_file" PATH="$TEST_DIR/mocks:$PATH" \
   "$ROOT/scripts/audio-scenes" save Headset >/dev/null
@@ -463,6 +525,10 @@ fi
 jq -e '(.devices.aliases | has("speakers") | not)
   and ((.devices.favorites | index("speakers")) == null)' "$rules_file" >/dev/null ||
   fail "device preference removal"
+printf '%s\n' '{}' >"$rules_file"
+"$ROOT/scripts/audio-app-rules" set-alias missing ""
+jq -e '.appRules == [] and .devices == {"aliases":{},"favorites":[],"hidden":[]}' \
+  "$rules_file" >/dev/null || fail "sparse audio rules normalization"
 unset OMARCHY_AUDIO_RULES_FILE
 echo "PASS: application rules and device preference store"
 rm -rf -- "$scenes_dir"

--- a/test/all
+++ b/test/all
@@ -199,7 +199,11 @@ const classified = model.classifyAudioNodes([
   playbackStream,
   recordingStream,
   { name: 'omarchy_speaker_tuning_output', isStream: true, isSink: true },
-  { name: 'omarchy_audio_test_record', isStream: true, isSink: false }
+  { name: 'omarchy_audio_test_record', isStream: true, isSink: false },
+  {
+    name: 'speaker-test', isStream: true, isSink: true, ready: true,
+    properties: { 'application.id': 'ssupt.audio-control' }
+  }
 ])
 assert.deepEqual(classified.sinks.map(node => node.name), ['speakers'])
 assert.deepEqual(classified.sources.map(node => node.name), ['microphone'])
@@ -232,8 +236,119 @@ assert.equal(model.streamIconName({ ready: true, properties: { 'application.icon
 assert.equal(model.streamIconName({ ready: true, properties: { 'application.icon_name': 'chromium-browser' } }, [], []), 'chromium')
 assert.equal(model.streamIconName({ ready: true, properties: { 'application.id': 'org.example.App.desktop' } }, [], []), 'org.example.App')
 assert.equal(model.streamIconName({ description: 'Spotify' }, [], []), 'spotify')
+const diagnostics = model.parseAudioDiagnostics(JSON.stringify({
+  version: 1,
+  healthy: true,
+  graph: { available: true, rate: 48000, quantum: 256, latencyMs: 5.3, loadPercent: 7, errors: 2 },
+  services: [{ name: 'pipewire.service', label: 'PipeWire', active: true, restarts: 1 }],
+  devices: [{ direction: 'output', name: 'sink', label: 'Speakers', channels: 2, default: true }],
+  routes: [{ direction: 'playback', labels: ['Browser', 'Filter', 'Speakers'] }],
+  capabilities: { speakerTest: true, supportReport: true, clipboard: true, recovery: true },
+  warnings: ['XRUN reported', 'XRUN reported']
+}))
+assert.equal(diagnostics.valid, true)
+assert.equal(diagnostics.value.graph.quantum, 256)
+assert.deepEqual(diagnostics.value.routes[0].labels, ['Browser', 'Filter', 'Speakers'])
+assert.deepEqual(diagnostics.value.warnings, ['XRUN reported'])
+assert.equal(model.parseAudioDiagnostics('not json').valid, false)
 console.log('PASS: profile and routing model')
 JS
+
+diagnostics_fixture="$TEST_DIR/fixtures/diagnostics"
+diagnostics_snapshot=$(
+  AUDIO_CONTROL_DIAGNOSTICS_FIXTURE_DIR="$diagnostics_fixture" \
+  AUDIO_CONTROL_RECOVERY_COMMAND=omarchy-restart-audio \
+  AUDIO_CONTROL_RECOVERY_LAUNCHER=omarchy-launch-floating-terminal-with-presentation \
+  AUDIO_CONTROL_SPEAKER_TEST_COMMAND=speaker-test \
+  AUDIO_CONTROL_CLIPBOARD_COMMAND=wl-copy \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-diagnostics" snapshot
+)
+jq -e '
+  .healthy == true
+  and .versions == {"plugin":"0.7.0","pipewire":"1.6.8","wireplumber":"0.5.15"}
+  and .graph.rate == 48000
+  and .graph.quantum == 256
+  and .graph.latencyMs == 5.3
+  and .graph.loadPercent == 5
+  and .graph.errors == 2
+  and .graph.activeNodes == 2
+  and (.services | length) == 3
+  and ([.services[].restarts] | add) == 1
+  and (.devices | length) == 3
+  and ([.devices[] | select(.name == "bluez_output.test")][0]
+    | .default == true and .bluetooth == true and .codec == "AAC" and .channels == 2)
+  and ([.devices[] | select(.direction == "input")][0].name == "alsa_input.usb-microphone")
+  and ([.devices[].name] | index("bluez_output.test.monitor") == null)
+  and ([.routes[] | select(.direction == "playback")][0].labels
+    == ["Browser","Output Filter","Wireless Headphones"])
+  and ([.routes[] | select(.direction == "recording")][0].labels
+    == ["Recorder","USB Microphone"])
+  and (.routes | length) == 2
+  and ([.routes[].labels[]] | index("Advanced Audio Control") == null)
+  and (.capabilities | .speakerTest and .supportReport and .clipboard and .recovery and .topology)
+  and (.warnings | index("PipeWire reports XRUNs or processing errors in the current graph.") != null)
+' <<<"$diagnostics_snapshot" >/dev/null || fail "audio diagnostics snapshot"
+
+support_report=$(
+  AUDIO_CONTROL_DIAGNOSTICS_FIXTURE_DIR="$diagnostics_fixture" \
+  AUDIO_CONTROL_RECOVERY_COMMAND=omarchy-restart-audio \
+  AUDIO_CONTROL_RECOVERY_LAUNCHER=omarchy-launch-floating-terminal-with-presentation \
+  AUDIO_CONTROL_SPEAKER_TEST_COMMAND=speaker-test \
+  AUDIO_CONTROL_CLIPBOARD_COMMAND=wl-copy \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-diagnostics" report
+)
+grep -q '^  playback: Browser -> Output Filter -> Wireless Headphones$' <<<"$support_report" ||
+  fail "support report active route"
+grep -q '^  Advanced Audio Control: 0.7.0$' <<<"$support_report" ||
+  fail "support report plugin version"
+grep -q '^  Peak DSP load: 5%$' <<<"$support_report" || fail "support report DSP load"
+! grep -q 'bluez_output.test\|alsa_input.usb-microphone' <<<"$support_report" ||
+  fail "support report leaked internal device names"
+grep -q 'Wireless Headphones \[redacted-address\]' <<<"$support_report" ||
+  fail "support report hardware address redaction"
+! grep -q '00:11:22:33:44:55' <<<"$support_report" ||
+  fail "support report leaked a hardware address"
+
+diagnostic_tmp=$(mktemp -d)
+clipboard_log="$diagnostic_tmp/clipboard"
+speaker_log="$diagnostic_tmp/speaker"
+recovery_log="$diagnostic_tmp/recovery"
+trap 'rm -rf "$diagnostic_tmp"' EXIT
+AUDIO_CONTROL_DIAGNOSTICS_FIXTURE_DIR="$diagnostics_fixture" \
+  AUDIO_CONTROL_RECOVERY_COMMAND=omarchy-restart-audio \
+  AUDIO_CONTROL_RECOVERY_LAUNCHER=omarchy-launch-floating-terminal-with-presentation \
+  AUDIO_CONTROL_SPEAKER_TEST_COMMAND=speaker-test \
+  AUDIO_CONTROL_CLIPBOARD_COMMAND=wl-copy \
+  AUDIO_CONTROL_CLIPBOARD_LOG="$clipboard_log" \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-diagnostics" copy-report
+grep -q '^Advanced Audio Control support report$' "$clipboard_log" ||
+  fail "support report clipboard"
+
+AUDIO_CONTROL_DIAGNOSTIC_SINK_FIXTURE="$diagnostics_fixture/sinks.json" \
+  AUDIO_CONTROL_SPEAKER_TEST_COMMAND=speaker-test \
+  AUDIO_CONTROL_SPEAKER_TEST_LOG="$speaker_log" \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-speaker-test" bluez_output.test
+grep -q '^sink=bluez_output.test$' "$speaker_log" || fail "speaker test target"
+grep -q 'application.id=ssupt.audio-control' "$speaker_log" || fail "speaker test private identity"
+grep -q '^args=-D pulse -c 2 -t wav -l 1 -S 35$' "$speaker_log" ||
+  fail "speaker test guarded channel pass"
+if AUDIO_CONTROL_DIAGNOSTIC_SINK_FIXTURE="$diagnostics_fixture/sinks.json" \
+  AUDIO_CONTROL_SPEAKER_TEST_COMMAND=speaker-test PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-speaker-test" missing-output >/dev/null 2>&1; then
+  fail "speaker test accepted an absent output"
+fi
+
+AUDIO_CONTROL_RECOVERY_COMMAND=omarchy-restart-audio \
+  AUDIO_CONTROL_RECOVERY_LAUNCHER=omarchy-launch-floating-terminal-with-presentation \
+  AUDIO_CONTROL_RECOVERY_LOG="$recovery_log" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-recovery"
+for _attempt in {1..50}; do
+  [[ -s $recovery_log ]] && break
+  sleep 0.01
+done
+grep -q '/omarchy-restart-audio$' "$recovery_log" || fail "guarded Omarchy recovery launch"
+echo "PASS: native diagnostics and guarded recovery"
+rm -rf -- "$diagnostic_tmp"
 
 route_log=$(mktemp)
 trap 'rm -f "$route_log"' EXIT
@@ -872,7 +987,7 @@ echo "PASS: menu integration"
 jq -e '
   .schemaVersion == 1
   and .id == "ssupt.audio-control"
-  and .version == "0.6.0"
+  and .version == "0.7.0"
   and .author == "ssupt"
   and (.kinds | index("bar-widget") != null)
   and (.kinds | index("panel") != null)

--- a/test/fixtures/diagnostics/dump.json
+++ b/test/fixtures/diagnostics/dump.json
@@ -1,0 +1,52 @@
+[
+  {
+    "id": 20,
+    "type": "PipeWire:Interface:Node",
+    "info": {"props": {"media.class": "Stream/Output/Audio", "application.name": "Browser"}}
+  },
+  {
+    "id": 30,
+    "type": "PipeWire:Interface:Node",
+    "info": {"props": {"media.class": "Audio/Sink", "node.description": "Output Filter"}}
+  },
+  {
+    "id": 40,
+    "type": "PipeWire:Interface:Node",
+    "info": {"props": {"media.class": "Audio/Sink", "node.description": "Wireless Headphones"}}
+  },
+  {
+    "id": 50,
+    "type": "PipeWire:Interface:Node",
+    "info": {"props": {"media.class": "Audio/Source", "node.description": "USB Microphone"}}
+  },
+  {
+    "id": 60,
+    "type": "PipeWire:Interface:Node",
+    "info": {"props": {"media.class": "Stream/Input/Audio", "application.name": "Recorder"}}
+  },
+  {
+    "id": 80,
+    "type": "PipeWire:Interface:Node",
+    "info": {"props": {"media.class": "Stream/Output/Audio", "application.id": "ssupt.audio-control", "application.name": "Advanced Audio Control"}}
+  },
+  {
+    "id": 70,
+    "type": "PipeWire:Interface:Link",
+    "info": {"state": "active", "output-node-id": 20, "input-node-id": 30}
+  },
+  {
+    "id": 71,
+    "type": "PipeWire:Interface:Link",
+    "info": {"state": "paused", "output-node-id": 30, "input-node-id": 40}
+  },
+  {
+    "id": 72,
+    "type": "PipeWire:Interface:Link",
+    "info": {"state": "active", "output-node-id": 50, "input-node-id": 60}
+  },
+  {
+    "id": 81,
+    "type": "PipeWire:Interface:Link",
+    "info": {"state": "active", "output-node-id": 80, "input-node-id": 40}
+  }
+]

--- a/test/fixtures/diagnostics/metadata.txt
+++ b/test/fixtures/diagnostics/metadata.txt
@@ -1,0 +1,3 @@
+Found "settings" metadata 31
+update: id:0 key:'clock.rate' value:'48000' type:''
+update: id:0 key:'clock.quantum' value:'256' type:''

--- a/test/fixtures/diagnostics/pactl-info.txt
+++ b/test/fixtures/diagnostics/pactl-info.txt
@@ -1,0 +1,3 @@
+Server Name: PulseAudio (on PipeWire 1.6.8)
+Default Sink: bluez_output.test
+Default Source: alsa_input.usb-microphone

--- a/test/fixtures/diagnostics/pipewire-version.txt
+++ b/test/fixtures/diagnostics/pipewire-version.txt
@@ -1,0 +1,3 @@
+pw-top
+Compiled with libpipewire 1.6.8
+Linked with libpipewire 1.6.8

--- a/test/fixtures/diagnostics/pw-top.txt
+++ b/test/fixtures/diagnostics/pw-top.txt
@@ -1,0 +1,3 @@
+S   ID  QUANT   RATE    WAIT    BUSY   W/Q   B/Q  ERR FORMAT           NAME
+R   40    256  48000   100us   80us  0.05  0.03    2 F32LE 2 48000   bluez_output.test
+R   20      0      0    20us   10us  0.01  0.01    0 F32LE 2 48000   Browser

--- a/test/fixtures/diagnostics/services.json
+++ b/test/fixtures/diagnostics/services.json
@@ -1,0 +1,5 @@
+[
+  {"name":"pipewire.service","label":"PipeWire","loadState":"loaded","activeState":"active","subState":"running","active":true,"restarts":0},
+  {"name":"wireplumber.service","label":"WirePlumber","loadState":"loaded","activeState":"active","subState":"running","active":true,"restarts":1},
+  {"name":"pipewire-pulse.service","label":"PipeWire Pulse","loadState":"loaded","activeState":"active","subState":"running","active":true,"restarts":0}
+]

--- a/test/fixtures/diagnostics/sinks.json
+++ b/test/fixtures/diagnostics/sinks.json
@@ -1,0 +1,26 @@
+[
+  {
+    "index": 100,
+    "name": "bluez_output.test",
+    "description": "Wireless Headphones 00:11:22:33:44:55",
+    "state": "RUNNING",
+    "sample_specification": "s24le 2ch 48000Hz",
+    "channel_map": "front-left,front-right",
+    "active_port": "headphones-output",
+    "properties": {
+      "device.bus": "bluetooth",
+      "device.profile.description": "High Fidelity Playback",
+      "bluetooth.codec": "AAC"
+    }
+  },
+  {
+    "index": 101,
+    "name": "alsa_output.hdmi",
+    "description": "HDMI Receiver",
+    "state": "SUSPENDED",
+    "sample_specification": "s32le 6ch 48000Hz",
+    "channel_map": "front-left,front-right,rear-left,rear-right,front-center,lfe",
+    "active_port": {"name": "hdmi-output-0", "description": "HDMI / DisplayPort"},
+    "properties": {"device.profile.description": "Digital Surround 5.1"}
+  }
+]

--- a/test/fixtures/diagnostics/sources.json
+++ b/test/fixtures/diagnostics/sources.json
@@ -1,0 +1,24 @@
+[
+  {
+    "index": 200,
+    "name": "alsa_input.usb-microphone",
+    "description": "USB Microphone",
+    "state": "IDLE",
+    "sample_specification": "s16le 1ch 48000Hz",
+    "channel_map": "mono",
+    "active_port": "analog-input-mic",
+    "monitor_source": "",
+    "properties": {"device.profile.description": "Mono Input"}
+  },
+  {
+    "index": 201,
+    "name": "bluez_output.test.monitor",
+    "description": "Monitor of Wireless Headphones",
+    "state": "RUNNING",
+    "sample_specification": "s24le 2ch 48000Hz",
+    "channel_map": "front-left,front-right",
+    "active_port": "headphones-output",
+    "monitor_source": "bluez_output.test",
+    "properties": {"device.class": "monitor"}
+  }
+]

--- a/test/fixtures/diagnostics/wireplumber-version.txt
+++ b/test/fixtures/diagnostics/wireplumber-version.txt
@@ -1,0 +1,3 @@
+wireplumber
+Compiled with libwireplumber 0.5.15
+Linked with libwireplumber 0.5.15

--- a/test/mocks/omarchy-launch-floating-terminal-with-presentation
+++ b/test/mocks/omarchy-launch-floating-terminal-with-presentation
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+[[ -n ${AUDIO_CONTROL_RECOVERY_LOG:-} ]] || exit 1
+printf '%s\n' "$*" >"$AUDIO_CONTROL_RECOVERY_LOG"

--- a/test/mocks/omarchy-restart-audio
+++ b/test/mocks/omarchy-restart-audio
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+exit 0

--- a/test/mocks/pactl
+++ b/test/mocks/pactl
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ $* == "-f json list sinks" && -n ${AUDIO_CONTROL_DIAGNOSTIC_SINK_FIXTURE:-} ]]; then
+  command cat "$AUDIO_CONTROL_DIAGNOSTIC_SINK_FIXTURE"
+  exit 0
+fi
+
 if [[ $* == "-f json list cards" && -n ${AUDIO_CONTROL_CARD_FIXTURE:-} ]]; then
   command cat "$AUDIO_CONTROL_CARD_FIXTURE"
   exit 0

--- a/test/mocks/speaker-test
+++ b/test/mocks/speaker-test
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+[[ -n ${AUDIO_CONTROL_SPEAKER_TEST_LOG:-} ]] || exit 1
+printf 'sink=%s\nprops=%s\nargs=%s\n' \
+  "${PULSE_SINK:-}" "${PULSE_PROP:-}" "$*" >"$AUDIO_CONTROL_SPEAKER_TEST_LOG"

--- a/test/mocks/wl-copy
+++ b/test/mocks/wl-copy
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+[[ -n ${AUDIO_CONTROL_CLIPBOARD_LOG:-} ]] || exit 1
+command cat >"$AUDIO_CONTROL_CLIPBOARD_LOG"


### PR DESCRIPTION
## Summary

- split policy, rules, scenes, microphone-test, and diagnostics lifecycle into focused controllers
- add the v0.7 Diagnostics tab with service, graph, device, and route health
- add a finite speaker channel test, privacy-conscious support report, and confirmed Omarchy recovery
- include routing and scene correctness fixes plus comprehensive test coverage

## Validation

- `./test/all`
- `qmllint ./*.qml`
- Bash syntax, JSON, and `git diff --check` checks
- `omarchy-plugin-validate .`
- isolated Quickshell manifest-entrypoint load
- live read-only diagnostics snapshot

The audible speaker test and actual audio recovery path were exercised through mocks rather than against the live session.