### PR TITLE
fix: harden audio control and release 0.7.1

### DIFF
--- a/AdvancedAudio.qml
+++ b/AdvancedAudio.qml
@@ -34,7 +34,8 @@ Item {
     diagnosticsPath: runtime.script("audio-diagnostics")
     speakerTestPath: runtime.script("audio-speaker-test")
     recoveryPath: runtime.script("audio-recovery")
-    sessionActive: window.visible && root.activeTab === 5
+    sessionActive: window.visible && root.activeTab === 5 && !root.recoveryConfirmOpen
+    mutationBlocked: root.graphMutationBusy
   }
 
   property var shell: null
@@ -50,15 +51,27 @@ Item {
   property bool bluetoothAutoSwitch: true
   property bool bluetoothAutoSwitchLoaded: false
   property bool autoswitchMutation: false
+  property bool autoswitchReconcilePending: false
   property string bluetoothProfilePreference: "quality"
   property bool bluetoothProfilePreferenceLoaded: false
   property bool bluetoothProfilePreferenceMutation: false
+  property bool bluetoothPreferenceReconcilePending: false
   property var audioScenes: []
   property bool scenesLoaded: false
+  property bool settingsLoaded: false
+  property bool preferencesLoaded: false
+  property bool sceneReloadPending: false
   readonly property var audioRules: rulesStore.rules
   property string newRuleApp: ""
   property string aliasEditingDevice: ""
   readonly property bool routingMutation: rulesStore.busy
+  readonly property bool diagnosticsMutationBusy: diagnostics.speakerTesting
+    || diagnostics.recovering
+  readonly property bool graphMutationBusy: sceneController.busy
+    || profileSetProc.running || portSetProc.running || microphoneTest.busy || policy.busy
+  readonly property bool sceneMutationBusy: graphMutationBusy
+    || sceneStoreProc.running || sceneReloadPending
+    || diagnosticsMutationBusy
   property var pendingSceneSave: null
   property string sceneStatus: ""
   property bool sceneStatusIsError: false
@@ -68,13 +81,19 @@ Item {
   property string portSetError: ""
   property string bluetoothAutoswitchError: ""
   property string bluetoothPreferenceError: ""
+  property string settingsSaveError: ""
+  property string settingsFormatError: ""
+  property bool audioControlSettingsWritable: true
+  property bool audioControlWritePending: false
+  property var previousAudioControlSettings: null
   readonly property var policySettings: policy.settings
   readonly property bool policySettingsLoaded: policy.loaded
   readonly property string pendingPolicyKey: policy.pendingKey
   readonly property string policyError: policy.error
   readonly property string error: {
     var errors = [profileSetError, portSetError, bluetoothAutoswitchError,
-      bluetoothPreferenceError, policyError, profileLoadError, portLoadError]
+      bluetoothPreferenceError, settingsSaveError, settingsFormatError,
+      policyError, profileLoadError, portLoadError]
     for (var i = 0; i < errors.length; i++) if (errors[i] !== "") return errors[i]
     return ""
   }
@@ -83,8 +102,8 @@ Item {
   property int activeTab: 0
   property bool cursorActive: false
   property int selectedIndex: 0
-  property bool profileMenuOpen: false
-  property var pendingSharedProfile: null
+  property int profileMenuCount: 0
+  readonly property bool profileMenuOpen: profileMenuCount > 0
   property var audioPreferences: Model.parseAudioPreferences("")
   property var audioControlSettings: ({
     version: 1,
@@ -111,19 +130,27 @@ Item {
   readonly property var pipewireNodes: Pipewire.nodes ? Pipewire.nodes.values : []
   readonly property var defaultOutputDevice: Pipewire.defaultAudioSink
   property string volumeSinkName: ""
+  property bool volumeSinkResolvePending: false
   readonly property var outputDevice: {
-    if (!defaultOutputDevice || !volumeSinkName
-        || String(defaultOutputDevice.name) === volumeSinkName) return defaultOutputDevice
-    for (var i = 0; i < pipewireNodes.length; i++) {
-      var node = pipewireNodes[i]
-      if (node && node.isSink && !node.isStream && String(node.name) === volumeSinkName)
-        return node
+    try {
+      if (!defaultOutputDevice || !volumeSinkName
+          || Model.nodeName(defaultOutputDevice) === volumeSinkName) return defaultOutputDevice
+      var match = null
+      for (var i = 0; i < pipewireNodes.length && i < 4096; i++) {
+        var node = pipewireNodes[i]
+        if (!node || !node.isSink || node.isStream
+            || Model.nodeName(node) !== volumeSinkName) continue
+        if (match) return defaultOutputDevice
+        match = node
+      }
+      return match || defaultOutputDevice
+    } catch (_error) {
+      return defaultOutputDevice
     }
-    return defaultOutputDevice
   }
-  readonly property var inputDevice: Pipewire.defaultAudioSource
-  readonly property bool inputDeviceMuted: !inputDevice || !inputDevice.audio
-    || inputDevice.audio.muted
+  readonly property var rawInputDevice: Pipewire.defaultAudioSource
+  readonly property var inputDevice: usableInputNode(rawInputDevice) ? rawInputDevice : null
+  readonly property bool inputDeviceMuted: audioNodeMuted(inputDevice, true)
   readonly property bool outputBalanceAvailable: balanceAvailable(outputDevice)
   readonly property bool inputBalanceAvailable: balanceAvailable(inputDevice)
   readonly property int audioPortStartIndex: 1
@@ -150,14 +177,26 @@ Item {
         : (activeTab === 0
           ? deviceItemCount + (inputDevice ? 1 : 0)
           : (activeTab === 1 ? 2 + bluetoothCards.length : policyItemCount))))
-  readonly property bool audioMutationBusy: profileSetProc.running || portSetProc.running
-    || microphoneTest.busy
+  readonly property bool audioMutationBusy: graphMutationBusy || diagnosticsMutationBusy
+  onAudioMutationBusyChanged: if (!audioMutationBusy) enforceOutputVolumeLimit()
+  onOutputOverdriveChanged: enforceOutputVolumeLimit()
+  readonly property bool policyMutationBlocked: sceneController.busy
+    || profileSetProc.running || portSetProc.running || microphoneTest.busy
+    || diagnosticsMutationBusy
   readonly property color hoverFill: Style.hoverFillFor(foreground, Color.accent)
-  onDefaultOutputDeviceChanged: resolveVolumeSink()
+  onDefaultOutputDeviceChanged: {
+    volumeSinkName = ""
+    resolveVolumeSink()
+  }
+  onOutputDeviceChanged: enforceOutputVolumeLimit()
 
   function open(payloadJson) {
     var payload = ({})
-    try { payload = JSON.parse(payloadJson || "{}") } catch (e) { payload = ({}) }
+    var rawPayload = typeof payloadJson === "string" ? payloadJson : ""
+    if (rawPayload.length <= 4096) {
+      try { payload = JSON.parse(rawPayload || "{}") } catch (e) { payload = ({}) }
+    }
+    if (!payload || typeof payload !== "object" || Array.isArray(payload)) payload = ({})
     activeTab = payload.tab === "bluetooth" ? 1
       : payload.tab === "policy" ? 2
       : payload.tab === "scenes" ? 3
@@ -185,13 +224,14 @@ Item {
     portSetError = ""
     bluetoothAutoswitchError = ""
     bluetoothPreferenceError = ""
+    settingsSaveError = ""
     policy.clearError()
   }
 
   function showOnCurrentWorkspace() {
     if (!openRequested) return
     window.visible = true
-    Quickshell.execDetached([runtime.script("place-advanced-window")])
+    Quickshell.execDetached(runtime.scriptCommand("place-advanced-window"))
     Qt.callLater(function() {
       if (!window.visible) return
       keyCatcher.forceActiveFocus()
@@ -202,7 +242,8 @@ Item {
   function close() {
     openRequested = false
     closingFromHost = true
-    profileMenuOpen = false
+    closeProfileMenus()
+    profileMenuCount = 0
     recoveryConfirmOpen = false
     microphoneTest.discard()
     window.visible = false
@@ -211,6 +252,8 @@ Item {
 
   function requestClose() {
     openRequested = false
+    closeProfileMenus()
+    profileMenuCount = 0
     recoveryConfirmOpen = false
     microphoneTest.discard()
     if (shell && typeof shell.hide === "function") shell.hide("ssupt.audio-control")
@@ -221,13 +264,21 @@ Item {
     if (!window.visible) return
     if (!profilesProc.running && !profileSetProc.running) profilesProc.running = true
     if (!bluetoothAutoswitchProc.running) {
+      autoswitchReconcileTimer.stop()
+      autoswitchReconcilePending = false
       autoswitchMutation = false
-      bluetoothAutoswitchProc.command = [runtime.script("audio-bluetooth-autoswitch")]
+      bluetoothAutoswitchProc.responseValid = false
+      bluetoothAutoswitchProc.response = ""
+      bluetoothAutoswitchProc.command = runtime.scriptCommand("audio-bluetooth-autoswitch")
       bluetoothAutoswitchProc.running = true
     }
     if (!bluetoothPreferenceProc.running) {
+      bluetoothPreferenceReconcileTimer.stop()
+      bluetoothPreferenceReconcilePending = false
       bluetoothProfilePreferenceMutation = false
-      bluetoothPreferenceProc.command = [runtime.script("audio-bluetooth-profile-preference")]
+      bluetoothPreferenceProc.responseValid = false
+      bluetoothPreferenceProc.response = ""
+      bluetoothPreferenceProc.command = runtime.scriptCommand("audio-bluetooth-profile-preference")
       bluetoothPreferenceProc.running = true
     }
     if (!portsProc.running && !portSetProc.running) portsProc.running = true
@@ -236,7 +287,58 @@ Item {
   }
 
   function resolveVolumeSink() {
-    if (!volumeSinkProc.running) volumeSinkProc.running = true
+    if (volumeSinkProc.running) {
+      volumeSinkResolvePending = true
+      return
+    }
+    volumeSinkResolvePending = false
+    volumeSinkProc.response = ""
+    volumeSinkProc.requestedDefaultName = Model.nodeName(defaultOutputDevice)
+    volumeSinkProc.requestedDefaultObjectId = Model.nodeObjectId(defaultOutputDevice)
+    volumeSinkProc.running = true
+  }
+
+  function mutableAudioNode(node) {
+    try {
+      if (!node || node.ready !== true || !node.audio
+          || pipewireNodes.length > 4096) return false
+      var objectId = Model.nodeObjectId(node)
+      if (objectId === "") return false
+      var match = null
+      for (var i = 0; i < pipewireNodes.length; i++) {
+        var candidate = pipewireNodes[i]
+        if (!candidate || Model.nodeObjectId(candidate) !== objectId) continue
+        if (match) return false
+        match = candidate
+      }
+      return match === node
+    } catch (_error) {
+      return false
+    }
+  }
+
+  function usableInputNode(node) {
+    try {
+      return !!node && node.isStream !== true && node.isSink !== true
+        && Model.nodeName(node) !== "" && Model.isAudioSource(node)
+        && !Model.isMonitorSource(node)
+        && !Model.isInternalAudioNode(Model.nodeName(node), Model.nodeProps(node))
+    } catch (_error) {
+      return false
+    }
+  }
+
+  function audioNodeMuted(node, fallback) {
+    if (!mutableAudioNode(node)) return fallback === true
+    try { return node.audio.muted === true } catch (_error) { return fallback === true }
+  }
+
+  function enforceOutputVolumeLimit() {
+    if (outputOverdrive || audioMutationBusy || !mutableAudioNode(outputDevice)) return
+    try {
+      var volume = Number(outputDevice.audio.volume)
+      if (isFinite(volume) && volume > 1) outputDevice.audio.volume = 1
+    } catch (_error) { }
   }
 
   function parseAudioProfiles(raw) {
@@ -273,15 +375,22 @@ Item {
   }
 
   function adjustPolicyVolumeAtCursor(delta) {
-    if (activeTab !== 2) return false
+    if (activeTab !== 2 || policyMutationBlocked) return false
     var index = selectedIndex - policyVolumeStartIndex
     if (index < 0 || index >= availablePolicyVolumes.length) return false
     var definition = availablePolicyVolumes[index]
-    policy.setSetting(definition.key, Number(policySettings[definition.key]) + delta * 0.05)
+    setPolicySetting(definition.key,
+      Number(Model.mapValue(policySettings, definition.key, 0)) + delta * 0.05)
     return true
   }
 
+  function setPolicySetting(key, value) {
+    if (policyMutationBlocked) return
+    policy.setSetting(key, value)
+  }
+
   function setOutputOverdrive(enabled) {
+    if (audioMutationBusy) return
     setAudioControlSetting("outputOverdrive", enabled)
   }
 
@@ -290,10 +399,16 @@ Item {
   }
 
   function setAudioControlSetting(key, value) {
+    if (!audioControlSettingsWritable || audioControlWritePending
+        || (key !== "outputOverdrive" && key !== "captureNotifications")) return
     var next = ({})
-    for (var setting in audioControlSettings) next[setting] = audioControlSettings[setting]
+    for (var setting in audioControlSettings)
+      if (Model.hasOwn(audioControlSettings, setting)) next[setting] = audioControlSettings[setting]
     next.version = 1
     next[key] = value
+    previousAudioControlSettings = audioControlSettings
+    audioControlWritePending = true
+    settingsSaveError = ""
     audioControlSettings = next
     if (key === "outputOverdrive") outputOverdrive = value
     else if (key === "captureNotifications") captureNotifications = value
@@ -316,18 +431,22 @@ Item {
   }
 
   function stereoIndices(node) {
-    if (!node || !node.audio || !node.audio.channels || !node.audio.volumes)
+    try {
+      if (!mutableAudioNode(node) || !node.audio.channels || !node.audio.volumes)
+        return { left: -1, right: -1 }
+      var channels = node.audio.channels
+      var left = -1
+      var right = -1
+      for (var i = 0; i < channels.length && i < 64; i++) {
+        if (channels[i] === PwAudioChannel.FrontLeft) left = i
+        else if (channels[i] === PwAudioChannel.FrontRight) right = i
+      }
+      if ((left < 0 || right < 0) && node.audio.volumes.length === 2)
+        return { left: 0, right: 1 }
+      return { left: left, right: right }
+    } catch (_error) {
       return { left: -1, right: -1 }
-    var channels = node.audio.channels
-    var left = -1
-    var right = -1
-    for (var i = 0; i < channels.length; i++) {
-      if (channels[i] === PwAudioChannel.FrontLeft) left = i
-      else if (channels[i] === PwAudioChannel.FrontRight) right = i
     }
-    if ((left < 0 || right < 0) && node.audio.volumes.length === 2)
-      return { left: 0, right: 1 }
-    return { left: left, right: right }
   }
 
   function balanceAvailable(node) {
@@ -336,25 +455,35 @@ Item {
   }
 
   function balanceFor(node) {
-    if (!node || !node.audio) return 0
-    var indices = stereoIndices(node)
-    if (indices.left < 0 || indices.right < 0) return 0
-    return Model.balanceValue(node.audio.volumes[indices.left], node.audio.volumes[indices.right])
+    try {
+      if (!mutableAudioNode(node)) return 0
+      var indices = stereoIndices(node)
+      if (indices.left < 0 || indices.right < 0) return 0
+      return Model.balanceValue(node.audio.volumes[indices.left], node.audio.volumes[indices.right])
+    } catch (_error) {
+      return 0
+    }
   }
 
   function setBalance(node, value) {
-    if (!node || !node.audio) return
+    if (audioMutationBusy || !mutableAudioNode(node)) return false
     var indices = stereoIndices(node)
-    if (indices.left < 0 || indices.right < 0) return
-    node.audio.volumes = Model.applyBalance(node.audio.volumes, indices.left, indices.right, value)
+    if (indices.left < 0 || indices.right < 0) return false
+    try {
+      node.audio.volumes = Model.applyBalance(
+        node.audio.volumes, indices.left, indices.right, value)
+      return true
+    } catch (_error) {
+      return false
+    }
   }
 
   function adjustBalanceAtCursor(delta) {
+    if (audioMutationBusy) return false
     var node = selectedIndex === outputBalanceIndex ? outputDevice
       : (selectedIndex === inputBalanceIndex ? inputDevice : null)
     if (!node) return false
-    setBalance(node, balanceFor(node) + delta * 0.1)
-    return true
+    return setBalance(node, balanceFor(node) + delta * 0.1)
   }
 
   function clampCursor() {
@@ -383,6 +512,10 @@ Item {
         if (typeof row.closeTargetMenu === "function") row.closeTargetMenu()
       }
     }
+  }
+
+  function updateProfileMenu(open) {
+    profileMenuCount = Math.max(0, profileMenuCount + (open ? 1 : -1))
   }
 
   function selectTab(index) {
@@ -422,7 +555,10 @@ Item {
         if (ruleRow) ruleRow.toggleTargetMenu()
       } else {
         var deviceIndex = selectedIndex - 2 - audioRules.appRules.length
-        toggleDeviceFavorite(managedDevices[deviceIndex].name, managedDevices[deviceIndex].favorite)
+        if (deviceIndex >= 0 && deviceIndex < managedDevices.length) {
+          var managed = managedDevices[deviceIndex]
+          if (managed) toggleDeviceFavorite(managed.name, managed.favorite)
+        }
       }
       return
     }
@@ -438,7 +574,8 @@ Item {
       }
       var policyToggle = policyToggleAtCursor()
       if (policyToggle)
-        policy.setSetting(policyToggle.key, policySettings[policyToggle.key] !== true)
+        setPolicySetting(policyToggle.key,
+          Model.mapValue(policySettings, policyToggle.key, false) !== true)
       return
     }
     if (activeTab === 0 && selectedIndex === 0) {
@@ -458,6 +595,8 @@ Item {
       return
     }
     if (activeTab === 0 && selectedIndex === microphoneTestIndex) {
+      if (profileSetProc.running || portSetProc.running || sceneController.busy
+          || policy.busy || diagnosticsMutationBusy) return
       microphoneTest.activate()
       return
     }
@@ -476,7 +615,8 @@ Item {
   }
 
   function requestRecovery() {
-    if (!diagnostics.snapshot.capabilities.recovery) return
+    if (graphMutationBusy || diagnostics.busy
+        || !diagnostics.snapshot.capabilities.recovery) return
     recoveryConfirm.selectedIndex = 1
     recoveryConfirmOpen = true
   }
@@ -487,8 +627,8 @@ Item {
   }
 
   function confirmRecovery() {
-    recoveryConfirmOpen = false
     diagnostics.runRecovery()
+    recoveryConfirmOpen = false
     Qt.callLater(function() { keyCatcher.forceActiveFocus() })
   }
 
@@ -513,41 +653,47 @@ Item {
   function setAudioProfile(card, profile) {
     if (!card || !card.name || !profile || audioMutationBusy) return
     profileSetError = ""
-    pendingSharedProfile = card.bluetooth && card.address ? {
-      address: String(card.address),
-      profile: String(profile)
-    } : null
-    profileSetProc.command = [runtime.script("audio-profile-set"), String(card.name), profile]
+    profileSetProc.command = runtime.scriptCommand(
+      "audio-profile-set", [String(card.name), profile])
     profileSetProc.running = true
   }
 
   function setAudioPort(port, value) {
     if (!port || !value || audioMutationBusy) return
     portSetError = ""
-    portSetProc.command = [runtime.script("audio-port-set"), port.direction, port.endpoint, value]
+    portSetProc.command = runtime.scriptCommand(
+      "audio-port-set", [port.direction, port.endpoint, value])
     portSetProc.running = true
   }
 
   function setBluetoothAutoSwitch(enabled) {
-    if (!bluetoothAutoSwitchLoaded || bluetoothAutoswitchProc.running) return
+    if (!bluetoothAutoSwitchLoaded || bluetoothAutoswitchProc.running
+        || autoswitchReconcilePending) return
     bluetoothAutoswitchError = ""
     autoswitchMutation = true
-    bluetoothAutoswitchProc.command = [runtime.script("audio-bluetooth-autoswitch"), enabled ? "on" : "off"]
+    bluetoothAutoswitchProc.responseValid = false
+    bluetoothAutoswitchProc.response = ""
+    bluetoothAutoswitchProc.command = runtime.scriptCommand(
+      "audio-bluetooth-autoswitch", [enabled ? "on" : "off"])
     bluetoothAutoswitchProc.running = true
   }
 
   function setBluetoothProfilePreference(value) {
     if (!bluetoothProfilePreferenceLoaded || bluetoothPreferenceProc.running
+        || bluetoothPreferenceReconcilePending
         || (value !== "quality" && value !== "latency")) return
     bluetoothPreferenceError = ""
     bluetoothProfilePreferenceMutation = true
-    bluetoothPreferenceProc.command = [runtime.script("audio-bluetooth-profile-preference"), value]
+    bluetoothPreferenceProc.responseValid = false
+    bluetoothPreferenceProc.response = ""
+    bluetoothPreferenceProc.command = runtime.scriptCommand(
+      "audio-bluetooth-profile-preference", [value])
     bluetoothPreferenceProc.running = true
   }
 
   Process {
     id: windowRuleProc
-    command: [runtime.script("prepare-advanced-window")]
+    command: runtime.scriptCommand("prepare-advanced-window")
     onExited: function(_exitCode) {
       // The placement helper below remains a fallback if Hyprland rejected
       // the pre-map rule. Do not leave the settings inaccessible on another
@@ -563,35 +709,97 @@ Item {
     watchChanges: true
     atomicWrites: true
     printErrors: false
-    onLoaded: root.loadAudioControlSettings(text())
-    onLoadFailed: root.loadAudioControlSettings("")
+    onLoaded: function() {
+      var raw = text()
+      if (!Model.isAudioControlSettingsDocument(raw)) {
+        var empty = String(raw || "").trim() === ""
+        root.audioControlSettingsWritable = empty
+        root.settingsFormatError = empty ? ""
+          : "Audio control settings use an unsupported or invalid format"
+        if (!root.settingsLoaded) {
+          root.loadAudioControlSettings("")
+          root.settingsLoaded = true
+        }
+        return
+      }
+      root.audioControlSettingsWritable = true
+      root.settingsFormatError = ""
+      root.loadAudioControlSettings(raw)
+      root.settingsLoaded = true
+    }
+    onLoadFailed: if (!root.settingsLoaded) {
+      root.audioControlSettingsWritable = true
+      root.loadAudioControlSettings("")
+      root.settingsLoaded = true
+    }
     onFileChanged: reload()
+    onSaved: {
+      root.audioControlWritePending = false
+      root.previousAudioControlSettings = null
+    }
+    onSaveFailed: function(_error) {
+      var previous = root.previousAudioControlSettings
+      root.audioControlWritePending = false
+      root.previousAudioControlSettings = null
+      if (previous) root.loadAudioControlSettings(JSON.stringify(previous))
+      root.settingsSaveError = "Could not save audio control settings"
+    }
   }
 
   FileView {
     path: runtime.preferencesPath
     watchChanges: true
     printErrors: false
-    onLoaded: root.loadAudioPreferences(text())
-    onLoadFailed: root.loadAudioPreferences("")
+    onLoaded: function() {
+      var raw = text()
+      if (!Model.isAudioPreferencesDocument(raw)) {
+        if (!root.preferencesLoaded) {
+          root.loadAudioPreferences("")
+          root.preferencesLoaded = true
+        }
+        return
+      }
+      root.loadAudioPreferences(raw)
+      root.preferencesLoaded = true
+    }
+    onLoadFailed: if (!root.preferencesLoaded) {
+      root.loadAudioPreferences("")
+      root.preferencesLoaded = true
+    }
     onFileChanged: reload()
   }
 
   FileView {
+    id: scenesFile
     path: runtime.scenesPath
     watchChanges: true
     printErrors: false
     onLoaded: function() {
-      root.audioScenes = Model.parseAudioScenes(text()).scenes
+      var raw = text()
+      if (!Model.isAudioScenesDocument(raw)) {
+        root.handleScenesLoadFailure()
+        return
+      }
+      root.audioScenes = Model.parseAudioScenes(raw).scenes
       root.scenesLoaded = true
       root.clampCursor()
+      sceneReloadWatchdog.stop()
+      root.sceneReloadPending = false
     }
-    onLoadFailed: function() {
-      root.audioScenes = []
-      root.scenesLoaded = true
-      root.clampCursor()
-    }
+    onLoadFailed: root.handleScenesLoadFailure()
     onFileChanged: reload()
+  }
+
+  function handleScenesLoadFailure() {
+      if (root.sceneReloadPending) {
+        sceneReloadWatchdog.stop()
+        root.sceneReloadPending = false
+        root.showSceneStatus("Saved scenes changed, but could not be reloaded", true)
+        return
+      }
+      if (!root.scenesLoaded) root.audioScenes = []
+      root.scenesLoaded = true
+      root.clampCursor()
   }
 
   function runRuleWrite(args) {
@@ -601,10 +809,12 @@ Item {
   AudioSceneController {
     id: sceneController
     scriptsDir: runtime.scriptsDir
+    outputVolumeMaximum: root.outputOverdrive ? 1.5 : 1.0
+    onCaptureFailed: function(error) { root.showSceneStatus(error, true) }
     onCaptureFinished: function(scene) {
       root.pendingSceneSave = scene
-      sceneStoreProc.command = [runtime.script("audio-scenes"), "save", scene.name,
-        JSON.stringify(scene)]
+      sceneStoreProc.command = runtime.scriptCommand(
+        "audio-scenes", ["save", scene.name, JSON.stringify(scene)])
       sceneStoreProc.running = true
     }
     onApplyFinished: function(result) {
@@ -632,6 +842,9 @@ Item {
         return
       }
       if (saving) root.showSceneStatus("Saved scene '" + name + "'", false)
+      root.sceneReloadPending = true
+      sceneReloadWatchdog.restart()
+      scenesFile.reload()
     }
   }
 
@@ -641,6 +854,16 @@ Item {
     onTriggered: root.sceneStatus = ""
   }
 
+  Timer {
+    id: sceneReloadWatchdog
+    interval: 3000
+    onTriggered: {
+      if (!root.sceneReloadPending) return
+      root.sceneReloadPending = false
+      root.showSceneStatus("Saved scenes changed, but could not be reloaded", true)
+    }
+  }
+
   function showSceneStatus(text, isError) {
     sceneStatus = text
     sceneStatusIsError = isError
@@ -648,30 +871,30 @@ Item {
   }
 
   function nextSceneName() {
-    var used = ({})
-    for (var i = 0; i < audioScenes.length; i++) used[audioScenes[i].name] = true
+    var used = []
+    for (var i = 0; i < audioScenes.length; i++) used.push(audioScenes[i].name)
     for (var n = 1; n < 100; n++)
-      if (!used["Scene " + n]) return "Scene " + n
+      if (used.indexOf("Scene " + n) === -1) return "Scene " + n
     return "Scene " + Math.floor(Math.random() * 100000)
   }
 
   function saveCurrentScene() {
-    if (sceneController.busy || sceneStoreProc.running) return
+    if (sceneMutationBusy) return
     sceneStatus = ""
     sceneController.capture(nextSceneName())
   }
 
   function applySceneAt(index) {
     var scene = index >= 0 ? audioScenes[index] : null
-    if (!scene || sceneController.busy || sceneStoreProc.running) return
+    if (!scene || sceneMutationBusy) return
     sceneStatus = ""
     sceneController.apply(scene)
   }
 
   function deleteSceneAt(index) {
     var scene = index >= 0 ? audioScenes[index] : null
-    if (!scene || sceneController.busy || sceneStoreProc.running) return
-    sceneStoreProc.command = [runtime.script("audio-scenes"), "delete", scene.name]
+    if (!scene || sceneMutationBusy) return
+    sceneStoreProc.command = runtime.scriptCommand("audio-scenes", ["delete", scene.name])
     sceneStoreProc.running = true
   }
 
@@ -699,6 +922,12 @@ Item {
 
   readonly property var managedDevices: rulesStore.managedDevices
   readonly property var newRuleAppOptions: rulesStore.availableApplicationLabels
+  onManagedDevicesChanged: {
+    if (aliasEditingDevice === "") return
+    for (var i = 0; i < managedDevices.length; i++)
+      if (managedDevices[i].name === aliasEditingDevice) return
+    cancelAliasEdit()
+  }
 
   function cancelAliasEdit() {
     aliasEditingDevice = ""
@@ -712,9 +941,9 @@ Item {
   }
 
   function commitAliasEdit(name, text) {
-    cancelAliasEdit()
     var trimmed = String(text || "").trim()
-    runRuleWrite(["set-alias", name, trimmed])
+    if (runRuleWrite(["set-alias", name, trimmed])) cancelAliasEdit()
+    else showSceneStatus("Another routing change is still finishing", true)
   }
 
   function toggleDeviceFavorite(name, currentFavorite) {
@@ -741,60 +970,80 @@ Item {
     id: microphoneTest
     scriptPath: runtime.script("audio-microphone-test")
     inputDevice: root.inputDevice
+    inputDeviceLive: root.mutableAudioNode(root.inputDevice)
     sessionActive: window.visible
   }
 
   Process {
     id: profilesProc
-    command: [runtime.script("audio-profiles")]
+    property string response: ""
+    command: runtime.scriptCommand("audio-profiles")
     stdout: StdioCollector {
       waitForEnd: true
-      onStreamFinished: root.parseAudioProfiles(text)
+      onStreamFinished: profilesProc.response = String(text || "")
     }
     onExited: function(exitCode) {
-      root.profilesLoaded = true
+      if (exitCode === 0) root.parseAudioProfiles(response)
+      else root.profilesLoaded = true
       root.profileLoadError = exitCode !== 0 && window.visible
         ? "Could not load audio profiles" : ""
+      response = ""
     }
   }
 
   Process {
     id: volumeSinkProc
-    command: ["omarchy-audio-output-sink"]
+    property string response: ""
+    property string requestedDefaultName: ""
+    property string requestedDefaultObjectId: ""
+    command: runtime.scriptCommand("audio-resolve-output-sink")
     stdout: StdioCollector {
       waitForEnd: true
-      onStreamFinished: root.volumeSinkName = String(text || "").trim()
+      onStreamFinished: volumeSinkProc.response = String(text || "").trim()
+    }
+    onExited: function(exitCode) {
+      var resolved = Model.sanitizeIdentifier(response, 160)
+      var currentDefaultName = Model.nodeName(root.defaultOutputDevice)
+      var currentDefaultObjectId = Model.nodeObjectId(root.defaultOutputDevice)
+      var requestStillCurrent = requestedDefaultName === currentDefaultName
+        && requestedDefaultObjectId === currentDefaultObjectId
+      var retry = root.volumeSinkResolvePending || !requestStillCurrent
+      if (requestStillCurrent)
+        root.volumeSinkName = exitCode === 0 && resolved !== "" ? resolved : ""
+      response = ""
+      requestedDefaultName = ""
+      requestedDefaultObjectId = ""
+      root.volumeSinkResolvePending = false
+      if (retry) Qt.callLater(root.resolveVolumeSink)
     }
   }
 
   Process {
     id: portsProc
-    command: [runtime.script("audio-ports")]
+    property string response: ""
+    command: runtime.scriptCommand("audio-ports")
     stdout: StdioCollector {
       waitForEnd: true
-      onStreamFinished: root.parseAudioPorts(text)
+      onStreamFinished: portsProc.response = String(text || "")
     }
     onExited: function(exitCode) {
+      if (exitCode === 0) root.parseAudioPorts(response)
       root.portLoadError = exitCode !== 0 && window.visible
         ? "Could not load audio ports" : ""
+      response = ""
     }
   }
 
   Process {
     id: profileSetProc
     onExited: function(exitCode) {
-      if (exitCode !== 0) root.profileSetError = "Could not change the audio profile"
-      else {
-        root.profileSetError = ""
-        if (root.pendingSharedProfile)
-          Quickshell.execDetached([
-            runtime.script("audio-preferences"),
-            "set-profile",
-            root.pendingSharedProfile.address,
-            root.pendingSharedProfile.profile
-          ])
-      }
-      root.pendingSharedProfile = null
+      root.profileSetError = exitCode === 0 ? ""
+        : (exitCode === 2
+          ? "Audio profile changed, but its shared preference could not be saved"
+          : (exitCode === 4
+            ? "Audio profile changed, but endpoint volume or mute state was only partially restored"
+            : (exitCode === 3 ? "That audio profile is no longer available"
+              : "Could not change the audio profile")))
       profileRefreshTimer.restart()
     }
   }
@@ -802,52 +1051,122 @@ Item {
   Process {
     id: portSetProc
     onExited: function(exitCode) {
-      root.portSetError = exitCode !== 0 ? "Could not change the audio port" : ""
+      root.portSetError = exitCode === 0 ? ""
+        : (exitCode === 4 ? "Audio port changed, but the active port could not be verified"
+          : (exitCode === 3 ? "That audio port is no longer available"
+            : "Could not change the audio port"))
       portRefreshTimer.restart()
     }
   }
 
   Process {
     id: bluetoothAutoswitchProc
+    property bool responseValid: false
+    property string response: ""
     stdout: StdioCollector {
       waitForEnd: true
       onStreamFinished: {
         var value = String(text || "").trim()
         if (value === "true" || value === "false") {
-          root.bluetoothAutoSwitch = value === "true"
-          root.bluetoothAutoSwitchLoaded = true
+          bluetoothAutoswitchProc.response = value
+          bluetoothAutoswitchProc.responseValid = true
         }
       }
     }
     onExited: function(exitCode) {
-      if (exitCode !== 0)
+      var wasMutation = root.autoswitchMutation
+      var succeeded = exitCode === 0 && responseValid
+      if (succeeded) {
+        root.bluetoothAutoSwitch = response === "true"
+        root.bluetoothAutoSwitchLoaded = true
+      }
+      if (!succeeded)
         root.bluetoothAutoswitchError = root.autoswitchMutation
-          ? "Could not change automatic headset mode"
+          ? (exitCode === 4
+            ? "Automatic headset mode changed and its previous value could not be restored"
+            : "Could not change automatic headset mode")
           : "Could not load automatic headset mode"
       else root.bluetoothAutoswitchError = ""
       root.autoswitchMutation = false
+      responseValid = false
+      response = ""
+      if (wasMutation && exitCode === 4) {
+        root.autoswitchReconcilePending = true
+        autoswitchReconcileTimer.restart()
+      }
     }
   }
 
   Process {
     id: bluetoothPreferenceProc
+    property bool responseValid: false
+    property string response: ""
     stdout: StdioCollector {
       waitForEnd: true
       onStreamFinished: {
         var value = String(text || "").trim()
         if (value === "quality" || value === "latency") {
-          root.bluetoothProfilePreference = value
-          root.bluetoothProfilePreferenceLoaded = true
+          bluetoothPreferenceProc.response = value
+          bluetoothPreferenceProc.responseValid = true
         }
       }
     }
     onExited: function(exitCode) {
-      if (exitCode !== 0)
+      var wasMutation = root.bluetoothProfilePreferenceMutation
+      var succeeded = exitCode === 0 && responseValid
+      if (succeeded) {
+        root.bluetoothProfilePreference = response
+        root.bluetoothProfilePreferenceLoaded = true
+      }
+      if (!succeeded)
         root.bluetoothPreferenceError = root.bluetoothProfilePreferenceMutation
-          ? "Could not change Bluetooth profile preference"
+          ? (exitCode === 4
+            ? "Bluetooth profile preference changed and its previous value could not be restored"
+            : "Could not change Bluetooth profile preference")
           : "Could not load Bluetooth profile preference"
       else root.bluetoothPreferenceError = ""
       root.bluetoothProfilePreferenceMutation = false
+      responseValid = false
+      response = ""
+      if (wasMutation && exitCode === 4) {
+        root.bluetoothPreferenceReconcilePending = true
+        bluetoothPreferenceReconcileTimer.restart()
+      }
+    }
+  }
+
+  Timer {
+    id: autoswitchReconcileTimer
+    interval: 250
+    repeat: false
+    onTriggered: {
+      if (bluetoothAutoswitchProc.running) {
+        restart()
+        return
+      }
+      root.autoswitchReconcilePending = false
+      bluetoothAutoswitchProc.responseValid = false
+      bluetoothAutoswitchProc.response = ""
+      bluetoothAutoswitchProc.command = runtime.scriptCommand("audio-bluetooth-autoswitch")
+      bluetoothAutoswitchProc.running = true
+    }
+  }
+
+  Timer {
+    id: bluetoothPreferenceReconcileTimer
+    interval: 250
+    repeat: false
+    onTriggered: {
+      if (bluetoothPreferenceProc.running) {
+        restart()
+        return
+      }
+      root.bluetoothPreferenceReconcilePending = false
+      bluetoothPreferenceProc.responseValid = false
+      bluetoothPreferenceProc.response = ""
+      bluetoothPreferenceProc.command = runtime.scriptCommand(
+        "audio-bluetooth-profile-preference")
+      bluetoothPreferenceProc.running = true
     }
   }
 
@@ -1114,6 +1433,8 @@ Item {
                     anchors.fill: parent
                     hoverEnabled: true
                     cursorShape: Qt.PointingHandCursor
+                    enabled: root.audioControlSettingsWritable
+                      && !root.audioControlWritePending && !root.audioMutationBusy
                     onContainsMouseChanged: if (containsMouse) root.setCursor(0)
                     onClicked: root.setOutputOverdrive(!root.outputOverdrive)
                   }
@@ -1157,7 +1478,7 @@ Item {
                     onCursorRequested: root.setCursor(audioPortDelegate.rowIndex)
                     onPortSelected: function(value) { root.setAudioPort(audioPortDelegate.port, value) }
                     onMenuToggled: function(open) {
-                      root.profileMenuOpen = open
+                      root.updateProfileMenu(open)
                       if (!open) Qt.callLater(function() { keyCatcher.forceActiveFocus() })
                     }
                   }
@@ -1227,6 +1548,7 @@ Item {
                       id: autoswitchToggle
                       checked: root.bluetoothAutoSwitch
                       busy: bluetoothAutoswitchProc.running
+                        || root.autoswitchReconcilePending
                       interactive: false
                       cursorRing: false
                       foreground: root.foreground
@@ -1236,7 +1558,9 @@ Item {
 
                   MouseArea {
                     anchors.fill: parent
-                    enabled: root.bluetoothAutoSwitchLoaded && !bluetoothAutoswitchProc.running
+                    enabled: root.bluetoothAutoSwitchLoaded
+                      && !bluetoothAutoswitchProc.running
+                      && !root.autoswitchReconcilePending
                     hoverEnabled: true
                     cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
                     onContainsMouseChanged: if (containsMouse) root.setCursor(0)
@@ -1253,11 +1577,13 @@ Item {
                   fill: root.hoverFill
                   fontFamily: root.fontFamily
                   preference: root.bluetoothProfilePreference
-                  menuEnabled: root.bluetoothProfilePreferenceLoaded && !bluetoothPreferenceProc.running
+                  menuEnabled: root.bluetoothProfilePreferenceLoaded
+                    && !bluetoothPreferenceProc.running
+                    && !root.bluetoothPreferenceReconcilePending
                   onCursorRequested: root.setCursor(1)
                   onPreferenceSelected: function(value) { root.setBluetoothProfilePreference(value) }
                   onMenuToggled: function(open) {
-                    root.profileMenuOpen = open
+                    root.updateProfileMenu(open)
                     if (!open) Qt.callLater(function() { keyCatcher.forceActiveFocus() })
                   }
                 }
@@ -1323,9 +1649,10 @@ Item {
                       required property int index
                       width: parent.width
                       definition: modelData
-                      checked: root.policySettings[modelData.key] === true
+                      checked: Model.mapValue(root.policySettings, modelData.key, false) === true
                       busy: policy.busy && root.pendingPolicyKey === modelData.key
                       enabled: root.policySettingsLoaded && !policy.busy
+                        && !root.policyMutationBlocked
                       opacity: enabled ? 1 : 0.6
                       hasCursor: root.cursorActive && root.activeTab === 2
                         && root.selectedIndex === index
@@ -1334,7 +1661,7 @@ Item {
                       fontFamily: root.fontFamily
                       onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(policyCoreRow)
                       onHovered: root.setCursor(index)
-                      onActivated: policy.setSetting(modelData.key, !checked)
+                      onActivated: root.setPolicySetting(modelData.key, !checked)
                     }
                   }
                 }
@@ -1367,8 +1694,9 @@ Item {
                       readonly property int rowIndex: root.policyVolumeStartIndex + index
                       width: parent.width
                       definition: modelData
-                      value: Number(root.policySettings[modelData.key])
+                      value: Number(Model.mapValue(root.policySettings, modelData.key, 0))
                       enabled: root.policySettingsLoaded && !policy.busy
+                        && !root.policyMutationBlocked
                       opacity: enabled ? 1 : 0.6
                       hasCursor: root.cursorActive && root.activeTab === 2
                         && root.selectedIndex === rowIndex
@@ -1377,7 +1705,7 @@ Item {
                       fontFamily: root.fontFamily
                       onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(policyVolumeRow)
                       onHovered: root.setCursor(rowIndex)
-                      onCommitted: function(value) { policy.setSetting(modelData.key, value) }
+                      onCommitted: function(value) { root.setPolicySetting(modelData.key, value) }
                     }
                   }
                 }
@@ -1409,9 +1737,10 @@ Item {
                       readonly property int rowIndex: root.policyExperimentalStartIndex + index
                       width: parent.width
                       definition: modelData
-                      checked: root.policySettings[modelData.key] === true
+                      checked: Model.mapValue(root.policySettings, modelData.key, false) === true
                       busy: policy.busy && root.pendingPolicyKey === modelData.key
                       enabled: root.policySettingsLoaded && !policy.busy
+                        && !root.policyMutationBlocked
                       opacity: enabled ? 1 : 0.6
                       hasCursor: root.cursorActive && root.activeTab === 2
                         && root.selectedIndex === rowIndex
@@ -1420,7 +1749,7 @@ Item {
                       fontFamily: root.fontFamily
                       onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(policyExperimentalRow)
                       onHovered: root.setCursor(rowIndex)
-                      onActivated: policy.setSetting(modelData.key, !checked)
+                      onActivated: root.setPolicySetting(modelData.key, !checked)
                     }
                   }
                 }
@@ -1445,7 +1774,8 @@ Item {
                     width: parent.width
                     definition: root.captureNotificationDefinition
                     checked: root.captureNotifications
-                    enabled: true
+                    enabled: root.audioControlSettingsWritable
+                      && !root.audioControlWritePending
                     hasCursor: root.cursorActive && root.activeTab === 2
                       && root.selectedIndex === root.captureNotificationIndex
                     foreground: root.foreground
@@ -1477,7 +1807,7 @@ Item {
                   id: sceneSaveRow
                   width: parent.width
                   implicitHeight: sceneSaveContent.implicitHeight + Style.space(18)
-                  enabled: !sceneController.busy && !sceneStoreProc.running
+                  enabled: !root.sceneMutationBusy
                   hasCursor: root.cursorActive && root.activeTab === 3 && root.selectedIndex === 0
                   onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(sceneSaveRow)
                   foreground: root.foreground
@@ -1488,7 +1818,7 @@ Item {
                   // clickable; clicks landing anywhere else still save.
                   MouseArea {
                     anchors.fill: parent
-                    enabled: !sceneController.busy && !sceneStoreProc.running
+                    enabled: !root.sceneMutationBusy
                     hoverEnabled: true
                     cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
                     onContainsMouseChanged: if (containsMouse) root.setCursor(0)
@@ -1520,8 +1850,9 @@ Item {
 
                       Text {
                         width: parent.width
-                        text: sceneController.busy || sceneStoreProc.running
-                          ? "Capturing the current audio state…"
+                        text: root.sceneMutationBusy
+                          ? (root.sceneReloadPending ? "Updating saved scenes…"
+                            : "Capturing the current audio state…")
                           : "Captures every connected device with its current settings."
                         color: Qt.darker(root.foreground, 1.35)
                         font.family: root.fontFamily
@@ -1553,7 +1884,7 @@ Item {
                     width: parent.width
                     sceneName: modelData ? String(modelData.name || "") : ""
                     summary: Model.sceneSummary(modelData)
-                    actionEnabled: !sceneController.busy && !sceneStoreProc.running
+                    actionEnabled: !root.sceneMutationBusy
                     hasCursor: root.cursorActive && root.activeTab === 3
                       && root.selectedIndex === 1 + sceneListRow.index
                     onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(sceneListRow)
@@ -1671,7 +2002,7 @@ Item {
                       onHovered: function(on) { if (on) root.setCursor(0) }
                       onChanged: function(value) { root.newRuleApp = value }
                       onPopupOpenChanged: {
-                        root.profileMenuOpen = popupOpen
+                        root.updateProfileMenu(popupOpen)
                         if (!popupOpen) Qt.callLater(function() { keyCatcher.forceActiveFocus() })
                       }
                     }
@@ -1740,7 +2071,7 @@ Item {
                       value: ""
                       options: rulesStore.targetOptions
                       hasCursor: newRuleDeviceRow.hasCursor
-                      enabled: root.newRuleApp !== ""
+                      enabled: root.newRuleApp !== "" && !root.routingMutation
                       opacity: enabled ? 1 : 0.6
                       foreground: root.foreground
                       fontFamily: root.fontFamily
@@ -1756,7 +2087,7 @@ Item {
                         root.newRuleApp = ""
                       }
                       onPopupOpenChanged: {
-                        root.profileMenuOpen = popupOpen
+                        root.updateProfileMenu(popupOpen)
                         if (!popupOpen) Qt.callLater(function() { keyCatcher.forceActiveFocus() })
                       }
                     }
@@ -1797,7 +2128,7 @@ Item {
                     fontFamily: root.fontFamily
                     onCursorRequested: root.setCursor(2 + routingRuleDelegate.index)
                     onMenuToggled: function(open) {
-                      root.profileMenuOpen = open
+                      root.updateProfileMenu(open)
                       if (!open) Qt.callLater(function() { keyCatcher.forceActiveFocus() })
                     }
                     onTargetChosen: function(value) {
@@ -1820,7 +2151,7 @@ Item {
 
                 Text {
                   width: parent.width
-                  text: "Give a device a custom name, favorite it to sort it first, or hide it everywhere."
+                  text: "Give a device a custom name, favorite it to sort it first, or hide it from mixer device lists."
                   color: Qt.darker(root.foreground, 1.35)
                   font.family: root.fontFamily
                   font.pixelSize: Style.font.bodySmall
@@ -1957,7 +2288,7 @@ Item {
                         root.setAudioProfile(bluetoothProfileDelegate.card, profile)
                       }
                       onMenuToggled: function(open) {
-                        root.profileMenuOpen = open
+                        root.updateProfileMenu(open)
                         if (!open) Qt.callLater(function() { keyCatcher.forceActiveFocus() })
                       }
                     }
@@ -2000,7 +2331,7 @@ Item {
                         root.setAudioProfile(deviceProfileDelegate.card, profile)
                       }
                       onMenuToggled: function(open) {
-                        root.profileMenuOpen = open
+                        root.updateProfileMenu(open)
                         if (!open) Qt.callLater(function() { keyCatcher.forceActiveFocus() })
                       }
                     }
@@ -2033,6 +2364,7 @@ Item {
                     rowIndex: root.outputBalanceIndex
                     deviceLabel: root.nodeLabel(root.outputDevice)
                     balanceValue: root.balanceFor(root.outputDevice)
+                    enabled: !root.audioMutationBusy
                     foreground: root.foreground
                     fill: root.hoverFill
                     fontFamily: root.fontFamily
@@ -2051,6 +2383,7 @@ Item {
                     rowIndex: root.inputBalanceIndex
                     deviceLabel: root.nodeLabel(root.inputDevice)
                     balanceValue: root.balanceFor(root.inputDevice)
+                    enabled: !root.audioMutationBusy
                     foreground: root.foreground
                     fill: root.hoverFill
                     fontFamily: root.fontFamily
@@ -2088,6 +2421,8 @@ Item {
                     microphoneMuted: root.inputDeviceMuted
                     error: microphoneTest.error
                     enabled: !profileSetProc.running && !portSetProc.running
+                      && !sceneController.busy && !policy.busy
+                      && !root.diagnosticsMutationBusy
                     hasCursor: root.cursorActive && root.activeTab === 0
                       && root.selectedIndex === root.microphoneTestIndex
                     foreground: root.foreground

--- a/AudioAppRuleRow.qml
+++ b/AudioAppRuleRow.qml
@@ -14,6 +14,7 @@ CursorSurface {
   required property bool menuEnabled
   property color urgent: Color.urgent
   property string fontFamily: Style.font.family
+  property bool menuReportedOpen: false
 
   signal targetChosen(string value)
   signal deleted()
@@ -27,6 +28,13 @@ CursorSurface {
 
   function toggleTargetMenu() { if (targetDropdown.enabled) targetDropdown.toggle() }
   function closeTargetMenu() { targetDropdown.close() }
+  function reportMenu(open) {
+    var next = open === true
+    if (menuReportedOpen === next) return
+    menuReportedOpen = next
+    menuToggled(next)
+  }
+  Component.onDestruction: root.reportMenu(false)
 
   Row {
     anchors.left: parent.left
@@ -80,7 +88,7 @@ CursorSurface {
 
       onHovered: function(on) { if (on) root.cursorRequested() }
       onChanged: function(value) { root.targetChosen(value) }
-      onPopupOpenChanged: root.menuToggled(popupOpen)
+      onPopupOpenChanged: root.reportMenu(popupOpen)
     }
 
     PanelActionButton {

--- a/AudioBluetoothPreferenceRow.qml
+++ b/AudioBluetoothPreferenceRow.qml
@@ -8,6 +8,7 @@ CursorSurface {
   required property string preference
   required property bool menuEnabled
   property string fontFamily: Style.font.family
+  property bool menuReportedOpen: false
 
   signal cursorRequested()
   signal preferenceSelected(string value)
@@ -19,6 +20,13 @@ CursorSurface {
 
   function togglePreferenceMenu() { if (preferenceDropdown.enabled) preferenceDropdown.toggle() }
   function closePreferenceMenu() { preferenceDropdown.close() }
+  function reportMenu(open) {
+    var next = open === true
+    if (menuReportedOpen === next) return
+    menuReportedOpen = next
+    menuToggled(next)
+  }
+  Component.onDestruction: root.reportMenu(false)
 
   Row {
     anchors.left: parent.left
@@ -73,7 +81,7 @@ CursorSurface {
 
       onHovered: function(on) { if (on) root.cursorRequested() }
       onChanged: function(value) { root.preferenceSelected(value) }
-      onPopupOpenChanged: root.menuToggled(popupOpen)
+      onPopupOpenChanged: root.reportMenu(popupOpen)
     }
   }
 

--- a/AudioDevicePrefRow.qml
+++ b/AudioDevicePrefRow.qml
@@ -29,6 +29,15 @@ CursorSurface {
   implicitHeight: prefContent.implicitHeight + Style.space(18)
   bordered: true
 
+  // Keep row activation below the explicit action buttons so a favorite,
+  // visibility, or edit-confirmation click cannot also start a rename.
+  MouseArea {
+    anchors.fill: parent
+    enabled: !root.editingAlias && root.interactive
+    cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
+    onClicked: root.aliasEditStarted()
+  }
+
   Row {
     id: prefContent
     anchors.left: parent.left
@@ -70,6 +79,7 @@ CursorSurface {
       TextField {
         id: aliasField
         visible: root.editingAlias
+        enabled: root.interactive
         width: parent.width
         // Occupy the title and device-code slots together so the outer
         // rectangle keeps its size while renaming.
@@ -113,7 +123,7 @@ CursorSurface {
         foreground: root.foreground
         fontFamily: root.fontFamily
         bordered: true
-        enabled: root.enabled
+        enabled: root.enabled && root.interactive
         onClicked: root.aliasCommitted(aliasField.text)
       }
 
@@ -125,7 +135,7 @@ CursorSurface {
         hoverColor: root.urgent
         fontFamily: root.fontFamily
         bordered: true
-        enabled: root.enabled
+        enabled: root.enabled && root.interactive
         onClicked: root.aliasCancelled()
       }
 
@@ -174,8 +184,4 @@ CursorSurface {
     onContainsMouseChanged: if (containsMouse) root.cursorRequested()
   }
 
-  TapHandler {
-    enabled: !root.editingAlias && root.interactive
-    onTapped: root.aliasEditStarted()
-  }
 }

--- a/AudioDiagnosticsController.qml
+++ b/AudioDiagnosticsController.qml
@@ -13,6 +13,9 @@ Item {
   required property string speakerTestPath
   required property string recoveryPath
   property bool sessionActive: false
+  // Supplied by the host so service recovery and channel playback cannot race
+  // profile, port, scene, microphone, or policy mutations.
+  property bool mutationBlocked: false
 
   property var snapshot: Model.emptyAudioDiagnostics()
   property bool loaded: false
@@ -21,16 +24,22 @@ Item {
   property bool statusIsError: false
   property bool snapshotValid: false
   property bool speakerCancelled: false
+  property bool speakerStopping: false
+  property bool recoveryPending: false
 
   readonly property bool refreshing: snapshotProc.running
   readonly property bool copying: copyProc.running
-  readonly property bool speakerTesting: speakerProc.running
-  readonly property bool recovering: recoveryProc.running
+  readonly property bool speakerTesting: speakerProc.running || speakerStopping
+  readonly property bool recovering: recoveryProc.running || recoveryPending
   readonly property bool busy: refreshing || copying || recovering
 
   onSessionActiveChanged: {
     if (sessionActive) refresh()
     else stopSpeakerTest(false)
+  }
+  onMutationBlockedChanged: if (mutationBlocked) {
+    recoveryPending = false
+    stopSpeakerTest(false)
   }
 
   function showStatus(message, isError) {
@@ -53,54 +62,66 @@ Item {
   }
 
   function refresh() {
-    if (snapshotProc.running) return
+    if (snapshotProc.running || copyProc.running || speakerTesting || recovering) return
     error = ""
     snapshotValid = false
-    snapshotProc.command = [diagnosticsPath, "snapshot"]
+    snapshotProc.response = ""
+    snapshotProc.command = ["/bin/bash", diagnosticsPath, "snapshot"]
     snapshotProc.running = true
   }
 
   function copySupportReport() {
-    if (copyProc.running || !snapshot.capabilities.supportReport
+    if (copyProc.running || snapshotProc.running || speakerTesting || recovering
+        || !snapshot.capabilities.supportReport
         || !snapshot.capabilities.clipboard) return
-    copyProc.command = [diagnosticsPath, "copy-report"]
+    copyProc.command = ["/bin/bash", diagnosticsPath, "copy-report"]
     copyProc.running = true
   }
 
   function toggleSpeakerTest() {
+    if (speakerStopping) return
     if (speakerProc.running) {
       stopSpeakerTest(true)
       return
     }
+    if (mutationBlocked || busy) return
     var sink = snapshot.defaults ? String(snapshot.defaults.output || "") : ""
     if (!snapshot.capabilities.speakerTest || sink === "") return
     speakerCancelled = false
-    speakerProc.command = [speakerTestPath, sink]
+    speakerProc.command = ["/bin/bash", speakerTestPath, sink]
     speakerProc.running = true
     showStatus("Testing each reported output channel…", false)
   }
 
   function stopSpeakerTest(showFeedback) {
-    if (!speakerProc.running) return
+    if (speakerStopping || !speakerProc.running) return
     speakerCancelled = true
+    speakerStopping = true
     speakerProc.running = false
     if (showFeedback) showStatus("Stopped the speaker test", false)
   }
 
   function runRecovery() {
-    if (recoveryProc.running || !snapshot.capabilities.recovery) return
-    stopSpeakerTest(false)
-    recoveryProc.command = [recoveryPath]
+    if (mutationBlocked || busy || !snapshot.capabilities.recovery) return
+    if (speakerProc.running || speakerStopping) {
+      recoveryPending = true
+      stopSpeakerTest(false)
+      return
+    }
+    recoveryProc.command = ["/bin/bash", recoveryPath]
     recoveryProc.running = true
   }
 
   Process {
     id: snapshotProc
+    property string response: ""
     stdout: StdioCollector {
       waitForEnd: true
-      onStreamFinished: root.loadSnapshot(text)
+      onStreamFinished: snapshotProc.response = String(text || "")
     }
     onExited: function(exitCode) {
+      if (exitCode === 0) root.loadSnapshot(response)
+      response = ""
       if (exitCode !== 0 || !root.snapshotValid) {
         root.loaded = true
         root.error = "Could not collect audio diagnostics"
@@ -124,11 +145,21 @@ Item {
     onExited: function(exitCode) {
       if (root.speakerCancelled) {
         root.speakerCancelled = false
+        root.speakerStopping = false
+        if (root.recoveryPending) {
+          root.recoveryPending = false
+          root.runRecovery()
+        }
         return
       }
+      root.speakerStopping = false
       root.showStatus(exitCode === 0
         ? "Finished the speaker channel test"
         : "Could not complete the speaker channel test", exitCode !== 0)
+      if (root.recoveryPending) {
+        root.recoveryPending = false
+        root.runRecovery()
+      }
     }
   }
 
@@ -136,8 +167,8 @@ Item {
     id: recoveryProc
     onExited: function(exitCode) {
       root.showStatus(exitCode === 0
-        ? "Opened Omarchy audio recovery in a terminal"
-        : "Could not open Omarchy audio recovery", exitCode !== 0)
+        ? "Finished Omarchy audio recovery"
+        : "Could not complete Omarchy audio recovery", exitCode !== 0)
       if (exitCode === 0) recoveryRefresh.restart()
     }
   }

--- a/AudioDiagnosticsView.qml
+++ b/AudioDiagnosticsView.qml
@@ -34,7 +34,8 @@ Column {
     if (index === 0) controller.refresh()
     else if (index === 1) controller.toggleSpeakerTest()
     else if (index === 2) controller.copySupportReport()
-    else if (index === 3 && snapshot.capabilities.recovery) recoveryRequested()
+    else if (index === 3 && snapshot.capabilities.recovery
+        && !controller.mutationBlocked && !controller.busy) recoveryRequested()
   }
 
   function graphDescription() {
@@ -121,7 +122,7 @@ Column {
             Text {
               width: parent.width
               text: root.controller.refreshing ? "Checking audio services…"
-                : (root.snapshot.healthy ? "Audio services are healthy" : "Audio needs attention")
+                : (root.snapshot.healthy ? "Audio system is healthy" : "Audio needs attention")
               color: root.snapshot.healthy ? root.foreground : root.urgent
               font.family: root.fontFamily
               font.pixelSize: Style.font.body
@@ -362,6 +363,8 @@ Column {
         : "Recheck services, graph statistics, devices, formats, and routes."
       icon: "󰑐"
       busy: root.controller.refreshing
+      actionEnabled: !root.controller.copying && !root.controller.speakerTesting
+        && !root.controller.recovering
       hasCursor: root.tabActive && root.cursorActive && root.selectedIndex === 0
       foreground: root.foreground
       fill: root.fill
@@ -384,7 +387,9 @@ Column {
             + " at a conservative level."
           : "No testable default output or speaker-test command is available.")
       icon: root.controller.speakerTesting ? "󰓛" : "󰓃"
-      actionEnabled: root.controller.speakerTesting || root.snapshot.capabilities.speakerTest
+      actionEnabled: root.controller.speakerTesting
+        || (root.snapshot.capabilities.speakerTest
+          && !root.controller.mutationBlocked && !root.controller.busy)
       hasCursor: root.tabActive && root.cursorActive && root.selectedIndex === 1
       foreground: root.foreground
       fill: root.fill
@@ -405,7 +410,8 @@ Column {
       icon: "󰆏"
       busy: root.controller.copying
       actionEnabled: root.snapshot.capabilities.supportReport
-        && root.snapshot.capabilities.clipboard
+        && root.snapshot.capabilities.clipboard && !root.controller.refreshing
+        && !root.controller.speakerTesting && !root.controller.recovering
       hasCursor: root.tabActive && root.cursorActive && root.selectedIndex === 2
       foreground: root.foreground
       fill: root.fill
@@ -424,6 +430,7 @@ Column {
         : "Omarchy's recovery command or terminal launcher is not available."
       icon: "󰑓"
       actionEnabled: root.snapshot.capabilities.recovery
+        && !root.controller.mutationBlocked && !root.controller.busy
       urgentAction: true
       hasCursor: root.tabActive && root.cursorActive && root.selectedIndex === 3
       foreground: root.foreground

--- a/AudioDropdown.qml
+++ b/AudioDropdown.qml
@@ -65,6 +65,8 @@ Item {
   signal changed(string value)
   signal hovered(bool isHovered)
 
+  onEnabledChanged: if (!enabled) popup.close()
+
   function optionValue(o) {
     return (o && typeof o === "object") ? String(o.value) : String(o)
   }

--- a/AudioMicrophoneTestController.qml
+++ b/AudioMicrophoneTestController.qml
@@ -2,6 +2,7 @@ import QtQuick
 import Quickshell
 import Quickshell.Io
 import Quickshell.Services.Pipewire
+import "Model.js" as Model
 
 // Owns the complete lifecycle of the private record/playback probe. The
 // advanced window only renders this state, which keeps process cancellation
@@ -11,38 +12,63 @@ Item {
 
   required property string scriptPath
   property var inputDevice: null
+  required property bool inputDeviceLive
   property bool sessionActive: false
 
   property string testState: "idle"
   property string operation: ""
   property bool cancelled: false
+  property bool discardRequested: false
+  property bool cancelNeedsClear: false
+  property string cancelFinalState: "idle"
   property int secondsRemaining: 0
   property string error: ""
 
-  readonly property bool microphoneMuted: !inputDevice || !inputDevice.audio
-    || inputDevice.audio.muted
-  readonly property bool busy: testProc.running || stopProc.running
-  readonly property real level: inputDevice && inputDevice.audio && !inputDevice.audio.muted
-    ? Math.max(0, Math.min(1, Number(peakMonitor.peak || 0))) : 0
+  readonly property bool microphoneMuted: deviceMuted()
+  readonly property bool busy: testProc.running || stopProc.running || clearProc.running
+    || cancelled || discardRequested
+  readonly property real level: {
+    try {
+      if (!inputDeviceLive || !inputDevice || !inputDevice.audio
+          || inputDevice.audio.muted) return 0
+      var value = Number(peakMonitor.peak)
+      return isFinite(value) ? Math.max(0, Math.min(1, value)) : 0
+    } catch (_error) {
+      return 0
+    }
+  }
 
   onInputDeviceChanged: if (testState !== "idle") discard()
+  onInputDeviceLiveChanged: if (!inputDeviceLive && testState !== "idle") discard()
   onMicrophoneMutedChanged: if (microphoneMuted && testState === "recording") cancel()
   onSessionActiveChanged: if (!sessionActive && testState !== "idle") discard()
 
+  function deviceMuted() {
+    if (!inputDeviceLive || !inputDevice) return true
+    try { return !inputDevice.audio || inputDevice.audio.muted === true }
+    catch (_error) { return true }
+  }
+
   function clearClip() {
-    Quickshell.execDetached([scriptPath, "clear"])
+    if (clearProc.running) return
+    clearProc.command = ["/bin/bash", scriptPath, "clear"]
+    clearProc.running = true
   }
 
   function startRecording() {
-    if (!inputDevice || !inputDevice.name || microphoneMuted || busy) return
+    var sourceName = Model.nodeName(inputDevice)
+    if (!inputDeviceLive || sourceName === "" || microphoneMuted || busy) return
     error = ""
     cancelled = false
+    discardRequested = false
+    cancelNeedsClear = false
     operation = "record"
     testState = "recording"
     secondsRemaining = 5
-    testProc.command = [scriptPath, "record", String(inputDevice.name)]
+    testProc.command = ["/bin/bash", scriptPath, "record", sourceName]
     testProc.running = true
     countdown.restart()
+    recordWatchdog.restart()
   }
 
   function play() {
@@ -51,7 +77,7 @@ Item {
     cancelled = false
     operation = "play"
     testState = "playing"
-    testProc.command = [scriptPath, "play"]
+    testProc.command = ["/bin/bash", scriptPath, "play"]
     testProc.running = true
   }
 
@@ -60,8 +86,10 @@ Item {
     error = ""
     testState = "stopping"
     countdown.stop()
+    recordWatchdog.stop()
+    stopWatchdog.restart()
     secondsRemaining = 0
-    stopProc.command = [scriptPath, "stop"]
+    stopProc.command = ["/bin/bash", scriptPath, "stop"]
     stopProc.running = true
   }
 
@@ -69,25 +97,35 @@ Item {
     if (!testProc.running) return
     var cancelledOperation = operation
     cancelled = true
+    cancelFinalState = cancelledOperation === "record" ? "idle" : "ready"
+    cancelNeedsClear = cancelledOperation === "record"
+    testState = "cancelling"
     testProc.running = false
     countdown.stop()
+    recordWatchdog.stop()
+    stopWatchdog.stop()
     secondsRemaining = 0
-    testState = cancelledOperation === "record" ? "idle" : "ready"
-    if (cancelledOperation === "record") clearClip()
   }
 
   function discard() {
+    discardRequested = true
     if (stopProc.running) stopProc.running = false
-    if (testProc.running) cancel()
+    if (testProc.running) {
+      cancel()
+      return
+    }
     countdown.stop()
+    recordWatchdog.stop()
+    stopWatchdog.stop()
     secondsRemaining = 0
     testState = "idle"
     error = ""
+    discardRequested = false
     clearClip()
   }
 
   function activate() {
-    if (testState === "stopping") return
+    if (testState === "stopping" || testState === "cancelling") return
     if (testState === "recording") stopRecording()
     else if (testProc.running) cancel()
     else if (testState === "ready") play()
@@ -97,7 +135,8 @@ Item {
   PwNodePeakMonitor {
     id: peakMonitor
     node: root.inputDevice
-    enabled: root.sessionActive && root.testState === "recording" && !!root.inputDevice
+    enabled: root.sessionActive && root.testState === "recording"
+      && root.inputDeviceLive && !!root.inputDevice
   }
 
   Process {
@@ -106,10 +145,17 @@ Item {
     onExited: function(exitCode) {
       var completedOperation = root.operation
       countdown.stop()
+      recordWatchdog.stop()
+      stopWatchdog.stop()
       root.secondsRemaining = 0
       if (root.cancelled) {
         root.cancelled = false
         root.operation = ""
+        var clear = root.cancelNeedsClear || root.discardRequested
+        root.testState = root.discardRequested ? "idle" : root.cancelFinalState
+        root.cancelNeedsClear = false
+        root.discardRequested = false
+        if (clear) root.clearClip()
         return
       }
 
@@ -142,11 +188,41 @@ Item {
     }
   }
 
+  Process {
+    id: clearProc
+    onExited: function(exitCode) {
+      if (exitCode !== 0 && root.sessionActive)
+        root.error = "Could not discard the microphone test"
+    }
+  }
+
   Timer {
     id: countdown
     interval: 1000
     repeat: true
     onTriggered: if (root.testState === "recording")
       root.secondsRemaining = Math.max(0, root.secondsRemaining - 1)
+  }
+
+  Timer {
+    id: recordWatchdog
+    interval: 8000
+    repeat: false
+    onTriggered: {
+      if (root.operation !== "record" || !testProc.running) return
+      root.error = "Microphone test recording timed out"
+      root.cancel()
+    }
+  }
+
+  Timer {
+    id: stopWatchdog
+    interval: 3000
+    repeat: false
+    onTriggered: {
+      if (root.testState !== "stopping" || !testProc.running) return
+      root.error = "Microphone test did not stop cleanly"
+      root.cancel()
+    }
   }
 }

--- a/AudioPolicyController.qml
+++ b/AudioPolicyController.qml
@@ -14,11 +14,13 @@ Item {
   property bool loaded: false
   property string error: ""
   property string pendingKey: ""
-  readonly property bool busy: policyProc.running
+  property bool reconcilePending: false
+  readonly property bool busy: policyProc.running || reconcilePending
 
   property bool mutation: false
   property bool responseValid: false
   property var previousSettings: ({})
+  property var pendingValue: null
 
   readonly property var coreDefinitions: [
     {
@@ -82,14 +84,15 @@ Item {
     var supported = []
     for (var i = 0; i < definitions.length; i++) {
       var definition = definitions[i]
-      if (settings[definition.key] !== undefined) supported.push(definition)
+      if (Model.hasOwn(settings, definition.key)) supported.push(definition)
     }
     return supported
   }
 
   function copySettings(source) {
     var copy = ({})
-    for (var key in source) copy[key] = source[key]
+    for (var key in source)
+      if (Model.hasOwn(source, key)) copy[key] = source[key]
     return copy
   }
 
@@ -97,17 +100,32 @@ Item {
     var response = Model.parseAudioPolicySettings(raw)
     responseValid = response.valid
     if (!response.valid) return
+    if (mutation) {
+      if (!Model.hasOwn(response.values, pendingKey)) {
+        responseValid = false
+        return
+      }
+      var actual = Model.mapValue(response.values, pendingKey, null)
+      if ((typeof pendingValue === "boolean" && actual !== pendingValue)
+          || (typeof pendingValue === "number"
+            && (typeof actual !== "number" || Math.abs(actual - pendingValue) > 0.001))) {
+        responseValid = false
+        return
+      }
+    }
     settings = response.values
     loaded = true
   }
 
   function refresh() {
-    loaded = false
     if (busy) return
+    loaded = false
     mutation = false
     responseValid = false
     pendingKey = ""
-    policyProc.command = [scriptPath]
+    pendingValue = null
+    policyProc.response = ""
+    policyProc.command = ["/bin/bash", scriptPath]
     policyProc.running = true
   }
 
@@ -116,8 +134,8 @@ Item {
   }
 
   function setSetting(key, value) {
-    if (!loaded || busy || settings[key] === undefined) return
-    var current = settings[key]
+    if (!loaded || busy || !Model.hasOwn(settings, key)) return
+    var current = Model.mapValue(settings, key, null)
     var normalized
     if (typeof current === "boolean") {
       if (typeof value !== "boolean") return
@@ -136,31 +154,53 @@ Item {
     mutation = true
     responseValid = false
     pendingKey = key
-    policyProc.command = [scriptPath, "set", key, String(normalized)]
+    pendingValue = normalized
+    policyProc.response = ""
+    policyProc.command = ["/bin/bash", scriptPath, "set", key, String(normalized)]
     policyProc.running = true
   }
 
   Process {
     id: policyProc
+    property string response: ""
     stdout: StdioCollector {
       waitForEnd: true
-      onStreamFinished: root.loadResponse(text)
+      onStreamFinished: policyProc.response = String(text || "")
     }
     onExited: function(exitCode) {
+      if (exitCode === 0) root.loadResponse(response)
+      response = ""
       var wasMutation = root.mutation
       if (exitCode !== 0 || !root.responseValid) {
-        root.settings = wasMutation ? root.previousSettings : ({})
+        if (wasMutation) root.settings = root.previousSettings
         root.loaded = true
         root.error = wasMutation
-          ? "Could not change the audio safety policy"
+          ? (exitCode === 4
+            ? "Audio safety policy changed and its previous value could not be restored"
+            : "Could not change the audio safety policy")
           : "Could not load audio safety policies"
       } else {
         root.error = ""
       }
       root.mutation = false
       root.pendingKey = ""
+      root.pendingValue = null
       root.previousSettings = ({})
+      if (wasMutation && exitCode === 4) {
+        root.reconcilePending = true
+        reconcileTimer.restart()
+      }
       root.settled()
+    }
+  }
+
+  Timer {
+    id: reconcileTimer
+    interval: 250
+    repeat: false
+    onTriggered: {
+      root.reconcilePending = false
+      root.refresh()
     }
   }
 }

--- a/AudioPortRow.qml
+++ b/AudioPortRow.qml
@@ -9,6 +9,7 @@ CursorSurface {
   required property int rowIndex
   required property bool menuEnabled
   property string fontFamily: Style.font.family
+  property bool menuReportedOpen: false
 
   signal cursorRequested()
   signal portSelected(string value)
@@ -20,6 +21,13 @@ CursorSurface {
 
   function togglePortMenu() { if (portDropdown.enabled) portDropdown.toggle() }
   function closePortMenu() { portDropdown.close() }
+  function reportMenu(open) {
+    var next = open === true
+    if (menuReportedOpen === next) return
+    menuReportedOpen = next
+    menuToggled(next)
+  }
+  Component.onDestruction: root.reportMenu(false)
 
   Row {
     anchors.left: parent.left
@@ -71,7 +79,7 @@ CursorSurface {
 
       onHovered: function(on) { if (on) root.cursorRequested() }
       onChanged: function(value) { root.portSelected(value) }
-      onPopupOpenChanged: root.menuToggled(popupOpen)
+      onPopupOpenChanged: root.reportMenu(popupOpen)
     }
   }
 

--- a/AudioProfileRow.qml
+++ b/AudioProfileRow.qml
@@ -11,6 +11,7 @@ CursorSurface {
   required property var options
   required property bool menuEnabled
   property string fontFamily: Style.font.family
+  property bool menuReportedOpen: false
 
   signal cursorRequested()
   signal profileSelected(string profile)
@@ -22,8 +23,14 @@ CursorSurface {
 
   function toggleProfileMenu() { if (profileDropdown.enabled) profileDropdown.toggle() }
   function closeProfileMenu() { profileDropdown.close() }
+  function reportMenu(open) {
+    var next = open === true
+    if (menuReportedOpen === next) return
+    menuReportedOpen = next
+    menuToggled(next)
+  }
 
-  Component.onDestruction: if (profileDropdown.popupOpen) root.menuToggled(false)
+  Component.onDestruction: root.reportMenu(false)
 
   Row {
     anchors.left: parent.left
@@ -76,7 +83,7 @@ CursorSurface {
 
       onHovered: function(on) { if (on) root.cursorRequested() }
       onChanged: function(profile) { root.profileSelected(profile) }
-      onPopupOpenChanged: root.menuToggled(popupOpen)
+      onPopupOpenChanged: root.reportMenu(popupOpen)
     }
   }
 }

--- a/AudioRulesController.qml
+++ b/AudioRulesController.qml
@@ -16,7 +16,8 @@ Item {
   property var rules: Model.parseAudioRules("")
   property bool loaded: false
   property string error: ""
-  readonly property bool busy: writeProc.running
+  property bool reloadPending: false
+  readonly property bool busy: writeProc.running || reloadPending
 
   readonly property var nodeGroups: Model.classifyAudioNodes(nodes)
   readonly property var sinks: nodeGroups.sinks
@@ -31,11 +32,48 @@ Item {
   signal writeFinished(bool success)
 
   function aliasFor(name) {
-    return rules.devices.aliases[String(name || "")] || ""
+    return String(Model.mapValue(
+      rules && rules.devices ? rules.devices.aliases : null,
+      String(name || ""), "") || "")
   }
 
   function isHidden(name) {
     return rules.devices.hidden.indexOf(String(name || "")) !== -1
+  }
+
+  function liveTargetInfo(name) {
+    var target = String(name || "")
+    var info = { count: 0, direction: "", node: null }
+    if (target === "") return info
+    var groups = [
+      { nodes: sinks, direction: "playback" },
+      { nodes: sources, direction: "recording" }
+    ]
+    for (var g = 0; g < groups.length; g++) {
+      for (var i = 0; i < groups[g].nodes.length && i < 512; i++) {
+        var node = groups[g].nodes[i]
+        if (Model.nodeName(node) !== target) continue
+        info.count++
+        if (info.count === 1) {
+          info.direction = groups[g].direction
+          info.node = node
+        } else {
+          info.direction = ""
+          info.node = null
+        }
+      }
+    }
+    return info
+  }
+
+  function directionNameCount(devices, name) {
+    var target = String(name || "")
+    var count = 0
+    for (var i = 0; i < devices.length && i < 512; i++) {
+      if (Model.nodeName(devices[i]) === target) count++
+      if (count > 1) break
+    }
+    return count
   }
 
   function deviceLabel(name) {
@@ -43,24 +81,12 @@ Item {
     if (target === "") return ""
     var alias = aliasFor(target)
     if (alias !== "") return alias
-    var groups = [sinks, sources]
-    for (var g = 0; g < groups.length; g++) {
-      for (var i = 0; i < groups[g].length; i++) {
-        var node = groups[g][i]
-        if (node && String(node.name || "") === target) return Model.nodeLabel(node)
-      }
-    }
-    return target
+    var info = liveTargetInfo(target)
+    return info.count === 1 ? Model.nodeLabel(info.node) : target
   }
 
   function targetIsLive(name) {
-    var target = String(name || "")
-    if (target === "") return false
-    for (var i = 0; i < sinks.length; i++)
-      if (sinks[i] && String(sinks[i].name || "") === target) return true
-    for (var j = 0; j < sources.length; j++)
-      if (sources[j] && String(sources[j].name || "") === target) return true
-    return false
+    return liveTargetInfo(name).count === 1
   }
 
   function optionsFor(direction, storedTarget) {
@@ -71,10 +97,14 @@ Item {
       label: recording ? "Follow default input" : "Follow default output"
     }]
     var stored = String(storedTarget || "")
-    for (var i = 0; i < devices.length; i++) {
-      var name = String(devices[i] ? devices[i].name || "" : "")
-      if (name !== "" && name !== stored)
+    var seen = []
+    for (var i = 0; i < devices.length && i < 512 && options.length < 513; i++) {
+      var name = Model.nodeName(devices[i])
+      if (name !== "" && name !== stored && seen.indexOf(name) === -1
+          && directionNameCount(devices, name) === 1 && !isHidden(name)) {
+        seen.push(name)
         options.push({ value: name, label: deviceLabel(name) })
+      }
     }
     if (stored !== "") options.push({ value: stored, label: deviceLabel(stored) })
     return options
@@ -85,9 +115,10 @@ Item {
     var seen = []
     var groups = [sinks, sources]
     for (var g = 0; g < groups.length; g++) {
-      for (var i = 0; i < groups[g].length; i++) {
-        var name = String(groups[g][i] ? groups[g][i].name || "" : "")
-        if (name === "" || seen.indexOf(name) !== -1) continue
+      for (var i = 0; i < groups[g].length && i < 512 && options.length < 512; i++) {
+        var name = Model.nodeName(groups[g][i])
+        if (name === "" || seen.indexOf(name) !== -1 || isHidden(name)
+            || liveTargetInfo(name).count !== 1) continue
         seen.push(name)
         options.push({ value: name, label: deviceLabel(name) })
       }
@@ -96,12 +127,8 @@ Item {
   }
 
   function directionForTarget(name) {
-    var target = String(name || "")
-    for (var i = 0; i < sinks.length; i++)
-      if (sinks[i] && String(sinks[i].name || "") === target) return "playback"
-    for (var j = 0; j < sources.length; j++)
-      if (sources[j] && String(sources[j].name || "") === target) return "recording"
-    return ""
+    var info = liveTargetInfo(name)
+    return info.count === 1 ? info.direction : ""
   }
 
   function buildManagedDevices() {
@@ -110,7 +137,7 @@ Item {
 
     function push(name, liveLabel) {
       var key = String(name || "")
-      if (key === "" || seen.indexOf(key) !== -1) return
+      if (key === "" || seen.indexOf(key) !== -1 || devices.length >= 512) return
       seen.push(key)
       var alias = root.aliasFor(key)
       devices.push({
@@ -123,14 +150,16 @@ Item {
 
     var i
     for (i = 0; i < sinks.length; i++)
-      push(sinks[i] ? sinks[i].name : "", Model.nodeLabel(sinks[i]))
+      push(Model.nodeName(sinks[i]), Model.nodeLabel(sinks[i]))
     for (i = 0; i < sources.length; i++)
-      push(sources[i] ? sources[i].name : "", Model.nodeLabel(sources[i]))
+      push(Model.nodeName(sources[i]), Model.nodeLabel(sources[i]))
     for (i = 0; i < rules.devices.favorites.length; i++)
       push(rules.devices.favorites[i], rules.devices.favorites[i])
     for (i = 0; i < rules.devices.hidden.length; i++)
       push(rules.devices.hidden[i], rules.devices.hidden[i])
-    for (var aliasName in rules.devices.aliases) push(aliasName, aliasName)
+    for (var aliasName in rules.devices.aliases) {
+      if (Model.hasOwn(rules.devices.aliases, aliasName)) push(aliasName, aliasName)
+    }
 
     devices.sort(function(a, b) {
       if (a.favorite !== b.favorite) return a.favorite ? -1 : 1
@@ -143,31 +172,79 @@ Item {
   function write(args) {
     if (busy) return false
     error = ""
-    writeProc.command = [scriptPath].concat(args)
+    writeProc.command = ["/bin/bash", scriptPath].concat(args)
     writeProc.running = true
     return true
   }
 
+  function handleLoadFailure() {
+    if (reloadPending) {
+      reloadWatchdog.stop()
+      reloadPending = false
+      error = "Audio rules changed, but could not be reloaded"
+      writeFinished(false)
+      return
+    }
+    if (!loaded) {
+      rules = Model.parseAudioRules("")
+      loaded = true
+      return
+    }
+    // Preserve a previously parsed registry across transient watch/read
+    // failures. Clearing it here would briefly unpin every application.
+    error = "Could not reload audio rules"
+  }
+
   FileView {
+    id: rulesFile
     path: root.rulesPath
     watchChanges: true
     printErrors: false
     onLoaded: {
-      root.rules = Model.parseAudioRules(text())
+      var raw = text()
+      if (!Model.isAudioRulesDocument(raw)) {
+        root.handleLoadFailure()
+        return
+      }
+      root.rules = Model.parseAudioRules(raw)
       root.loaded = true
+      root.error = ""
+      if (root.reloadPending) {
+        reloadWatchdog.stop()
+        root.reloadPending = false
+        root.error = ""
+        root.writeFinished(true)
+      }
     }
-    onLoadFailed: {
-      root.rules = Model.parseAudioRules("")
-      root.loaded = true
-    }
+    onLoadFailed: root.handleLoadFailure()
     onFileChanged: reload()
   }
 
   Process {
     id: writeProc
     onExited: function(exitCode) {
-      root.error = exitCode === 0 ? "" : "Could not update the audio rules"
-      root.writeFinished(exitCode === 0)
+      if (exitCode !== 0) {
+        root.error = "Could not update the audio rules"
+        root.writeFinished(false)
+        return
+      }
+      // Keep writes serialized until the shared file has been parsed back
+      // into memory. Otherwise enforcement can briefly apply the old rule
+      // immediately after a successful manual route edit.
+      root.reloadPending = true
+      reloadWatchdog.restart()
+      rulesFile.reload()
+    }
+  }
+
+  Timer {
+    id: reloadWatchdog
+    interval: 3000
+    onTriggered: {
+      if (!root.reloadPending) return
+      root.reloadPending = false
+      root.error = "Audio rules changed, but could not be reloaded"
+      root.writeFinished(false)
     }
   }
 

--- a/AudioRuntime.qml
+++ b/AudioRuntime.qml
@@ -9,13 +9,14 @@ QtObject {
 
   readonly property string configHome: {
     var configured = Quickshell.env("XDG_CONFIG_HOME")
-    return configured || Quickshell.env("HOME") + "/.config"
+    var home = Quickshell.env("HOME")
+    return configured || (home ? home + "/.config" : "")
   }
-  readonly property string settingsPath: configHome + "/omarchy/audio-control.json"
-  readonly property string preferencesPath: configHome + "/omarchy/audio-preferences.json"
-  readonly property string scenesPath: configHome + "/omarchy/audio-scenes.json"
-  readonly property string rulesPath: configHome + "/omarchy/audio-rules.json"
-  readonly property string scriptsDir: localPath(Qt.resolvedUrl("scripts/"))
+  readonly property string settingsPath: configPath("audio-control.json")
+  readonly property string preferencesPath: configPath("audio-preferences.json")
+  readonly property string scenesPath: configPath("audio-scenes.json")
+  readonly property string rulesPath: configPath("audio-rules.json")
+  readonly property string scriptsDir: localPath(Qt.resolvedUrl("scripts/")).replace(/\/$/, "")
 
   function localPath(url) {
     return decodeURIComponent(String(url).replace(/^file:\/\//, ""))
@@ -23,5 +24,13 @@ QtObject {
 
   function script(name) {
     return scriptsDir + "/" + String(name || "")
+  }
+
+  function configPath(name) {
+    return configHome === "" ? "" : configHome + "/omarchy/" + name
+  }
+
+  function scriptCommand(name, args) {
+    return ["/bin/bash", script(name)].concat(args || [])
   }
 }

--- a/AudioSceneController.qml
+++ b/AudioSceneController.qml
@@ -6,58 +6,101 @@ import "Model.js" as Model
 
 // Captures live audio state into scene documents and applies them back.
 //
-// Apply is transactional in spirit: every target is resolved against live
-// state first, unavailable devices are reported as skipped instead of
-// failing the whole scene, and independent script steps run sequentially so
-// results stay predictable. Direct node mutations (volume, mute, balance)
-// happen instantly through the bound PipeWire objects; card profiles,
-// ports, and defaults go through the existing helper scripts, with defaults
-// applied last so they point at the post-profile device world.
+// Apply is transactional in spirit: independent steps run sequentially and
+// each live target is resolved only when its step executes. Card profiles can
+// recreate every endpoint on a card, so profiles finish before ports, direct
+// node mutations, and defaults. Unavailable devices are reported as skipped
+// instead of aborting unrelated parts of the scene.
 Item {
   id: controller
 
   required property string scriptsDir
+  property real outputVolumeMaximum: 1.5
 
   property bool busy: false
   readonly property var nodes: Pipewire.nodes ? Pipewire.nodes.values : []
 
   signal applyFinished(var result)
   signal captureFinished(var scene)
+  signal captureFailed(string error)
 
   property var pendingQueue: []
   property string currentLabel: ""
   property var currentResult: null
-  property int stepToken: 0
+  property bool stepTimedOut: false
   property bool capturePortsDone: false
   property bool captureProfilesDone: false
+  property bool capturePortsSucceeded: false
+  property bool captureProfilesSucceeded: false
   property string capturePortsRaw: ""
   property string captureProfilesRaw: ""
   property string captureName: ""
+  property var pendingDeviceMutation: null
+  property int deviceVerificationAttempts: 0
+  property bool deviceRollbackVerification: false
 
   function findSink(name) {
     var target = String(name || "")
-    for (var i = 0; i < nodes.length; i++) {
-      var node = nodes[i]
-      if (node && !node.isStream && node.isSink && String(node.name || "") === target)
-        return node
+    if (target === "") return null
+    var match = null
+    for (var i = 0; i < nodes.length && i < 4096; i++) {
+      try {
+        var node = nodes[i]
+        if (node && !node.isStream && node.isSink
+            && !Model.isInternalAudioNode(node.name, Model.nodeProps(node))
+            && String(node.name || "") === target) {
+          if (match) return null
+          match = node
+        }
+      } catch (_error) { }
     }
-    return null
+    return match
   }
 
   function findSource(name) {
     var target = String(name || "")
-    for (var i = 0; i < nodes.length; i++) {
-      var node = nodes[i]
-      if (node && !node.isStream && !node.isSink && Model.isAudioSource(node)
-          && !Model.isInternalAudioNode(node.name) && !Model.isMonitorSource(node)
-          && String(node.name || "") === target)
-        return node
+    if (target === "") return null
+    var match = null
+    for (var i = 0; i < nodes.length && i < 4096; i++) {
+      try {
+        var node = nodes[i]
+        if (node && !node.isStream && !node.isSink && Model.isAudioSource(node)
+            && !Model.isInternalAudioNode(node.name, Model.nodeProps(node))
+            && !Model.isMonitorSource(node)
+            && String(node.name || "") === target) {
+          if (match) return null
+          match = node
+        }
+      } catch (_error) { }
     }
-    return null
+    return match
   }
 
   function findDevice(direction, name) {
     return direction === "input" ? findSource(name) : findSink(name)
+  }
+
+  function capturableDeviceName(node, direction) {
+    try {
+      if (!node || node.ready !== true || node.isStream || !node.audio
+          || Model.nodeObjectId(node) === ""
+          || Model.isInternalAudioNode(node.name, Model.nodeProps(node))) return ""
+      if (direction === "output") {
+        if (node.isSink !== true) return ""
+      } else if (direction === "input") {
+        if (node.isSink === true || !Model.isAudioSource(node)
+            || Model.isMonitorSource(node)) return ""
+      } else {
+        return ""
+      }
+      var name = Model.sanitizeIdentifier(String(node.name || ""), 160)
+      // Names are persisted in scene files, so only capture one when it
+      // resolves back to this exact live object. Otherwise a later apply could
+      // transfer state to one of several same-name endpoints.
+      return name !== "" && findDevice(direction, name) === node ? name : ""
+    } catch (_error) {
+      return ""
+    }
   }
 
   function stereoIndices(node) {
@@ -65,7 +108,7 @@ Item {
       return { left: -1, right: -1 }
     var left = -1
     var right = -1
-    for (var i = 0; i < node.audio.channels.length; i++) {
+    for (var i = 0; i < node.audio.channels.length && i < 64; i++) {
       if (node.audio.channels[i] === PwAudioChannel.FrontLeft) left = i
       else if (node.audio.channels[i] === PwAudioChannel.FrontRight) right = i
     }
@@ -80,108 +123,267 @@ Item {
     return Model.balanceValue(node.audio.volumes[indices.left], node.audio.volumes[indices.right])
   }
 
-  function setNodeBalance(node, value) {
-    var indices = stereoIndices(node)
-    if (indices.left < 0 || indices.right < 0) return false
-    node.audio.volumes = Model.applyBalance(
-      node.audio.volumes, indices.left, indices.right, value)
-    return true
-  }
-
   function apply(scene) {
     if (busy || !scene || typeof scene !== "object") return
 
-    var result = { name: String(scene.name || ""), applied: 0, skipped: [], errors: [] }
-    var queue = []
-    var currentOutput = Pipewire.defaultAudioSink && Pipewire.defaultAudioSink.name
-      ? String(Pipewire.defaultAudioSink.name) : ""
-    var currentInput = Pipewire.defaultAudioSource && Pipewire.defaultAudioSource.name
-      ? String(Pipewire.defaultAudioSource.name) : ""
-
-    // Card profiles may create or destroy devices, so they run before
-    // everything that targets devices.
-    var profiles = Array.isArray(scene.profiles) ? scene.profiles : []
-    for (var i = 0; i < profiles.length; i++) {
-      queue.push({
-        command: [scriptsDir + "/audio-profile-set",
-          String(profiles[i].card), String(profiles[i].profile)],
-        label: "Profile " + profiles[i].card
-      })
-    }
-
-    var ports = Array.isArray(scene.ports) ? scene.ports : []
-    for (var j = 0; j < ports.length; j++) {
-      queue.push({
-        command: [scriptsDir + "/audio-port-set",
-          String(ports[j].direction), String(ports[j].endpoint), String(ports[j].value)],
-        label: "Port " + ports[j].endpoint
-      })
-    }
-
-    var devices = Array.isArray(scene.devices) ? scene.devices : []
-    for (var k = 0; k < devices.length; k++) {
-      var entry = devices[k]
-      var node = findDevice(entry.direction, entry.name)
-      if (!node || !node.audio || node.audio.volumes === undefined) {
-        result.skipped.push(entry.name)
-        continue
-      }
-      node.audio.muted = entry.muted === true
-      var volume = Math.max(0, Math.min(1.5, Number(entry.volume)))
-      if (isFinite(volume)) node.audio.volume = volume
-      setNodeBalance(node, Math.max(-1, Math.min(1, Number(entry.balance))))
-      result.applied++
-    }
-
-    var defaults = scene.defaults && typeof scene.defaults === "object" ? scene.defaults : {}
-    if (defaults.output !== "") {
-      var outputNode = findSink(defaults.output)
-      if (!outputNode || outputNode.id === undefined)
-        result.skipped.push(defaults.output + " (default output)")
-      else
-        queue.push({
-          command: [scriptsDir + "/audio-output-set-default",
-            String(outputNode.id), String(outputNode.name), currentOutput],
-          label: "Default output"
-        })
-    }
-    if (defaults.input !== "") {
-      var inputNode = findSource(defaults.input)
-      if (!inputNode || inputNode.id === undefined)
-        result.skipped.push(defaults.input + " (default input)")
-      else
-        queue.push({
-          command: [scriptsDir + "/audio-input-set-default",
-            String(inputNode.id), String(inputNode.name), currentInput],
-          label: "Default input"
-        })
-    }
+    var normalized = Model.sanitizeSceneEntry(scene)
+    if (!normalized) return
+    var result = { name: normalized.name, applied: 0, skipped: [], errors: [] }
 
     busy = true
     currentResult = result
-    pendingQueue = queue
+    pendingQueue = Model.audioScenePlan(normalized)
     runNext()
   }
 
   function runNext() {
-    if (pendingQueue.length === 0) {
-      finishApply()
+    if (applyStepProc.running || sceneSettleTimer.running
+        || deviceVerifyTimer.running || pendingDeviceMutation) return
+
+    while (pendingQueue.length > 0) {
+      var step = pendingQueue[0]
+      pendingQueue = pendingQueue.slice(1)
+      currentLabel = step.label
+
+      if (step.kind === "settle") {
+        sceneSettleTimer.restart()
+        return
+      }
+      if (step.kind === "device") {
+        if (applyDeviceStep(step)) return
+        currentLabel = ""
+        continue
+      }
+
+      var command = []
+      if (step.kind === "profile") {
+        command = ["/bin/bash", scriptsDir + "/audio-profile-set", step.card, step.profile]
+      } else if (step.kind === "port") {
+        command = ["/bin/bash", scriptsDir + "/audio-port-set",
+          step.direction, step.endpoint, step.value]
+      } else if (step.kind === "default") {
+        var node = findDevice(step.direction, step.name)
+        var objectId = Model.nodeObjectId(node)
+        var nodeName = Model.nodeName(node)
+        if (!node || objectId === "" || nodeName === ""
+            || findDevice(step.direction, nodeName) !== node) {
+          if (currentResult)
+            currentResult.skipped.push(step.name + " (default " + step.direction + ")")
+          currentLabel = ""
+          continue
+        }
+        var current = step.direction === "input"
+          ? Pipewire.defaultAudioSource : Pipewire.defaultAudioSink
+        var previousName = Model.nodeName(current)
+        var previousObjectId = Model.nodeObjectId(current)
+        command = ["/bin/bash", scriptsDir + (step.direction === "input"
+            ? "/audio-input-set-default" : "/audio-output-set-default"),
+          objectId, nodeName, previousName, previousObjectId]
+      } else {
+        if (currentResult) currentResult.errors.push("Unknown scene step")
+        currentLabel = ""
+        continue
+      }
+
+      stepTimedOut = false
+      applyStepProc.command = command
+      applyStepProc.running = true
+      stepWatchdog.restart()
       return
     }
-    var step = pendingQueue[0]
-    pendingQueue = pendingQueue.slice(1)
-    currentLabel = step.label
-    stepToken++
-    applyStepProc.token = stepToken
-    applyStepProc.command = step.command
-    applyStepProc.running = true
-    stepWatchdog.restart()
+
+    finishApply()
+  }
+
+  function applyDeviceStep(step) {
+    try {
+      return applyDeviceStepUnchecked(step)
+    } catch (_error) {
+      pendingDeviceMutation = null
+      deviceVerificationAttempts = 0
+      deviceRollbackVerification = false
+      if (currentResult) currentResult.errors.push(step.name)
+      return false
+    }
+  }
+
+  function applyDeviceStepUnchecked(step) {
+    var node = null
+    try { node = findDevice(step.direction, step.name) } catch (_error) { }
+    var objectId = Model.nodeObjectId(node)
+    if (!node || objectId === "" || node.ready !== true || !node.audio
+        || node.audio.volumes === undefined) {
+      if (currentResult) currentResult.skipped.push(step.name)
+      return false
+    }
+
+    var desiredVolume = Number(step.volume)
+    var maximum = step.direction === "output" ? outputVolumeMaximum : 1.5
+    if (!isFinite(desiredVolume) || !isFinite(maximum)) {
+      if (currentResult) currentResult.errors.push(step.name)
+      return false
+    }
+    desiredVolume = Math.max(0, Math.min(maximum, desiredVolume))
+
+    var currentVolumes = node.audio.volumes
+    var channelCount = currentVolumes && typeof currentVolumes.length === "number"
+      ? Math.floor(Number(currentVolumes.length)) : 0
+    var originalVolumes = []
+    if (channelCount > 0 && channelCount <= 64) {
+      for (var originalIndex = 0; originalIndex < channelCount; originalIndex++) {
+        var originalChannelVolume = Number(currentVolumes[originalIndex])
+        if (!isFinite(originalChannelVolume)) {
+          if (currentResult) currentResult.errors.push(step.name)
+          return false
+        }
+        originalVolumes.push(originalChannelVolume)
+      }
+    }
+    var originalVolume = Number(node.audio.volume)
+    if (!isFinite(originalVolume)) originalVolume = 0
+    var expectedMuted = step.direction === "input" && step.muted === true
+    var desiredVolumes = []
+    if (channelCount > 0 && channelCount <= 64) {
+      for (var i = 0; i < channelCount; i++) desiredVolumes.push(desiredVolume)
+      var indices = stereoIndices(node)
+      if (indices.left >= 0 && indices.right >= 0)
+        desiredVolumes = Model.applyBalance(
+          desiredVolumes, indices.left, indices.right, step.balance)
+    }
+    pendingDeviceMutation = {
+      step: step,
+      objectId: objectId,
+      originalMuted: node.audio.muted === true,
+      originalVolume: originalVolume,
+      originalVolumes: originalVolumes,
+      expectedMuted: expectedMuted,
+      expectedVolume: desiredVolume,
+      expectedVolumes: desiredVolumes
+    }
+    deviceVerificationAttempts = 0
+    deviceRollbackVerification = false
+
+    try {
+      // Silence the endpoint before changing its gain. This avoids a stored
+      // low-volume scene briefly playing at the endpoint's previous level.
+      node.audio.muted = true
+      if (channelCount > 0 && channelCount <= 64) {
+        node.audio.volumes = desiredVolumes
+      } else {
+        node.audio.volume = desiredVolume
+      }
+      // Output scenes intentionally restore audibly; input mute remains a
+      // privacy-bearing part of the saved scene.
+      node.audio.muted = expectedMuted
+    } catch (_mutationError) {
+      beginDeviceRollback(node)
+    }
+    deviceVerifyTimer.restart()
+    return true
+  }
+
+  function deviceStateMatches(node, muted, volume, volumes) {
+    try {
+      if (!node || node.ready !== true || !node.audio || node.audio.muted !== muted)
+        return false
+      if (volumes && volumes.length > 0) {
+        var liveVolumes = node.audio.volumes
+        if (!liveVolumes || liveVolumes.length !== volumes.length || volumes.length > 64)
+          return false
+        for (var i = 0; i < volumes.length; i++) {
+          var actual = Number(liveVolumes[i])
+          if (!isFinite(actual) || Math.abs(actual - Number(volumes[i])) > 0.015)
+            return false
+        }
+        return true
+      }
+      var actualVolume = Number(node.audio.volume)
+      return isFinite(actualVolume) && Math.abs(actualVolume - Number(volume)) <= 0.015
+    } catch (_error) {
+      return false
+    }
+  }
+
+  function beginDeviceRollback(node) {
+    try {
+      var pending = pendingDeviceMutation
+      if (!pending || !node || Model.nodeObjectId(node) !== pending.objectId) return false
+      deviceRollbackVerification = true
+      deviceVerificationAttempts = 0
+      node.audio.muted = true
+      if (pending.originalVolumes.length > 0) node.audio.volumes = pending.originalVolumes
+      else node.audio.volume = pending.originalVolume
+      node.audio.muted = pending.originalMuted
+      return true
+    } catch (_rollbackError) {
+      return false
+    }
+  }
+
+  function finishDeviceMutation(success, rollbackSucceeded) {
+    var pending = pendingDeviceMutation
+    deviceVerifyTimer.stop()
+    pendingDeviceMutation = null
+    deviceVerificationAttempts = 0
+    deviceRollbackVerification = false
+    currentLabel = ""
+    if (pending && currentResult) {
+      if (success) currentResult.applied++
+      else currentResult.errors.push(pending.step.name
+        + (rollbackSucceeded ? "" : " could not be restored"))
+    }
+    // A verified rollback leaves unrelated scene steps safe to continue. If
+    // restoration itself failed, the live graph is unknown; stop before a
+    // later profile/default/device step compounds that partial state.
+    if (!success && !rollbackSucceeded) pendingQueue = []
+    runNext()
+  }
+
+  function verifyDeviceMutation() {
+    var pending = pendingDeviceMutation
+    if (!pending) return
+    var node = null
+    try { node = findDevice(pending.step.direction, pending.step.name) } catch (_error) { }
+    if (!node || Model.nodeObjectId(node) !== pending.objectId) {
+      // The captured object vanished. Never transfer its state to a same-name
+      // replacement; there is no remaining object to roll back.
+      finishDeviceMutation(false, true)
+      return
+    }
+    var matches = deviceRollbackVerification
+      ? deviceStateMatches(node, pending.originalMuted,
+          pending.originalVolume, pending.originalVolumes)
+      : deviceStateMatches(node, pending.expectedMuted,
+          pending.expectedVolume, pending.expectedVolumes)
+    if (matches) {
+      finishDeviceMutation(!deviceRollbackVerification, true)
+      return
+    }
+    deviceVerificationAttempts++
+    if (deviceVerificationAttempts < 10) {
+      deviceVerifyTimer.restart()
+      return
+    }
+    if (!deviceRollbackVerification && beginDeviceRollback(node)) {
+      deviceVerifyTimer.restart()
+      return
+    }
+    finishDeviceMutation(false, false)
   }
 
   function finishApply() {
+    stepWatchdog.stop()
+    sceneSettleTimer.stop()
+    deviceVerifyTimer.stop()
     busy = false
     var result = currentResult
     currentResult = null
+    pendingQueue = []
+    currentLabel = ""
+    stepTimedOut = false
+    pendingDeviceMutation = null
+    deviceVerificationAttempts = 0
+    deviceRollbackVerification = false
     if (result) applyFinished(result)
   }
 
@@ -191,32 +393,50 @@ Item {
     captureName = String(name || "")
     capturePortsDone = false
     captureProfilesDone = false
+    capturePortsSucceeded = false
+    captureProfilesSucceeded = false
     capturePortsRaw = ""
     captureProfilesRaw = ""
-    capturePortsProc.command = [scriptsDir + "/audio-ports"]
+    capturePortsProc.command = ["/bin/bash", scriptsDir + "/audio-ports"]
     capturePortsProc.running = true
-    captureProfilesProc.command = [scriptsDir + "/audio-profiles"]
+    captureProfilesProc.command = ["/bin/bash", scriptsDir + "/audio-profiles"]
     captureProfilesProc.running = true
   }
 
   function finishCapture() {
     if (!capturePortsDone || !captureProfilesDone) return
 
+    if (!capturePortsSucceeded || !captureProfilesSucceeded) {
+      var failedParts = []
+      if (!capturePortsSucceeded) failedParts.push("device ports")
+      if (!captureProfilesSucceeded) failedParts.push("card profiles")
+      busy = false
+      captureName = ""
+      captureFailed("Could not capture " + failedParts.join(" and ") + " for the scene")
+      return
+    }
+
     var devices = []
-    for (var i = 0; i < nodes.length; i++) {
-      var node = nodes[i]
-      if (!node || node.ready !== true || node.isStream || !node.audio
-          || Model.isInternalAudioNode(node.name)) continue
-      var direction = node.isSink ? "output" : (Model.isAudioSource(node) ? "input" : "")
-      if (direction === "" || Model.isMonitorSource(node)) continue
-      devices.push({
-        name: String(node.name || ""),
-        direction: direction,
-        volume: Math.max(0, Math.min(1.5, Number(node.audio.volume))),
-        // Only input muting is a deliberate state worth restoring.
-        muted: direction === "input" && node.audio.muted === true,
-        balance: balanceOf(node)
-      })
+    for (var i = 0; i < nodes.length && i < 4096 && devices.length < 64; i++) {
+      try {
+        var node = nodes[i]
+        if (!node || node.ready !== true || node.isStream || !node.audio) continue
+        var direction = node.isSink ? "output" : (Model.isAudioSource(node) ? "input" : "")
+        var deviceName = capturableDeviceName(node, direction)
+        var deviceVolume = Number(node.audio.volume)
+        if (deviceName === "" || !isFinite(deviceVolume)) continue
+        devices.push({
+          name: deviceName,
+          direction: direction,
+          volume: Math.max(0, Math.min(direction === "output"
+            ? outputVolumeMaximum : 1.5, deviceVolume)),
+          // Only input muting is a deliberate state worth restoring.
+          muted: direction === "input" && node.audio.muted === true,
+          balance: balanceOf(node)
+        })
+      } catch (_captureError) {
+        // Live nodes may vanish while a scene snapshot is assembled.
+      }
     }
 
     var ports = []
@@ -238,33 +458,44 @@ Item {
     }
 
     busy = false
+    var defaultSink = Pipewire.defaultAudioSink
     var defaultSource = Pipewire.defaultAudioSource
-    // A monitor source is not a microphone; storing it as the scene's
-    // default input would only produce a skipped entry later.
+    var defaultOutputName = capturableDeviceName(defaultSink, "output")
+    // Monitor, stream, and internal sources are not microphones; storing one
+    // as a scene default would only produce an unsafe or permanently skipped
+    // entry later.
+    var defaultInputName = capturableDeviceName(defaultSource, "input")
     var capturedScene = Model.sanitizeSceneEntry({
       version: 1,
       name: captureName,
       savedAt: new Date().toISOString(),
       defaults: {
-        output: Pipewire.defaultAudioSink && Pipewire.defaultAudioSink.name
-          ? String(Pipewire.defaultAudioSink.name) : "",
-        input: defaultSource && defaultSource.name && !Model.isMonitorSource(defaultSource)
-          ? String(defaultSource.name) : ""
+        output: defaultOutputName,
+        input: defaultInputName
       },
       devices: devices,
       ports: ports,
       profiles: profiles
     })
+    captureName = ""
     if (capturedScene) captureFinished(capturedScene)
+    else captureFailed("Could not assemble the current audio scene")
   }
 
   Process {
     id: applyStepProc
-    property int token: 0
 
     onExited: function(exitCode) {
-      // A watchdog timeout advances the queue itself; ignore the late exit.
-      if (token !== controller.stepToken) return
+      stepWatchdog.stop()
+      if (controller.stepTimedOut) {
+        controller.stepTimedOut = false
+        controller.currentLabel = ""
+        // The helper was killed with an unknown transactional state. Do not
+        // compound that uncertainty by applying the remainder of the scene.
+        controller.pendingQueue = []
+        controller.finishApply()
+        return
+      }
       controller.finishStep(exitCode)
     }
   }
@@ -274,12 +505,30 @@ Item {
     interval: 30000
     onTriggered: {
       if (!applyStepProc.running) return
-      applyStepProc.token = -1
       if (controller.currentResult)
         controller.currentResult.errors.push(controller.currentLabel + " timed out")
+      controller.stepTimedOut = true
+      // Do not reuse this Process until its onExited signal confirms that the
+      // timed-out child is gone. Reusing it here lets the old exit complete a
+      // newly started step and corrupts the rest of the queue.
       applyStepProc.running = false
+    }
+  }
+
+  Timer {
+    id: sceneSettleTimer
+    interval: 200
+    onTriggered: {
+      controller.currentLabel = ""
       controller.runNext()
     }
+  }
+
+  Timer {
+    id: deviceVerifyTimer
+    interval: 100
+    repeat: false
+    onTriggered: controller.verifyDeviceMutation()
   }
 
   function finishStep(exitCode) {
@@ -291,7 +540,18 @@ Item {
       // not a failure. Exit 2 means the change landed but its shared
       // preference could not be saved; the audible part still applied.
       if (exitCode === 3) currentResult.skipped.push(label)
-      else if (exitCode !== 0 && exitCode !== 2) currentResult.errors.push(label)
+      else if (exitCode === 2) {
+        currentResult.applied++
+        currentResult.errors.push(label + " preference could not be saved")
+      } else if (exitCode === 4) {
+        currentResult.applied++
+        currentResult.errors.push(label + " only partially applied")
+        // Helper exit 4 explicitly means changed/unknown state with incomplete
+        // recovery. Treat it like a watchdog timeout and do not layer the rest
+        // of the scene on top of an unverified graph.
+        pendingQueue = []
+      } else if (exitCode !== 0) currentResult.errors.push(label)
+      else currentResult.applied++
     }
     runNext()
   }
@@ -301,12 +561,13 @@ Item {
     stdout: StdioCollector {
       waitForEnd: true
       onStreamFinished: {
-        // A non-zero exit leaves whatever was collected; parseAudioPorts
-        // turns unusable output into an empty list during assembly.
         controller.capturePortsRaw = String(text || "")
-        controller.capturePortsDone = true
-        controller.finishCapture()
       }
+    }
+    onExited: function(exitCode) {
+      controller.capturePortsSucceeded = exitCode === 0
+      controller.capturePortsDone = true
+      controller.finishCapture()
     }
   }
 
@@ -316,9 +577,12 @@ Item {
       waitForEnd: true
       onStreamFinished: {
         controller.captureProfilesRaw = String(text || "")
-        controller.captureProfilesDone = true
-        controller.finishCapture()
       }
+    }
+    onExited: function(exitCode) {
+      controller.captureProfilesSucceeded = exitCode === 0
+      controller.captureProfilesDone = true
+      controller.finishCapture()
     }
   }
 }

--- a/AudioSinkRow.qml
+++ b/AudioSinkRow.qml
@@ -19,7 +19,8 @@ CursorSurface {
   signal claimed(string section, int index)
   signal activated(var node)
 
-  readonly property bool isActive: root.node && String(root.node.name || "") === root.preferredName
+  readonly property bool isActive: Model.nodeName(root.node) !== ""
+    && Model.nodeName(root.node) === root.preferredName
 
   current: root.isActive
   implicitHeight: deviceInner.implicitHeight + Style.spacing.xl

--- a/AudioSourceRow.qml
+++ b/AudioSourceRow.qml
@@ -17,7 +17,8 @@ CursorSurface {
   signal claimed(string section, int index)
   signal activated(var node)
 
-  readonly property bool isActive: root.node && String(root.node.name || "") === root.preferredName
+  readonly property bool isActive: Model.nodeName(root.node) !== ""
+    && Model.nodeName(root.node) === root.preferredName
 
   current: root.isActive
   implicitHeight: deviceInner.implicitHeight + Style.spacing.xl

--- a/AudioStreamRow.qml
+++ b/AudioStreamRow.qml
@@ -10,32 +10,36 @@ CursorSurface {
   id: root
 
   required property var node
+  required property bool nodeLive
   required property int rowIndex
   property bool recording: false
   required property var bar
   required property bool monitorEnabled
   required property bool representsPlayer
   required property var currentRoute
-  required property int targetCount
   required property var routeOptions
   required property string streamLabel
   required property var iconSource
   required property bool routeAvailable
   required property bool routeSetBusy
+  required property bool mutationBlocked
+  property bool popupReportedOpen: false
 
   signal claimed(string section, int index)
+  signal volumeRequested(real value)
+  signal muteRequested()
   signal routeChosen(string optionValue)
   signal popupToggled(bool open)
 
   // PipeWire nodes publish their audio interface only once bound; reading
   // it earlier — which happens while streams churn during profile or codec
   // switches — has historically destabilized Quickshell's Pipewire service.
-  readonly property bool nodeReady: !!root.node && root.node.ready === true
-  readonly property real streamVolume: root.nodeReady && root.node.audio ? root.node.audio.volume : 0
-  readonly property bool streamMuted: root.nodeReady && root.node.audio ? root.node.audio.muted : false
+  readonly property bool nodeReady: liveAudioReady()
+  readonly property real streamVolume: liveAudioVolume()
+  readonly property bool streamMuted: liveAudioMuted()
   readonly property real meterLevel: !root.nodeReady ? 0 : Model.audioMeterLevel(
     streamPeakMonitor.peaks,
-    root.node && root.node.audio ? root.node.audio.volumes : [],
+    liveAudioVolumes(),
     streamPeakMonitor.peak,
     streamVolume,
     streamMuted)
@@ -46,15 +50,45 @@ CursorSurface {
   readonly property string routeOptionValue: routeMode !== "" && targetSerial !== ""
     ? routeMode + ":" + targetSerial : ""
   readonly property bool routeIsExplicit: routeMode === "override"
+  readonly property bool routeMenuAvailable: root.routeOptions.length > 1
+    && root.targetSerial !== ""
 
   implicitHeight: streamColumn.implicitHeight + Style.spacing.xl
 
-  function toggleOutputMenu() {
-    if (root.targetCount > 1 && root.targetSerial !== "" && routeDropdown.enabled)
-      routeDropdown.toggle()
+  function liveAudioReady() {
+    try { return root.nodeLive && !!root.node && root.node.ready === true && !!root.node.audio }
+    catch (_error) { return false }
   }
 
-  Component.onDestruction: if (routeDropdown.popupOpen) root.popupToggled(false)
+  function liveAudioVolume() {
+    try {
+      var value = root.nodeReady ? Number(root.node.audio.volume) : 0
+      return isFinite(value) ? value : 0
+    } catch (_error) { return 0 }
+  }
+
+  function liveAudioMuted() {
+    try { return root.nodeReady && root.node.audio.muted === true }
+    catch (_error) { return false }
+  }
+
+  function liveAudioVolumes() {
+    try { return root.nodeReady && root.node.audio.volumes ? root.node.audio.volumes : [] }
+    catch (_error) { return [] }
+  }
+
+  function toggleOutputMenu() {
+    if (root.routeMenuAvailable && routeDropdown.enabled)
+      routeDropdown.toggle()
+  }
+  function reportPopup(open) {
+    var next = open === true
+    if (popupReportedOpen === next) return
+    popupReportedOpen = next
+    popupToggled(next)
+  }
+
+  Component.onDestruction: root.reportPopup(false)
 
   PwNodePeakMonitor {
     id: streamPeakMonitor
@@ -117,10 +151,10 @@ CursorSurface {
 
           MouseArea {
             anchors.fill: parent
+            enabled: !root.mutationBlocked
             cursorShape: Qt.PointingHandCursor
             onClicked: {
-              if (root.nodeReady && root.node.audio)
-                root.node.audio.muted = !root.node.audio.muted
+              if (root.nodeReady) root.muteRequested()
             }
           }
         }
@@ -146,7 +180,7 @@ CursorSurface {
 
           Text {
             id: routeChevron
-            visible: root.targetCount > 1 && root.targetSerial !== ""
+            visible: root.routeMenuAvailable
             width: Style.space(22)
             text: {
               var position = root.bar ? root.bar.position : "left"
@@ -192,7 +226,7 @@ CursorSurface {
         anchors.top: parent.top
         anchors.bottom: parent.bottom
         z: 1
-        visible: root.targetCount > 1 && root.targetSerial !== ""
+        visible: root.routeMenuAvailable
         rowHeight: height
         popupRowHeight: Style.space(34)
         popupDirection: {
@@ -214,13 +248,13 @@ CursorSurface {
         triggerChrome: false
         value: root.routeOptionValue
         options: root.routeOptions
-        enabled: root.routeAvailable && !root.routeSetBusy
+        enabled: root.routeAvailable && !root.routeSetBusy && !root.mutationBlocked
         foreground: root.bar.foreground
         fontFamily: root.bar.fontFamily
 
         onHovered: function(on) { if (on) root.claimed(root.routeSection, root.rowIndex) }
         onChanged: function(route) { root.routeChosen(route) }
-        onPopupOpenChanged: root.popupToggled(popupOpen)
+        onPopupOpenChanged: root.reportPopup(popupOpen)
       }
     }
 
@@ -232,13 +266,15 @@ CursorSurface {
       step: 0.05
       value: root.streamVolume
       opacity: root.streamMuted ? 0.5 : 1.0
+      enabled: root.nodeReady && !root.mutationBlocked
 
       onMoved: function(v) {
-        if (root.nodeReady && root.node.audio) root.node.audio.volume = v
+        if (!root.mutationBlocked && root.nodeReady)
+          root.volumeRequested(v)
       }
       onRightClicked: {
-        if (root.nodeReady && root.node.audio)
-          root.node.audio.muted = !root.node.audio.muted
+        if (!root.mutationBlocked && root.nodeReady)
+          root.muteRequested()
       }
     }
 

--- a/MicrophoneTestRow.qml
+++ b/MicrophoneTestRow.qml
@@ -19,22 +19,24 @@ CursorSurface {
   signal hovered()
 
   readonly property bool running: state === "recording" || state === "stopping"
-    || state === "playing"
+    || state === "playing" || state === "cancelling"
   readonly property bool ready: state === "ready"
-  readonly property bool primaryEnabled: state !== "stopping"
+  readonly property bool primaryEnabled: state !== "stopping" && state !== "cancelling"
     && (running || ready || !microphoneMuted)
   readonly property string description: {
     if (error !== "") return error
     if (state === "recording")
       return "Recording… " + Math.max(0, secondsRemaining) + " seconds remaining."
     if (state === "stopping") return "Finishing the partial recording…"
+    if (state === "cancelling") return "Cleaning up the microphone test…"
     if (state === "ready") return "Private test clip ready. Play it back or discard it."
     if (state === "playing") return "Playing the private test clip through the current output."
     if (microphoneMuted) return "Unmute the microphone before recording a test."
     return "Record five seconds from the current input, then choose when to play it back."
   }
   readonly property string primaryIcon: running ? "󰓛" : (ready ? "󰐊" : "󰑊")
-  readonly property string primaryTooltip: state === "stopping" ? "Finishing microphone test"
+  readonly property string primaryTooltip: state === "stopping" || state === "cancelling"
+    ? "Finishing microphone test"
     : (running ? "Stop and keep microphone test"
     : (ready ? "Play microphone test" : "Record five-second microphone test")
     )

--- a/Model.js
+++ b/Model.js
@@ -1,48 +1,74 @@
 function isPlaybackStream(node) {
-  if (!node || !node.isStream) return false
-  if (node.isSink === true) return true
+  try {
+    if (!node || !node.isStream) return false
+    if (node.isSink === true) return true
+    if (node.isSink === false) return false
 
-  var mediaClass = String(node.type || "")
-  return mediaClass.indexOf("Stream/Output/Audio") !== -1
-    || mediaClass.indexOf("AudioOutStream") !== -1
-    || mediaClass.indexOf("Output") !== -1
+    var mediaClass = String(node.type || "")
+    return mediaClass.indexOf("Stream/Output/Audio") !== -1
+      || mediaClass.indexOf("AudioOutStream") !== -1
+      || mediaClass.indexOf("Output") !== -1
+  } catch (e) {
+    return false
+  }
 }
 
 function isRecordingStream(node) {
-  if (!node || !node.isStream) return false
-  if (node.isSink === false) return true
+  try {
+    if (!node || !node.isStream) return false
+    if (node.isSink === false) return true
+    if (node.isSink === true) return false
 
-  var mediaClass = String(node.type || "")
-  return mediaClass.indexOf("Stream/Input/Audio") !== -1
-    || mediaClass.indexOf("AudioInStream") !== -1
-    || mediaClass.indexOf("Input") !== -1
+    var mediaClass = String(node.type || "")
+    return mediaClass.indexOf("Stream/Input/Audio") !== -1
+      || mediaClass.indexOf("AudioInStream") !== -1
+      || mediaClass.indexOf("Input") !== -1
+  } catch (e) {
+    return false
+  }
 }
 
 function isAudioSource(node) {
-  if (!node) return false
-  if (node.audio) return true
+  try {
+    if (!node || node.isStream || node.isSink === true) return false
 
-  var mediaClass = String(node.type || "")
-  return mediaClass.indexOf("Audio/Source") !== -1
-    || mediaClass.indexOf("AudioSource") !== -1
-    || mediaClass.indexOf("Source") !== -1
+    var mediaClass = String(node.type || "")
+    if (mediaClass.indexOf("Audio/Source") !== -1
+      || mediaClass.indexOf("AudioSource") !== -1
+      || mediaClass.indexOf("Source") !== -1) return true
+
+    // Quickshell supplies isSink=false for real capture endpoints. Merely
+    // exposing an audio interface is not enough: filter/control nodes can also
+    // have one and must never be presented as microphones.
+    return node.isSink === false && !!node.audio
+  } catch (e) {
+    return false
+  }
 }
 
 function isInternalAudioNode(name, properties) {
-  var value = String(name || "").trim().toLowerCase()
-  var props = properties && typeof properties === "object" ? properties : {}
-  return value === "quickshell"
-    || value.indexOf("omarchy_audio_test") === 0
-    || value.indexOf("omarchy_speaker_tuning") === 0
-    || String(props["application.id"] || "") === "ssupt.audio-control"
+  try {
+    var value = String(name || "").trim().toLowerCase()
+    var props = properties && typeof properties === "object" ? properties : {}
+    return value === "quickshell"
+      || value.indexOf("omarchy_audio_test") === 0
+      || value.indexOf("omarchy_speaker_tuning") === 0
+      || String(props["application.id"] || "") === "ssupt.audio-control"
+  } catch (e) {
+    return false
+  }
 }
 
 function isMonitorSource(node) {
-  if (!node) return false
-  var name = String(node.name || "").toLowerCase()
-  var properties = nodeProps(node)
-  return name.endsWith(".monitor")
-    || String(properties["device.class"] || "").toLowerCase() === "monitor"
+  try {
+    if (!node) return false
+    var name = nodeName(node).toLowerCase()
+    var properties = nodeProps(node)
+    return name.endsWith(".monitor")
+      || String(properties["device.class"] || "").toLowerCase() === "monitor"
+  } catch (e) {
+    return false
+  }
 }
 
 // Keep PipeWire classification in one place so every surface excludes the
@@ -51,24 +77,116 @@ function isMonitorSource(node) {
 function classifyAudioNodes(nodes) {
   var values = nodes && typeof nodes.length === "number" ? nodes : []
   var result = { sinks: [], sources: [], playbackStreams: [], recordingStreams: [] }
-  for (var i = 0; i < values.length; i++) {
-    var node = values[i]
-    if (!node) continue
-    if (node.isStream) {
-      if (isInternalAudioNode(node.name, nodeProps(node))) continue
-      if (isPlaybackStream(node)) result.playbackStreams.push(node)
-      else if (isRecordingStream(node)) result.recordingStreams.push(node)
-      continue
-    }
-    if (node.isSink === true) result.sinks.push(node)
-    else if (isAudioSource(node) && !isInternalAudioNode(node.name) && !isMonitorSource(node))
-      result.sources.push(node)
+  for (var i = 0; i < values.length && i < 4096; i++) {
+    try {
+      var node = values[i]
+      if (!node) continue
+      if (node.isStream) {
+        if (isInternalAudioNode(nodeName(node), nodeProps(node))) continue
+        if (isPlaybackStream(node) && result.playbackStreams.length < 512)
+          result.playbackStreams.push(node)
+        else if (isRecordingStream(node) && result.recordingStreams.length < 512)
+          result.recordingStreams.push(node)
+        continue
+      }
+      if (node.isSink === true && result.sinks.length < 512) result.sinks.push(node)
+      else if (result.sources.length < 512 && isAudioSource(node)
+          && !isInternalAudioNode(nodeName(node), nodeProps(node)) && !isMonitorSource(node))
+        result.sources.push(node)
+    } catch (e) { }
   }
   return result
 }
 
 function listSnapshot(list) {
-  return list && list.slice ? list.slice() : []
+  var result = []
+  try {
+    var values = list && typeof list.length === "number" ? list : []
+    for (var i = 0; i < values.length && i < 4096; i++) result.push(values[i])
+  } catch (e) { }
+  return result
+}
+
+// Configuration files contain user- and service-provided strings that become
+// object keys. Plain property lookup is unsafe for names such as "constructor"
+// or "__proto__", because those can resolve through (or mutate) Object's
+// prototype instead of representing a real stored entry.
+function hasOwn(object, key) {
+  return !!object && Object.prototype.hasOwnProperty.call(object, String(key))
+}
+
+function mapValue(object, key, fallback) {
+  return hasOwn(object, key) ? object[String(key)] : fallback
+}
+
+function setMapValue(object, key, value) {
+  Object.defineProperty(object, String(key), {
+    value: value,
+    writable: true,
+    enumerable: true,
+    configurable: true
+  })
+}
+
+function boundedSerializedInput(raw, maximumLength) {
+  var text = String(raw === undefined || raw === null ? "" : raw)
+  return text.length <= maximumLength ? text : null
+}
+
+function storedObjectDocument(raw, maximumLength) {
+  var text = boundedSerializedInput(raw, maximumLength)
+  if (text === null || text.trim() === "") return null
+  try {
+    var parsed = JSON.parse(text)
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? parsed : null
+  } catch (e) {
+    return null
+  }
+}
+
+function hasVersionOneOrNone(parsed) {
+  return !hasOwn(parsed, "version") || parsed.version === 1
+}
+
+// FileView can observe an atomic replacement between rename/watch events and
+// briefly fail or expose malformed external edits. These validators let the
+// QML surfaces retain their last known-good state instead of interpreting a
+// transient read as a request to reset every preference.
+function isAudioPreferencesDocument(raw) {
+  var parsed = storedObjectDocument(raw, 1048576)
+  if (!parsed || !hasVersionOneOrNone(parsed)) return false
+  if (hasOwn(parsed, "defaults") && (!parsed.defaults
+      || typeof parsed.defaults !== "object" || Array.isArray(parsed.defaults))) return false
+  if (hasOwn(parsed, "bluetoothProfiles") && (!parsed.bluetoothProfiles
+      || typeof parsed.bluetoothProfiles !== "object"
+      || Array.isArray(parsed.bluetoothProfiles))) return false
+  return true
+}
+
+function isAudioControlSettingsDocument(raw) {
+  var parsed = storedObjectDocument(raw, 65536)
+  if (!parsed || !hasVersionOneOrNone(parsed)) return false
+  if (hasOwn(parsed, "outputOverdrive") && typeof parsed.outputOverdrive !== "boolean")
+    return false
+  if (hasOwn(parsed, "captureNotifications")
+      && typeof parsed.captureNotifications !== "boolean") return false
+  return true
+}
+
+function isAudioScenesDocument(raw) {
+  var parsed = storedObjectDocument(raw, 2097152)
+  return !!parsed && hasVersionOneOrNone(parsed)
+    && (!hasOwn(parsed, "scenes") || Array.isArray(parsed.scenes))
+}
+
+function isAudioRulesDocument(raw) {
+  var parsed = storedObjectDocument(raw, 1048576)
+  if (!parsed || !hasVersionOneOrNone(parsed)) return false
+  if (hasOwn(parsed, "appRules") && !Array.isArray(parsed.appRules)) return false
+  if (hasOwn(parsed, "devices") && (!parsed.devices
+      || typeof parsed.devices !== "object" || Array.isArray(parsed.devices))) return false
+  return true
 }
 
 function normalizedBluetoothAddress(value) {
@@ -77,8 +195,9 @@ function normalizedBluetoothAddress(value) {
 
 function parseAudioPreferences(raw) {
   var parsed
+  var text = boundedSerializedInput(raw, 1048576)
   try {
-    parsed = JSON.parse(String(raw || "{}"))
+    parsed = text === null ? {} : JSON.parse(text || "{}")
   } catch (e) {
     parsed = {}
   }
@@ -90,17 +209,24 @@ function parseAudioPreferences(raw) {
   if (!rawProfiles || typeof rawProfiles !== "object" || Array.isArray(rawProfiles)) rawProfiles = {}
 
   var profiles = {}
+  var inspectedProfiles = 0
   for (var address in rawProfiles) {
+    if (inspectedProfiles++ >= 512 || Object.keys(profiles).length >= 128) break
+    if (!hasOwn(rawProfiles, address)) continue
     var key = normalizedBluetoothAddress(address)
-    var profile = rawProfiles[address]
-    if (key !== "" && typeof profile === "string" && profile !== "") profiles[key] = profile
+    var profile = typeof rawProfiles[address] === "string"
+      ? sanitizeIdentifier(rawProfiles[address], 160) : ""
+    if (/^[0-9a-f]{12}$/.test(key) && profile !== "" && !hasOwn(profiles, key))
+      setMapValue(profiles, key, profile)
   }
 
   return {
     version: 1,
     defaults: {
-      output: typeof defaults.output === "string" ? defaults.output : "",
-      input: typeof defaults.input === "string" ? defaults.input : ""
+      output: typeof defaults.output === "string"
+        ? sanitizeIdentifier(defaults.output, 160) : "",
+      input: typeof defaults.input === "string"
+        ? sanitizeIdentifier(defaults.input, 160) : ""
     },
     bluetoothProfiles: profiles
   }
@@ -108,9 +234,10 @@ function parseAudioPreferences(raw) {
 
 function preferredAudioProfile(preferences, address, options, activeProfile) {
   var profiles = preferences && preferences.bluetoothProfiles
-  var saved = profiles ? String(profiles[normalizedBluetoothAddress(address)] || "") : ""
+  var saved = profiles
+    ? String(mapValue(profiles, normalizedBluetoothAddress(address), "") || "") : ""
   var values = options && typeof options.length === "number" ? options : []
-  for (var i = 0; i < values.length; i++) {
+  for (var i = 0; i < values.length && i < 256; i++) {
     var value = values[i] && typeof values[i] === "object" ? values[i].value : values[i]
     if (String(value || "") === saved) return saved
   }
@@ -123,16 +250,36 @@ function preferredAudioNodeName(preferences, direction, liveNode, nodes) {
     ? String(defaults[direction] || "") : ""
   var values = nodes && typeof nodes.length === "number" ? nodes : []
   if (saved !== "") {
-    for (var i = 0; i < values.length; i++)
-      if (values[i] && String(values[i].name || "") === saved) return saved
+    var savedMatches = 0
+    for (var i = 0; i < values.length && i < 4096; i++) {
+      try {
+        if (nodeName(values[i]) === saved) savedMatches++
+      } catch (e) { }
+      if (savedMatches > 1) break
+    }
+    if (savedMatches === 1) return saved
   }
-  return liveNode ? String(liveNode.name || "") : ""
+
+  // A name is the persisted identity used by the default-device helpers. A
+  // transient duplicate must not make two rows look selected or invite a
+  // mutation the helper will (correctly) reject as ambiguous.
+  var liveName = nodeName(liveNode)
+  if (liveName === "") return ""
+  var liveMatches = 0
+  for (i = 0; i < values.length && i < 4096; i++) {
+    try {
+      if (nodeName(values[i]) === liveName) liveMatches++
+    } catch (e) { }
+    if (liveMatches > 1) return ""
+  }
+  return liveName
 }
 
 function parseAudioControlSettings(raw) {
   var parsed
+  var text = boundedSerializedInput(raw, 65536)
   try {
-    parsed = JSON.parse(String(raw || "{}"))
+    parsed = text === null ? {} : JSON.parse(text || "{}")
   } catch (e) {
     parsed = {}
   }
@@ -152,9 +299,30 @@ function clampNumber(value, fallback, minimum, maximum) {
 
 function sanitizeSceneString(value, fallback, maximumLength) {
   var text = String(value === undefined || value === null ? "" : value).trim()
+  text = text.replace(/[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]/g, " ")
+    .replace(/ +/g, " ").trim()
   if (text === "") return fallback
   if (maximumLength && text.length > maximumLength) text = text.substring(0, maximumLength)
   return text
+}
+
+// Identifiers are passed back to PipeWire and must remain byte-for-byte equal
+// to what it published. Labels can be cleaned for display, but silently
+// trimming, truncating, or replacing characters in a node/profile identifier
+// produces a preference that can never match the live object. Reject those
+// identifiers instead.
+function sanitizeIdentifier(value, maximumLength) {
+  if (typeof value !== "string" || value === ""
+      || (maximumLength && value.length > maximumLength)
+      || /[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]/.test(value))
+    return ""
+  return value
+}
+
+function normalizeAppKey(value) {
+  return sanitizeSceneString(value, "", 120).replace(/[A-Z]/g, function(letter) {
+    return letter.toLowerCase()
+  })
 }
 
 function sanitizeSceneEntry(raw) {
@@ -165,13 +333,17 @@ function sanitizeSceneEntry(raw) {
   var defaults = raw.defaults && typeof raw.defaults === "object" && !Array.isArray(raw.defaults)
     ? raw.defaults : {}
   var devices = []
+  var seenDevices = {}
   var rawDevices = Array.isArray(raw.devices) ? raw.devices : []
-  for (var i = 0; i < rawDevices.length && devices.length < 64; i++) {
+  for (var i = 0; i < rawDevices.length && i < 256 && devices.length < 64; i++) {
     var device = rawDevices[i]
     if (!device || typeof device !== "object") continue
-    var deviceName = sanitizeSceneString(device.name, "", 160)
-    var direction = device.direction === "input" ? "input" : "output"
-    if (deviceName === "") continue
+    var deviceName = sanitizeIdentifier(device.name, 160)
+    if (device.direction !== "input" && device.direction !== "output") continue
+    var direction = device.direction
+    var deviceKey = direction + ":" + deviceName
+    if (deviceName === "" || hasOwn(seenDevices, deviceKey)) continue
+    setMapValue(seenDevices, deviceKey, true)
     devices.push({
       name: deviceName,
       direction: direction,
@@ -185,28 +357,34 @@ function sanitizeSceneEntry(raw) {
   }
 
   var ports = []
+  var seenPorts = {}
   var rawPorts = Array.isArray(raw.ports) ? raw.ports : []
-  for (var j = 0; j < rawPorts.length && ports.length < 64; j++) {
+  for (var j = 0; j < rawPorts.length && j < 256 && ports.length < 64; j++) {
     var port = rawPorts[j]
     if (!port || typeof port !== "object") continue
-    var endpoint = sanitizeSceneString(port.endpoint, "", 160)
-    var portDirection = port.direction === "input" ? "input" : "output"
-    var portValue = sanitizeSceneString(port.value, "", 160)
-    if (endpoint === "" || portValue === "") continue
+    var endpoint = sanitizeIdentifier(port.endpoint, 160)
+    if (port.direction !== "input" && port.direction !== "output") continue
+    var portDirection = port.direction
+    var portValue = sanitizeIdentifier(port.value, 160)
+    var portKey = portDirection + ":" + endpoint
+    if (endpoint === "" || portValue === "" || hasOwn(seenPorts, portKey)) continue
+    setMapValue(seenPorts, portKey, true)
     ports.push({ direction: portDirection, endpoint: endpoint, value: portValue })
   }
 
   var profiles = []
+  var seenProfiles = {}
   var rawProfiles = Array.isArray(raw.profiles) ? raw.profiles : []
-  for (var k = 0; k < rawProfiles.length && profiles.length < 64; k++) {
+  for (var k = 0; k < rawProfiles.length && k < 256 && profiles.length < 64; k++) {
     var profile = rawProfiles[k]
     if (!profile || typeof profile !== "object") continue
-    var card = sanitizeSceneString(profile.card, "", 160)
-    var profileValue = sanitizeSceneString(profile.profile, "", 160)
-    if (card === "" || profileValue === "") continue
+    var card = sanitizeIdentifier(profile.card, 160)
+    var profileValue = sanitizeIdentifier(profile.profile, 160)
+    if (card === "" || profileValue === "" || hasOwn(seenProfiles, card)) continue
     // Restoring "off" would power down cards the user may have enabled since;
     // scenes choose how a card behaves when it is used, never whether it is.
     if (profileValue === "off") continue
+    setMapValue(seenProfiles, card, true)
     profiles.push({ card: card, profile: profileValue })
   }
 
@@ -214,8 +392,8 @@ function sanitizeSceneEntry(raw) {
     name: name,
     savedAt: sanitizeSceneString(raw.savedAt, "", 32),
     defaults: {
-      output: sanitizeSceneString(defaults.output, "", 160),
-      input: sanitizeSceneString(defaults.input, "", 160)
+      output: sanitizeIdentifier(defaults.output, 160),
+      input: sanitizeIdentifier(defaults.input, 160)
     },
     devices: devices,
     ports: ports,
@@ -225,8 +403,9 @@ function sanitizeSceneEntry(raw) {
 
 function parseAudioScenes(raw) {
   var parsed
+  var text = boundedSerializedInput(raw, 2097152)
   try {
-    parsed = JSON.parse(String(raw || "{}"))
+    parsed = text === null ? {} : JSON.parse(text || "{}")
   } catch (e) {
     parsed = {}
   }
@@ -235,10 +414,10 @@ function parseAudioScenes(raw) {
   var scenes = []
   var rawScenes = Array.isArray(parsed.scenes) ? parsed.scenes : []
   var seen = {}
-  for (var i = 0; i < rawScenes.length && scenes.length < 24; i++) {
+  for (var i = 0; i < rawScenes.length && i < 96 && scenes.length < 24; i++) {
     var scene = sanitizeSceneEntry(rawScenes[i])
-    if (!scene || seen[scene.name]) continue
-    seen[scene.name] = true
+    if (!scene || hasOwn(seen, scene.name)) continue
+    setMapValue(seen, scene.name, true)
     scenes.push(scene)
   }
   return { version: 1, scenes: scenes }
@@ -266,8 +445,9 @@ function sceneSummary(scene) {
 
 function parseAudioRules(raw) {
   var parsed
+  var text = boundedSerializedInput(raw, 1048576)
   try {
-    parsed = JSON.parse(String(raw || "{}"))
+    parsed = text === null ? {} : JSON.parse(text || "{}")
   } catch (e) {
     parsed = {}
   }
@@ -276,14 +456,16 @@ function parseAudioRules(raw) {
   var appRules = []
   var rawRules = Array.isArray(parsed.appRules) ? parsed.appRules : []
   var seen = {}
-  for (var i = 0; i < rawRules.length && appRules.length < 64; i++) {
+  for (var i = 0; i < rawRules.length && i < 256 && appRules.length < 64; i++) {
     var rule = rawRules[i]
     if (!rule || typeof rule !== "object") continue
-    var app = sanitizeSceneString(rule.app, "", 120).toLowerCase()
-    var direction = rule.direction === "recording" ? "recording" : "playback"
-    var target = sanitizeSceneString(rule.target, "", 160)
-    if (app === "" || target === "" || seen[direction + ":" + app]) continue
-    seen[direction + ":" + app] = true
+    var app = normalizeAppKey(rule.app)
+    if (rule.direction !== "recording" && rule.direction !== "playback") continue
+    var direction = rule.direction
+    var target = sanitizeIdentifier(rule.target, 160)
+    var ruleKey = direction + ":" + app
+    if (app === "" || target === "" || hasOwn(seen, ruleKey)) continue
+    setMapValue(seen, ruleKey, true)
     appRules.push({ app: app, direction: direction, target: target })
   }
 
@@ -291,19 +473,21 @@ function parseAudioRules(raw) {
     ? parsed.devices : {}
   var aliases = {}
   if (devices.aliases && typeof devices.aliases === "object" && !Array.isArray(devices.aliases)) {
+    var inspectedAliases = 0
     for (var nodeName in devices.aliases) {
+      if (inspectedAliases++ >= 256 || Object.keys(aliases).length >= 128) break
+      if (!hasOwn(devices.aliases, nodeName)) continue
       var alias = sanitizeSceneString(devices.aliases[nodeName], "", 80)
-      var key = String(nodeName || "").trim()
-      if (key !== "" && alias !== "") aliases[key] = alias
-      if (Object.keys(aliases).length >= 128) break
+      var key = sanitizeIdentifier(nodeName, 160)
+      if (key !== "" && alias !== "") setMapValue(aliases, key, alias)
     }
   }
 
   function stringList(value, maximum) {
     var out = []
     var rawList = Array.isArray(value) ? value : []
-    for (var j = 0; j < rawList.length && out.length < maximum; j++) {
-      var entry = sanitizeSceneString(rawList[j], "", 160)
+    for (var j = 0; j < rawList.length && j < 256 && out.length < maximum; j++) {
+      var entry = sanitizeIdentifier(rawList[j], 160)
       if (entry !== "" && out.indexOf(entry) === -1) out.push(entry)
     }
     return out
@@ -323,10 +507,10 @@ function parseAudioRules(raw) {
 // Case-insensitive lookup: rules are matched against the labels applications
 // publish, and those spellings vary across launches.
 function findAppRule(rules, direction, appKey) {
-  var key = String(appKey || "").trim().toLowerCase()
+  var key = normalizeAppKey(appKey)
   if (key === "") return null
   var values = Array.isArray(rules) ? rules : []
-  for (var i = 0; i < values.length; i++)
+  for (var i = 0; i < values.length && i < 256; i++)
     if (values[i].direction === direction && values[i].app === key) return values[i]
   return null
 }
@@ -335,22 +519,25 @@ function availableRuleApplicationLabels(playbackStreams, recordingStreams, rules
   var candidates = []
 
   function consider(node, direction) {
-    if (!node || node.ready !== true || !node.audio) return
-    var label = String(rawStreamLabel(node) || "").trim()
-    if (label === "") return
-    var key = label.toLowerCase()
-    var candidate = null
-    for (var i = 0; i < candidates.length; i++) {
-      if (candidates[i].key === key) {
-        candidate = candidates[i]
-        break
+    try {
+      if (!node || node.ready !== true || !node.audio) return
+      var label = sanitizeSceneString(rawStreamLabel(node), "", 120)
+      if (label === "") return
+      var key = normalizeAppKey(label)
+      var candidate = null
+      for (var i = 0; i < candidates.length && i < 512; i++) {
+        if (candidates[i].key === key) {
+          candidate = candidates[i]
+          break
+        }
       }
-    }
-    if (!candidate) {
-      candidate = { key: key, label: label, playback: false, recording: false }
-      candidates.push(candidate)
-    }
-    candidate[direction] = true
+      if (!candidate && candidates.length < 512) {
+        candidate = { key: key, label: label, playback: false, recording: false }
+        candidates.push(candidate)
+      }
+      if (!candidate) return
+      candidate[direction] = true
+    } catch (e) { }
   }
 
   var playback = playbackStreams && typeof playbackStreams.length === "number"
@@ -358,11 +545,11 @@ function availableRuleApplicationLabels(playbackStreams, recordingStreams, rules
   var recording = recordingStreams && typeof recordingStreams.length === "number"
     ? recordingStreams : []
   var i
-  for (i = 0; i < playback.length; i++) consider(playback[i], "playback")
-  for (i = 0; i < recording.length; i++) consider(recording[i], "recording")
+  for (i = 0; i < playback.length && i < 512; i++) consider(playback[i], "playback")
+  for (i = 0; i < recording.length && i < 512; i++) consider(recording[i], "recording")
 
   var available = []
-  for (i = 0; i < candidates.length; i++) {
+  for (i = 0; i < candidates.length && i < 512 && available.length < 512; i++) {
     var value = candidates[i]
     if ((value.playback && !findAppRule(rules, "playback", value.key))
         || (value.recording && !findAppRule(rules, "recording", value.key)))
@@ -374,8 +561,12 @@ function availableRuleApplicationLabels(playbackStreams, recordingStreams, rules
 function deviceSortComparator(favorites) {
   var values = Array.isArray(favorites) ? favorites : []
   return function(a, b) {
-    var aKey = String(a && typeof a === "object" ? a.name || "" : a || "")
-    var bKey = String(b && typeof b === "object" ? b.name || "" : b || "")
+    var aKey = ""
+    var bKey = ""
+    try { aKey = String(a && typeof a === "object" ? a.name || "" : a || "") }
+    catch (e) { }
+    try { bKey = String(b && typeof b === "object" ? b.name || "" : b || "") }
+    catch (e) { }
     var ra = values.indexOf(aKey)
     var rb = values.indexOf(bKey)
     var fa = ra >= 0 ? 0 : 1
@@ -388,8 +579,10 @@ function deviceSortComparator(favorites) {
 
 function parseAudioPolicySettings(raw) {
   var parsed
+  var text = boundedSerializedInput(raw, 262144)
   try {
-    parsed = JSON.parse(String(raw || ""))
+    if (text === null) throw new Error("Audio policy response is too large")
+    parsed = JSON.parse(text)
   } catch (e) {
     return { valid: false, values: {} }
   }
@@ -458,8 +651,10 @@ function emptyAudioDiagnostics() {
 
 function parseAudioDiagnostics(raw) {
   var parsed
+  var text = boundedSerializedInput(raw, 8388608)
   try {
-    parsed = JSON.parse(String(raw || ""))
+    if (text === null) throw new Error("Audio diagnostics response is too large")
+    parsed = JSON.parse(text)
   } catch (e) {
     return { valid: false, value: emptyAudioDiagnostics() }
   }
@@ -502,7 +697,7 @@ function parseAudioDiagnostics(raw) {
   }
 
   var rawServices = Array.isArray(parsed.services) ? parsed.services : []
-  for (var i = 0; i < rawServices.length && value.services.length < 8; i++) {
+  for (var i = 0; i < rawServices.length && i < 32 && value.services.length < 8; i++) {
     var service = rawServices[i]
     if (!service || typeof service !== "object") continue
     var serviceName = sanitizeSceneString(service.name, "", 80)
@@ -519,14 +714,15 @@ function parseAudioDiagnostics(raw) {
   }
 
   var rawDevices = Array.isArray(parsed.devices) ? parsed.devices : []
-  for (var j = 0; j < rawDevices.length && value.devices.length < 64; j++) {
+  for (var j = 0; j < rawDevices.length && j < 256 && value.devices.length < 64; j++) {
     var device = rawDevices[j]
     if (!device || typeof device !== "object") continue
+    if (device.direction !== "input" && device.direction !== "output") continue
     var deviceName = sanitizeSceneString(device.name, "", 240)
     var label = sanitizeSceneString(device.label, deviceName, 160)
     if (deviceName === "" || label === "") continue
     value.devices.push({
-      direction: device.direction === "input" ? "input" : "output",
+      direction: device.direction,
       name: deviceName,
       label: label,
       state: sanitizeSceneString(device.state, "unknown", 32),
@@ -542,9 +738,10 @@ function parseAudioDiagnostics(raw) {
   }
 
   var rawRoutes = Array.isArray(parsed.routes) ? parsed.routes : []
-  for (var k = 0; k < rawRoutes.length && value.routes.length < 64; k++) {
+  for (var k = 0; k < rawRoutes.length && k < 256 && value.routes.length < 64; k++) {
     var route = rawRoutes[k]
     if (!route || typeof route !== "object" || !Array.isArray(route.labels)) continue
+    if (route.direction !== "recording" && route.direction !== "playback") continue
     var labels = []
     for (var l = 0; l < route.labels.length && labels.length < 16; l++) {
       var routeLabel = sanitizeSceneString(route.labels[l], "", 160)
@@ -553,7 +750,7 @@ function parseAudioDiagnostics(raw) {
     }
     if (labels.length < 2) continue
     value.routes.push({
-      direction: route.direction === "recording" ? "recording" : "playback",
+      direction: route.direction,
       labels: labels
     })
   }
@@ -569,7 +766,7 @@ function parseAudioDiagnostics(raw) {
   }
 
   var rawWarnings = Array.isArray(parsed.warnings) ? parsed.warnings : []
-  for (var m = 0; m < rawWarnings.length && value.warnings.length < 32; m++) {
+  for (var m = 0; m < rawWarnings.length && m < 128 && value.warnings.length < 32; m++) {
     var warning = sanitizeSceneString(rawWarnings[m], "", 240)
     if (warning !== "" && value.warnings.indexOf(warning) === -1)
       value.warnings.push(warning)
@@ -579,8 +776,10 @@ function parseAudioDiagnostics(raw) {
 }
 
 function balanceValue(left, right) {
-  var l = Math.max(0, Number(left || 0))
-  var r = Math.max(0, Number(right || 0))
+  var l = Number(left)
+  var r = Number(right)
+  if (!isFinite(l) || l < 0) l = 0
+  if (!isFinite(r) || r < 0) r = 0
   var peak = Math.max(l, r)
   if (peak === 0) return 0
   return r >= l ? 1 - l / peak : -(1 - r / peak)
@@ -589,11 +788,21 @@ function balanceValue(left, right) {
 function applyBalance(volumes, leftIndex, rightIndex, balance) {
   var values = []
   var source = volumes && typeof volumes.length === "number" ? volumes : []
-  for (var i = 0; i < source.length; i++) values.push(Number(source[i] || 0))
+  var sourceLength = Math.floor(Number(source.length))
+  // Audio channel collections are tiny in practice. Refuse an implausible
+  // collection instead of copying an attacker-controlled array-like object or
+  // returning a truncated channel map that could be assigned back to PipeWire.
+  if (!isFinite(sourceLength) || sourceLength < 0 || sourceLength > 64) return source
+  for (var i = 0; i < sourceLength; i++) {
+    var channel = Number(source[i])
+    values.push(isFinite(channel) && channel >= 0 ? channel : 0)
+  }
   if (leftIndex < 0 || rightIndex < 0 || leftIndex >= values.length || rightIndex >= values.length)
     return values
 
-  var value = Math.max(-1, Math.min(1, Number(balance || 0)))
+  var value = Number(balance)
+  if (!isFinite(value)) value = 0
+  value = Math.max(-1, Math.min(1, value))
   var peak = Math.max(values[leftIndex], values[rightIndex])
   values[leftIndex] = peak * (value > 0 ? 1 - value : 1)
   values[rightIndex] = peak * (value < 0 ? 1 + value : 1)
@@ -610,8 +819,9 @@ function audioMeterLevel(peaks, volumes, peak, volume, muted) {
   // PwNodePeakMonitor deliberately removes each channel's node volume from
   // its peaks. Reapply those volumes so the meter represents the signal that
   // actually leaves the application, including channel balance.
-  if (peakValues.length > 0 && peakValues.length === volumeValues.length) {
-    for (var i = 0; i < peakValues.length; i++) {
+  if (peakValues.length > 0 && peakValues.length <= 64
+      && peakValues.length === volumeValues.length) {
+    for (var i = 0; i < peakValues.length && i < 64; i++) {
       var channelPeak = Number(peakValues[i])
       var channelVolume = Number(volumeValues[i])
       if (!isFinite(channelPeak) || channelPeak < 0) channelPeak = 0
@@ -631,7 +841,9 @@ function audioMeterLevel(peaks, volumes, peak, volume, muted) {
 
 function outputVolumeName(volume, muted) {
   if (muted) return "Muted"
-  var p = Math.round(volume * 100)
+  var numericVolume = Number(volume)
+  if (!isFinite(numericVolume) || numericVolume < 0) numericVolume = 0
+  var p = Math.round(numericVolume * 100)
   if (p === 0) return "Silenced"
   if (p > 125) return "Overdrive"
   if (p >= 100) return "Concert hall"
@@ -645,49 +857,74 @@ function outputVolumeName(volume, muted) {
 
 function parseSinkAvailability(raw) {
   var next = {}
-  var lines = String(raw || "").split("\n")
-  for (var i = 0; i < lines.length; i++) {
-    var line = lines[i].trim()
+  var text = boundedSerializedInput(raw, 1048576)
+  if (text === null) return next
+  var lines = text.split("\n")
+  for (var i = 0; i < lines.length && i < 1024 && Object.keys(next).length < 256; i++) {
+    var line = lines[i]
     if (!line) continue
     var parts = line.split("\t")
-    if (parts.length >= 2) next[parts[0]] = parts[1] !== "0"
+    var name = sanitizeIdentifier(parts[0], 160)
+    if (parts.length >= 2 && name !== "" && (parts[1] === "0" || parts[1] === "1")) {
+      var available = parts[1] === "1"
+      // Duplicate endpoint names are not safe routing identities. Preserve a
+      // repeated agreement, but make contradictory records unavailable rather
+      // than trusting whichever upstream line happened to arrive last.
+      if (hasOwn(next, name) && next[name] !== available) next[name] = false
+      else if (!hasOwn(next, name)) setMapValue(next, name, available)
+    }
   }
   return next
 }
 
 function parseAudioProfiles(raw) {
   var cards
+  var text = boundedSerializedInput(raw, 8388608)
   try {
-    cards = JSON.parse(String(raw || "[]"))
+    if (text === null) return []
+    cards = JSON.parse(text || "[]")
   } catch (e) {
     return []
   }
   if (!Array.isArray(cards)) return []
 
   var normalized = []
-  for (var i = 0; i < cards.length; i++) {
+  var seenCards = {}
+  for (var i = 0; i < cards.length && i < 256 && normalized.length < 64; i++) {
     var card = cards[i]
-    if (!card || !card.name || !Array.isArray(card.profiles) || card.profiles.length === 0) continue
+    if (!card || typeof card !== "object" || Array.isArray(card)
+        || !Array.isArray(card.profiles) || card.profiles.length === 0) continue
+    var cardName = sanitizeIdentifier(card.name, 160)
+    if (cardName === "" || hasOwn(seenCards, cardName)) continue
 
     var profiles = []
-    for (var j = 0; j < card.profiles.length; j++) {
+    var seenProfiles = {}
+    for (var j = 0; j < card.profiles.length && j < 256 && profiles.length < 64; j++) {
       var profile = card.profiles[j]
-      if (!profile || !profile.value) continue
+      if (!profile || typeof profile !== "object" || Array.isArray(profile)) continue
+      var profileValue = sanitizeIdentifier(profile.value, 160)
+      if (profileValue === "" || hasOwn(seenProfiles, profileValue)) continue
+      var sinks = Math.floor(clampNumber(profile.sinks, 0, 0, 64))
+      var sources = Math.floor(clampNumber(profile.sources, 0, 0, 64))
+      setMapValue(seenProfiles, profileValue, true)
       profiles.push({
-        value: String(profile.value),
-        label: String(profile.label || profile.value),
-        sinks: Number(profile.sinks || 0),
-        sources: Number(profile.sources || 0)
+        value: profileValue,
+        label: sanitizeSceneString(profile.label, profileValue, 160),
+        sinks: sinks,
+        sources: sources
       })
     }
     if (profiles.length === 0) continue
 
+    setMapValue(seenCards, cardName, true)
+    var activeProfile = sanitizeIdentifier(card.activeProfile, 160) || "off"
+    if (!hasOwn(seenProfiles, activeProfile)) activeProfile = "off"
     normalized.push({
-      name: String(card.name),
-      label: String(card.label || card.name),
+      name: cardName,
+      label: sanitizeSceneString(card.label, cardName, 160),
       bluetooth: card.bluetooth === true,
-      address: String(card.address || ""),
-      activeProfile: String(card.activeProfile || "off"),
+      address: sanitizeIdentifier(card.address, 80),
+      activeProfile: activeProfile,
       profiles: profiles
     })
   }
@@ -703,30 +940,47 @@ function parseAudioProfiles(raw) {
 
 function parseAudioPorts(raw) {
   var values
+  var text = boundedSerializedInput(raw, 8388608)
   try {
-    values = JSON.parse(String(raw || "[]"))
+    if (text === null) return []
+    values = JSON.parse(text || "[]")
   } catch (e) {
     return []
   }
   if (!Array.isArray(values)) return []
 
   var ports = []
-  for (var i = 0; i < values.length; i++) {
+  var seenEndpoints = {}
+  for (var i = 0; i < values.length && i < 512 && ports.length < 128; i++) {
     var item = values[i]
-    if (!item || (item.direction !== "output" && item.direction !== "input")
-        || !item.endpoint || !Array.isArray(item.ports) || item.ports.length < 2) continue
+    if (!item || typeof item !== "object" || Array.isArray(item)
+        || (item.direction !== "output" && item.direction !== "input")
+        || !Array.isArray(item.ports) || item.ports.length < 2) continue
+    var endpoint = sanitizeIdentifier(item.endpoint, 160)
+    var endpointKey = item.direction + ":" + endpoint
+    if (endpoint === "" || hasOwn(seenEndpoints, endpointKey)) continue
     var options = []
-    for (var j = 0; j < item.ports.length; j++) {
+    var seenOptions = {}
+    for (var j = 0; j < item.ports.length && j < 256 && options.length < 64; j++) {
       var port = item.ports[j]
-      if (!port || !port.value) continue
-      options.push({ value: String(port.value), label: String(port.label || port.value) })
+      if (!port || typeof port !== "object" || Array.isArray(port)) continue
+      var portValue = sanitizeIdentifier(port.value, 160)
+      if (portValue === "" || hasOwn(seenOptions, portValue)) continue
+      setMapValue(seenOptions, portValue, true)
+      options.push({
+        value: portValue,
+        label: sanitizeSceneString(port.label, portValue, 160)
+      })
     }
     if (options.length < 2) continue
+    setMapValue(seenEndpoints, endpointKey, true)
+    var activePort = sanitizeIdentifier(item.activePort, 160)
+    if (!hasOwn(seenOptions, activePort)) activePort = ""
     ports.push({
       direction: item.direction,
-      endpoint: String(item.endpoint),
-      label: String(item.label || item.endpoint),
-      activePort: String(item.activePort || ""),
+      endpoint: endpoint,
+      label: sanitizeSceneString(item.label, endpoint, 160),
+      activePort: activePort,
       ports: options
     })
   }
@@ -754,7 +1008,7 @@ function audioProfileOptions(card) {
   // objects, so accept any indexed profile collection with a length.
   if (!card || !card.profiles || typeof card.profiles.length !== "number") return []
   var options = []
-  for (var i = 0; i < card.profiles.length; i++) {
+  for (var i = 0; i < card.profiles.length && i < 256 && options.length < 64; i++) {
     var profile = card.profiles[i]
     options.push({
       value: profile.value,
@@ -767,20 +1021,20 @@ function audioProfileOptions(card) {
 function audioCardsByBluetooth(cards, bluetooth) {
   var values = Array.isArray(cards) ? cards : []
   var filtered = []
-  for (var i = 0; i < values.length; i++)
+  for (var i = 0; i < values.length && i < 256 && filtered.length < 64; i++)
     if (values[i] && values[i].bluetooth === bluetooth) filtered.push(values[i])
   return filtered
 }
 
 function hasBluetoothCards(cards) {
   var values = Array.isArray(cards) ? cards : []
-  for (var i = 0; i < values.length; i++)
+  for (var i = 0; i < values.length && i < 256; i++)
     if (values[i] && values[i].bluetooth) return true
   return false
 }
 
 function friendlyDeviceLabel(text) {
-  var label = String(text || "").trim()
+  var label = sanitizeSceneString(text, "", 160)
   label = label.replace(/^sof-soundwire\s+/i, "")
   label = label.replace(/^built-?in audio\s+/i, "")
   label = label.replace(/\s+Output$/i, "")
@@ -789,13 +1043,64 @@ function friendlyDeviceLabel(text) {
   return label
 }
 
+// QObject-backed PipeWire nodes can disappear between two QML binding
+// evaluations. Keep graph identity reads in one exception-safe, strictly
+// validated accessor so stale proxies never abort a refresh or become helper
+// arguments after their native object has gone away.
+function nodeName(node) {
+  try {
+    if (!node || typeof node.name !== "string") return ""
+    return sanitizeIdentifier(node.name, 160)
+  } catch (e) {
+    return ""
+  }
+}
+
 function nodeProps(node) {
-  return node && node.ready && node.properties ? node.properties : {}
+  try {
+    return node && node.ready && node.properties ? node.properties : {}
+  } catch (e) {
+    return {}
+  }
 }
 
 function nodeSerial(node) {
-  var serial = nodeProps(node)["object.serial"]
-  return serial === undefined || serial === null ? "" : String(serial)
+  try {
+    var serial = nodeProps(node)["object.serial"]
+    var text = serial === undefined || serial === null ? "" : String(serial)
+    return /^\d{1,20}$/.test(text) ? text : ""
+  } catch (e) {
+    return ""
+  }
+}
+
+function nodeObjectId(node) {
+  try {
+    if (!node) return ""
+    var direct = node.id === undefined || node.id === null ? "" : String(node.id)
+    var propertyValue = nodeProps(node)["object.id"]
+    var propertyId = propertyValue === undefined || propertyValue === null
+      ? "" : String(propertyValue)
+    if (direct !== "" && !/^\d{1,20}$/.test(direct)) return ""
+    if (propertyId !== "" && !/^\d{1,20}$/.test(propertyId)) return ""
+    if (direct !== "" && propertyId !== "" && direct !== propertyId) return ""
+    return direct !== "" ? direct : propertyId
+  } catch (e) {
+    return ""
+  }
+}
+
+function uniqueNodeSerial(nodes, node) {
+  var serial = nodeSerial(node)
+  if (serial === "") return ""
+  var values = nodes && typeof nodes.length === "number" ? nodes : []
+  if (values.length > 4096) return ""
+  var matches = 0
+  for (var i = 0; i < values.length && i < 4096; i++) {
+    if (nodeSerial(values[i]) === serial) matches++
+    if (matches > 1) return ""
+  }
+  return matches === 1 ? serial : ""
 }
 
 function deviceRouteOptions(devices, defaultDevice, followLabel, overridePrefix, labelFor) {
@@ -803,13 +1108,25 @@ function deviceRouteOptions(devices, defaultDevice, followLabel, overridePrefix,
   var values = Array.isArray(devices) ? devices : []
   var options = []
   var defaultSerial = nodeSerial(defaultDevice)
-  if (defaultSerial !== "")
+  var serialCounts = {}
+  for (var i = 0; i < values.length && i < 512; i++) {
+    var countedSerial = nodeSerial(values[i])
+    if (countedSerial === "") continue
+    setMapValue(serialCounts, countedSerial,
+      Number(mapValue(serialCounts, countedSerial, 0)) + 1)
+  }
+  var defaultOccurrences = Number(mapValue(serialCounts, defaultSerial, 0))
+  // A hidden default is absent from this picker but still a valid follow
+  // target. An observed duplicate serial is unsafe because the shell helper
+  // cannot know which endpoint the user intended.
+  if (defaultSerial !== "" && defaultOccurrences <= 1)
     options.push({ value: "default:" + defaultSerial, label: followLabel })
 
   var seen = []
-  for (var i = 0; i < values.length; i++) {
+  for (i = 0; i < values.length && i < 512; i++) {
     var defaultCandidate = values[i]
-    if (nodeSerial(defaultCandidate) !== defaultSerial || defaultSerial === "") continue
+    if (nodeSerial(defaultCandidate) !== defaultSerial || defaultSerial === ""
+        || defaultOccurrences !== 1) continue
     seen.push(defaultSerial)
     options.push({
       value: "override:" + defaultSerial,
@@ -817,10 +1134,11 @@ function deviceRouteOptions(devices, defaultDevice, followLabel, overridePrefix,
     })
     break
   }
-  for (i = 0; i < values.length; i++) {
+  for (i = 0; i < values.length && i < 512 && options.length < 513; i++) {
     var device = values[i]
     var serial = nodeSerial(device)
-    if (serial === "" || seen.indexOf(serial) !== -1) continue
+    if (serial === "" || Number(mapValue(serialCounts, serial, 0)) !== 1
+        || seen.indexOf(serial) !== -1) continue
     seen.push(serial)
     options.push({ value: "override:" + serial, label: overridePrefix + labelFor(device) })
   }
@@ -843,76 +1161,131 @@ function parseStreamOutputOption(value) {
   if (separator < 1) return { mode: "", sink: "" }
   var mode = text.substring(0, separator)
   var sink = text.substring(separator + 1)
-  if ((mode !== "default" && mode !== "override") || !/^\d+$/.test(sink))
+  if ((mode !== "default" && mode !== "override") || !/^\d{1,20}$/.test(sink))
     return { mode: "", sink: "" }
   return { mode: mode, sink: sink }
 }
 
+function parseAudioStreamRoutes(raw) {
+  var parsed
+  var text = boundedSerializedInput(raw, 2097152)
+  try {
+    if (text === null) throw new Error("Audio route response is too large")
+    parsed = JSON.parse(text)
+  } catch (e) {
+    return { valid: false, playback: {}, recording: {} }
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)
+      || !parsed.playback || typeof parsed.playback !== "object" || Array.isArray(parsed.playback)
+      || !parsed.recording || typeof parsed.recording !== "object" || Array.isArray(parsed.recording))
+    return { valid: false, playback: {}, recording: {} }
+
+  function normalize(routes) {
+    var result = {}
+    var inspected = 0
+    for (var serial in routes) {
+      if (inspected++ >= 512) break
+      if (!hasOwn(routes, serial) || !/^\d{1,20}$/.test(serial)) continue
+      var route = routes[serial]
+      if (!route || typeof route !== "object" || Array.isArray(route)) continue
+      var target = String(route.target === undefined || route.target === null ? "" : route.target)
+      var mode = String(route.mode || "")
+      if (!/^\d{1,20}$/.test(target) || (mode !== "default" && mode !== "override")) continue
+      setMapValue(result, serial, { target: target, mode: mode })
+    }
+    return result
+  }
+
+  return {
+    valid: true,
+    playback: normalize(parsed.playback),
+    recording: normalize(parsed.recording)
+  }
+}
+
 function nodeLabel(node) {
-  if (!node) return "Unknown"
-  var p = nodeProps(node)
-  var nickname = friendlyDeviceLabel(node.nickname || node.nick || p["node.nick"] || p["device.profile.description"] || "")
-  if (nickname) return nickname
-  return friendlyDeviceLabel(node.description || p["node.description"] || node.name || "Unknown")
+  try {
+    if (!node) return "Unknown"
+    var p = nodeProps(node)
+    var nickname = friendlyDeviceLabel(node.nickname || node.nick
+      || p["node.nick"] || p["device.profile.description"] || "")
+    if (nickname) return nickname
+    return friendlyDeviceLabel(node.description || p["node.description"]
+      || nodeName(node) || "Unknown")
+  } catch (e) {
+    return "Unknown"
+  }
 }
 
 function isHeadphones(node) {
-  if (!node) return false
-  var p = nodeProps(node)
-  var blob = String([
-    node.name, node.description, node.nickname,
-    p["device.icon-name"] || "",
-    p["device.product.name"] || "",
-    p["node.description"] || "",
-    p["node.nick"] || ""
-  ].join(" ")).toLowerCase()
-  return blob.indexOf("headphone") !== -1
-    || blob.indexOf("headset") !== -1
-    || blob.indexOf("earbud") !== -1
-    || blob.indexOf("earphone") !== -1
-    || blob.indexOf("airpod") !== -1
+  try {
+    if (!node) return false
+    var p = nodeProps(node)
+    var blob = String([
+      node.name, node.description, node.nickname,
+      p["device.icon-name"] || "",
+      p["device.product.name"] || "",
+      p["node.description"] || "",
+      p["node.nick"] || ""
+    ].join(" ")).toLowerCase()
+    return blob.indexOf("headphone") !== -1
+      || blob.indexOf("headset") !== -1
+      || blob.indexOf("earbud") !== -1
+      || blob.indexOf("earphone") !== -1
+      || blob.indexOf("airpod") !== -1
+  } catch (e) {
+    return false
+  }
 }
 
 function sinkGlyph(node) {
-  if (!node) return "󰓃"
-  if (isHeadphones(node)) return "󰋋"
-  var p = nodeProps(node)
-  var blob = String([
-    node.name, node.description, node.nickname,
-    p["device.icon-name"] || "",
-    p["device.product.name"] || ""
-  ].join(" ")).toLowerCase()
-  if (blob.indexOf("bluetooth") !== -1) return "󰂯"
-  if (blob.indexOf("hdmi") !== -1 || blob.indexOf("display") !== -1) return "󰍹"
-  return "󰓃"
+  try {
+    if (!node) return "󰓃"
+    if (isHeadphones(node)) return "󰋋"
+    var p = nodeProps(node)
+    var blob = String([
+      node.name, node.description, node.nickname,
+      p["device.icon-name"] || "",
+      p["device.product.name"] || ""
+    ].join(" ")).toLowerCase()
+    if (blob.indexOf("bluetooth") !== -1) return "󰂯"
+    if (blob.indexOf("hdmi") !== -1 || blob.indexOf("display") !== -1) return "󰍹"
+    return "󰓃"
+  } catch (e) {
+    return "󰓃"
+  }
 }
 
 function sourceGlyph(node) {
-  if (!node) return "󰍬"
-  var p = nodeProps(node)
-  var blob = String([
-    node.name, node.description, node.nickname,
-    p["device.icon-name"] || ""
-  ].join(" ")).toLowerCase()
-  if (blob.indexOf("headset") !== -1) return "󰋋"
-  if (blob.indexOf("bluetooth") !== -1) return "󰂯"
-  if (blob.indexOf("webcam") !== -1 || blob.indexOf("camera") !== -1) return "󰄀"
-  return "󰍬"
+  try {
+    if (!node) return "󰍬"
+    var p = nodeProps(node)
+    var blob = String([
+      node.name, node.description, node.nickname,
+      p["device.icon-name"] || ""
+    ].join(" ")).toLowerCase()
+    if (blob.indexOf("headset") !== -1) return "󰋋"
+    if (blob.indexOf("bluetooth") !== -1) return "󰂯"
+    if (blob.indexOf("webcam") !== -1 || blob.indexOf("camera") !== -1) return "󰄀"
+    return "󰍬"
+  } catch (e) {
+    return "󰍬"
+  }
 }
 
 function friendlyStreamLabel(label) {
-  label = String(label || "").trim()
+  label = sanitizeSceneString(label, "", 160)
   if (!label) return ""
 
   var known = {
     "spotify": "Spotify"
   }
   var normalized = label.toLowerCase()
-  return known[normalized] || label
+  return mapValue(known, normalized, label)
 }
 
 function streamLabelKey(label) {
-  return String(label || "").trim().toLowerCase()
+  return normalizeAppKey(label)
 }
 
 function streamLabelIsGeneric(label) {
@@ -920,24 +1293,36 @@ function streamLabelIsGeneric(label) {
 }
 
 function rawStreamLabel(node) {
-  if (!node) return ""
-  var p = nodeProps(node)
-  return p["application.name"]
-    || node.description
-    || p["media.name"]
-    || p["node.name"]
-    || node.name
+  try {
+    if (!node) return ""
+    var p = nodeProps(node)
+    return p["application.name"]
+      || node.description
+      || p["media.name"]
+      || p["node.name"]
+      || node.name
+  } catch (e) {
+    return ""
+  }
 }
 
 function mprisPlayerLabel(player) {
-  if (!player) return ""
-  return friendlyStreamLabel(player.identity || player.desktopEntry || "")
+  try {
+    if (!player) return ""
+    return friendlyStreamLabel(player.identity || player.desktopEntry || "")
+  } catch (e) {
+    return ""
+  }
 }
 
 function mprisPlayerIsProxy(player) {
-  var dbusName = String(player && player.dbusName || "").toLowerCase()
-  var desktopEntry = String(player && player.desktopEntry || "").toLowerCase()
-  return dbusName.indexOf("playerctld") !== -1 || desktopEntry === "playerctld"
+  try {
+    var dbusName = String(player && player.dbusName || "").toLowerCase()
+    var desktopEntry = String(player && player.desktopEntry || "").toLowerCase()
+    return dbusName.indexOf("playerctld") !== -1 || desktopEntry === "playerctld"
+  } catch (e) {
+    return false
+  }
 }
 
 function streamRepresentsMprisPlayer(streamLabel, playerLabel) {
@@ -950,27 +1335,31 @@ function streamRepresentsMprisPlayer(streamLabel, playerLabel) {
 }
 
 function mprisLabelsFor(players, predicate) {
-  var values = Array.isArray(players) ? players : []
+  // Quickshell service `.values` collections are indexed QML sequences, not
+  // guaranteed JavaScript Arrays.
+  var values = players && typeof players.length === "number" ? players : []
   var playingCandidates = []
   var candidates = []
   var playingProxyCandidates = []
   var proxyCandidates = []
 
-  for (var i = 0; i < values.length; i++) {
-    var player = values[i]
-    if (!player) continue
-    if (!player.isPlaying && !player.canPlay) continue
+  for (var i = 0; i < values.length && i < 256; i++) {
+    try {
+      var player = values[i]
+      if (!player) continue
+      if (!player.isPlaying && !player.canPlay) continue
 
-    var playerLabel = mprisPlayerLabel(player)
-    if (!playerLabel || !predicate(playerLabel)) continue
+      var playerLabel = mprisPlayerLabel(player)
+      if (!playerLabel || !predicate(playerLabel)) continue
 
-    if (mprisPlayerIsProxy(player)) {
-      if (player.isPlaying) playingProxyCandidates.push(playerLabel)
-      proxyCandidates.push(playerLabel)
-    } else {
-      if (player.isPlaying) playingCandidates.push(playerLabel)
-      candidates.push(playerLabel)
-    }
+      if (mprisPlayerIsProxy(player)) {
+        if (player.isPlaying) playingProxyCandidates.push(playerLabel)
+        proxyCandidates.push(playerLabel)
+      } else {
+        if (player.isPlaying) playingCandidates.push(playerLabel)
+        candidates.push(playerLabel)
+      }
+    } catch (e) { }
   }
 
   if (playingCandidates.length === 1) return playingCandidates[0]
@@ -991,8 +1380,8 @@ function unmatchedMprisStreamLabel(label, players, streams) {
   if (!streamLabelIsGeneric(label)) return ""
 
   return mprisLabelsFor(players, function(playerLabel) {
-    var values = Array.isArray(streams) ? streams : []
-    for (var i = 0; i < values.length; i++) {
+    var values = streams && typeof streams.length === "number" ? streams : []
+    for (var i = 0; i < values.length && i < 512; i++) {
       var stream = values[i]
       var streamLabel = rawStreamLabel(stream)
       if (!streamLabelIsGeneric(streamLabel) && streamRepresentsMprisPlayer(streamLabel, playerLabel))
@@ -1018,7 +1407,7 @@ function uniqueRecordingStreamLabels(streams) {
   var values = Array.isArray(streams) ? streams : []
   var labels = []
   var keys = []
-  for (var i = 0; i < values.length; i++) {
+  for (var i = 0; i < values.length && i < 512 && labels.length < 512; i++) {
     var label = recordingStreamLabel(values[i])
     var key = streamLabelKey(label)
     if (keys.indexOf(key) !== -1) continue
@@ -1033,24 +1422,30 @@ function addedRecordingStreamLabels(previous, current) {
   var now = Array.isArray(current) ? current : []
   var previousKeys = []
   var additions = []
+  var additionKeys = []
   var i
-  for (i = 0; i < before.length; i++) previousKeys.push(streamLabelKey(before[i]))
-  for (i = 0; i < now.length; i++) {
-    var label = String(now[i] || "").trim()
-    if (label !== "" && previousKeys.indexOf(streamLabelKey(label)) === -1)
+  for (i = 0; i < before.length && i < 512; i++) previousKeys.push(streamLabelKey(before[i]))
+  for (i = 0; i < now.length && i < 512 && additions.length < 512; i++) {
+    var label = sanitizeSceneString(now[i], "", 160)
+    var key = streamLabelKey(label)
+    if (label !== "" && previousKeys.indexOf(key) === -1
+        && additionKeys.indexOf(key) === -1) {
+      additionKeys.push(key)
       additions.push(label)
+    }
   }
   return additions
 }
 
 function normalizeStreamIconName(name) {
-  var value = String(name || "").trim()
+  var value = sanitizeSceneString(name, "", 128).replace(/\.desktop$/i, "")
+  if (!/^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$/.test(value)) return ""
   var aliases = {
     "chromium-browser": "chromium",
     "spotify-client": "spotify",
     "discord": "discord"
   }
-  return aliases[value.toLowerCase()] || value
+  return mapValue(aliases, value.toLowerCase(), value)
 }
 
 function streamIconName(node, players, streams) {
@@ -1058,12 +1453,14 @@ function streamIconName(node, players, streams) {
   var direct = p["application.icon_name"] || p["application.icon-name"] || ""
   if (direct) return normalizeStreamIconName(direct)
 
-  var values = Array.isArray(players) ? players : []
-  for (var i = 0; i < values.length; i++) {
-    var player = values[i]
-    if (!player || !streamRepresentsPlayer(node, player, values, streams)) continue
-    if (player.desktopEntry)
-      return normalizeStreamIconName(String(player.desktopEntry).replace(/\.desktop$/i, ""))
+  var values = players && typeof players.length === "number" ? players : []
+  for (var i = 0; i < values.length && i < 256; i++) {
+    try {
+      var player = values[i]
+      if (!player || !streamRepresentsPlayer(node, player, values, streams)) continue
+      if (player.desktopEntry)
+        return normalizeStreamIconName(String(player.desktopEntry).replace(/\.desktop$/i, ""))
+    } catch (e) { }
   }
 
   var applicationId = String(p["application.id"] || "")
@@ -1077,8 +1474,67 @@ function streamIconName(node, players, streams) {
     "chromium": "chromium"
   }
   var label = streamLabelKey(rawStreamLabel(node))
-  if (labelIcons[label]) return labelIcons[label]
+  if (hasOwn(labelIcons, label)) return labelIcons[label]
   return ""
+}
+
+// Return a declarative scene plan so ordering is independently testable and
+// the controller can resolve live PipeWire objects only when each step runs.
+// Profiles can recreate endpoints, so no port, device, or default target may
+// be resolved before all profile helpers have completed.
+function audioScenePlan(scene) {
+  var normalized = sanitizeSceneEntry(scene)
+  if (!normalized) return []
+
+  var steps = []
+  var i
+  for (i = 0; i < normalized.profiles.length; i++) {
+    steps.push({
+      kind: "profile",
+      card: normalized.profiles[i].card,
+      profile: normalized.profiles[i].profile,
+      label: "Profile " + normalized.profiles[i].card
+    })
+  }
+  if (normalized.profiles.length > 0) steps.push({ kind: "settle", label: "Audio devices" })
+
+  for (i = 0; i < normalized.ports.length; i++) {
+    steps.push({
+      kind: "port",
+      direction: normalized.ports[i].direction,
+      endpoint: normalized.ports[i].endpoint,
+      value: normalized.ports[i].value,
+      label: "Port " + normalized.ports[i].endpoint
+    })
+  }
+  for (i = 0; i < normalized.devices.length; i++) {
+    steps.push({
+      kind: "device",
+      direction: normalized.devices[i].direction,
+      name: normalized.devices[i].name,
+      volume: normalized.devices[i].volume,
+      muted: normalized.devices[i].muted,
+      balance: normalized.devices[i].balance,
+      label: normalized.devices[i].name
+    })
+  }
+  if (normalized.defaults.output !== "") {
+    steps.push({
+      kind: "default",
+      direction: "output",
+      name: normalized.defaults.output,
+      label: "Default output"
+    })
+  }
+  if (normalized.defaults.input !== "") {
+    steps.push({
+      kind: "default",
+      direction: "input",
+      name: normalized.defaults.input,
+      label: "Default input"
+    })
+  }
+  return steps
 }
 
 function streamRepresentsPlayer(node, player, players, streams) {
@@ -1100,6 +1556,12 @@ if (typeof module !== "undefined") {
     isMonitorSource: isMonitorSource,
     classifyAudioNodes: classifyAudioNodes,
     listSnapshot: listSnapshot,
+    hasOwn: hasOwn,
+    mapValue: mapValue,
+    isAudioPreferencesDocument: isAudioPreferencesDocument,
+    isAudioControlSettingsDocument: isAudioControlSettingsDocument,
+    isAudioScenesDocument: isAudioScenesDocument,
+    isAudioRulesDocument: isAudioRulesDocument,
     normalizedBluetoothAddress: normalizedBluetoothAddress,
     parseAudioPreferences: parseAudioPreferences,
     preferredAudioProfile: preferredAudioProfile,
@@ -1107,6 +1569,8 @@ if (typeof module !== "undefined") {
     parseAudioControlSettings: parseAudioControlSettings,
     parseAudioScenes: parseAudioScenes,
     sanitizeSceneEntry: sanitizeSceneEntry,
+    sanitizeIdentifier: sanitizeIdentifier,
+    normalizeAppKey: normalizeAppKey,
     sceneSummary: sceneSummary,
     parseAudioRules: parseAudioRules,
     findAppRule: findAppRule,
@@ -1127,11 +1591,15 @@ if (typeof module !== "undefined") {
     audioCardsByBluetooth: audioCardsByBluetooth,
     hasBluetoothCards: hasBluetoothCards,
     friendlyDeviceLabel: friendlyDeviceLabel,
+    nodeName: nodeName,
     nodeProps: nodeProps,
     nodeSerial: nodeSerial,
+    nodeObjectId: nodeObjectId,
+    uniqueNodeSerial: uniqueNodeSerial,
     streamOutputOptions: streamOutputOptions,
     recordingInputOptions: recordingInputOptions,
     parseStreamOutputOption: parseStreamOutputOption,
+    parseAudioStreamRoutes: parseAudioStreamRoutes,
     nodeLabel: nodeLabel,
     isHeadphones: isHeadphones,
     sinkGlyph: sinkGlyph,
@@ -1151,6 +1619,7 @@ if (typeof module !== "undefined") {
     uniqueRecordingStreamLabels: uniqueRecordingStreamLabels,
     addedRecordingStreamLabels: addedRecordingStreamLabels,
     streamIconName: streamIconName,
-    streamRepresentsPlayer: streamRepresentsPlayer
+    streamRepresentsPlayer: streamRepresentsPlayer,
+    audioScenePlan: audioScenePlan
   }
 }

--- a/Panel.qml
+++ b/Panel.qml
@@ -16,14 +16,27 @@ Panel {
   AudioRuntime { id: runtime }
 
   readonly property var sink: Pipewire.defaultAudioSink
-  readonly property var source: Pipewire.defaultAudioSource
+  readonly property var rawSource: Pipewire.defaultAudioSource
+  // PipeWire permits a sink monitor to be the default source. Treating that
+  // loopback node as a microphone would expose the wrong mute/level controls
+  // and produce misleading capture state in the panel.
+  readonly property var source: usableInputNode(rawSource) ? rawSource : null
   readonly property var nodes: Pipewire.nodes ? Pipewire.nodes.values : []
   AudioRulesController {
     id: rulesStore
     nodes: root.nodes
     rulesPath: runtime.rulesPath
     scriptPath: runtime.script("audio-app-rules")
-    onRulesChanged: Qt.callLater(root.enforceRoutingRules)
+    onRulesChanged: {
+      root.resetRoutingEnforcement()
+      Qt.callLater(root.enforceRoutingRules)
+    }
+    onWriteFinished: function(success) {
+      if (success) return
+      root.streamRouteSetError = "Application route changed, but its saved rule could not be updated"
+      root.resetRoutingEnforcement()
+      Qt.callLater(root.enforceRoutingRules)
+    }
   }
   readonly property var mprisPlayers: Mpris.players ? Mpris.players.values : []
   readonly property var appLibrary: bar && bar.shell ? bar.shell.appLibrary : null
@@ -31,10 +44,13 @@ Panel {
     ? bar.shell.firstPartyServiceFor("omarchy.media") : null
   readonly property var activeMediaPlayer: mediaService ? mediaService.activePlayer : null
   property var audioPreferences: Model.parseAudioPreferences("")
+  property bool audioPreferencesLoaded: false
   property bool outputOverdrive: false
   property bool captureNotifications: true
+  property bool audioControlSettingsLoaded: false
   property bool notificationsAvailable: false
   property var audioScenes: []
+  property bool audioScenesLoaded: false
   readonly property var audioRules: rulesStore.rules
   readonly property bool rulesLoaded: rulesStore.loaded
   property string sceneFeedback: ""
@@ -44,6 +60,7 @@ Panel {
   property real inputPeakHold: 0
   property bool inputClipping: false
   readonly property real outputVolumeMaximum: outputOverdrive ? 1.5 : 1.0
+  onOutputOverdriveChanged: enforceOutputVolumeLimit()
 
   readonly property var candidateSinks: rulesStore.sinks
   readonly property var candidateSources: rulesStore.sources
@@ -52,6 +69,17 @@ Panel {
 
   property var sinkAvailability: ({})
   property bool sinkAvailabilityLoaded: false
+
+  function usableInputNode(node) {
+    try {
+      return !!node && node.isStream !== true && node.isSink !== true
+        && Model.nodeName(node) !== "" && Model.isAudioSource(node)
+        && !Model.isMonitorSource(node)
+        && !Model.isInternalAudioNode(Model.nodeName(node), Model.nodeProps(node))
+    } catch (_error) {
+      return false
+    }
+  }
 
   function loadAudioPreferences(raw) {
     audioPreferences = Model.parseAudioPreferences(raw)
@@ -83,10 +111,15 @@ Panel {
 
   readonly property var rawAudioSinks: {
     var list = []
-    for (var i = 0; i < candidateSinks.length; i++)
-      if (sinkAvailable(candidateSinks[i]) && !deviceHidden(candidateSinks[i].name))
-        list.push(candidateSinks[i])
-    if (sink && !deviceHidden(sink.name) && list.indexOf(sink) < 0) list.unshift(sink)
+    for (var i = 0; i < candidateSinks.length; i++) {
+      var candidate = candidateSinks[i]
+      var candidateName = Model.nodeName(candidate)
+      if (candidateName !== "" && sinkAvailable(candidate)
+          && !deviceHidden(candidateName)) list.push(candidate)
+    }
+    var sinkName = Model.nodeName(sink)
+    if (sinkName !== "" && !deviceHidden(sinkName) && list.indexOf(sink) < 0)
+      list.unshift(sink)
     var sorted = list.slice()
     sorted.sort(Model.deviceSortComparator(audioRules.devices.favorites))
     return sorted
@@ -94,9 +127,13 @@ Panel {
 
   readonly property var rawAudioSources: {
     var list = []
-    for (var i = 0; i < candidateSources.length; i++)
-      if (!deviceHidden(candidateSources[i].name)) list.push(candidateSources[i])
-    if (source && !Model.isMonitorSource(source) && !deviceHidden(source.name)
+    for (var i = 0; i < candidateSources.length; i++) {
+      var candidate = candidateSources[i]
+      var candidateName = Model.nodeName(candidate)
+      if (candidateName !== "" && !deviceHidden(candidateName)) list.push(candidate)
+    }
+    var sourceName = Model.nodeName(source)
+    if (sourceName !== "" && !Model.isMonitorSource(source) && !deviceHidden(sourceName)
         && list.indexOf(source) < 0) list.unshift(source)
     var sorted = list.slice()
     sorted.sort(Model.deviceSortComparator(audioRules.devices.favorites))
@@ -104,10 +141,12 @@ Panel {
   }
 
   readonly property var cachedVisibleAudioSinks: cachedAudioSinks.filter(function(node) {
-    return node && !deviceHidden(node.name)
+    var name = Model.nodeName(node)
+    return name !== "" && sinkAvailable(node) && !deviceHidden(name)
   })
   readonly property var cachedVisibleAudioSources: cachedAudioSources.filter(function(node) {
-    return node && !deviceHidden(node.name) && !Model.isMonitorSource(node)
+    var name = Model.nodeName(node)
+    return name !== "" && !deviceHidden(name) && !Model.isMonitorSource(node)
   })
   readonly property var audioSinks: rawAudioSinks.length > 0
     ? rawAudioSinks : cachedVisibleAudioSinks
@@ -124,22 +163,32 @@ Panel {
 
   readonly property var audioStreams: {
     var list = []
-    for (var i = 0; i < candidateStreams.length; i++)
-      if (candidateStreams[i].audio) list.push(candidateStreams[i])
+    for (var i = 0; i < candidateStreams.length; i++) {
+      try {
+        if (candidateStreams[i] && candidateStreams[i].audio) list.push(candidateStreams[i])
+      } catch (_error) { }
+    }
     return list
   }
 
   readonly property var recordingStreams: {
     var list = []
-    for (var i = 0; i < candidateRecordingStreams.length; i++)
-      if (candidateRecordingStreams[i].audio) list.push(candidateRecordingStreams[i])
+    for (var i = 0; i < candidateRecordingStreams.length; i++) {
+      try {
+        if (candidateRecordingStreams[i] && candidateRecordingStreams[i].audio)
+          list.push(candidateRecordingStreams[i])
+      } catch (_error) { }
+    }
     return list
   }
 
   readonly property var activeRecordingLabels: Model.uniqueRecordingStreamLabels(recordingStreams)
   readonly property int recordingApplicationCount: activeRecordingLabels.length
-  readonly property real inputPeakLevel: inputMuted
-    ? 0 : Math.max(0, Math.min(1, Number(inputPeakMonitor.peak || 0)))
+  readonly property real inputPeakLevel: {
+    if (inputMuted) return 0
+    var value = Number(inputPeakMonitor.peak)
+    return isFinite(value) ? Math.max(0, Math.min(1, value)) : 0
+  }
   readonly property color urgent: bar ? bar.urgent : Color.urgent
   readonly property string recordingTooltip: {
     var microphoneAction = hasInput
@@ -195,20 +244,28 @@ Panel {
   // share a display name.
   property var streamRoutes: ({})
   property var recordingStreamRoutes: ({})
-  property bool streamOutputMenuOpen: false
+  property int streamOutputMenuCount: 0
+  readonly property bool streamOutputMenuOpen: streamOutputMenuCount > 0
   property string streamRouteReadError: ""
   property string streamRouteSetError: ""
   readonly property string streamRouteError: streamRouteSetError !== ""
     ? streamRouteSetError : streamRouteReadError
   property string defaultOutputError: ""
   property string defaultInputError: ""
-  property var previousDefaultSink: null
-  property var previousDefaultSource: null
   readonly property string defaultDeviceError: defaultOutputError !== ""
     ? defaultOutputError : defaultInputError
   readonly property string panelError: defaultDeviceError !== ""
-    ? defaultDeviceError : streamRouteError
+    ? defaultDeviceError : (streamRouteError !== "" ? streamRouteError : rulesStore.error)
   property var pendingStreamRoute: null
+  readonly property bool routeMutationBusy: defaultSinkProc.running
+    || defaultSourceProc.running || streamRouteSetProc.running
+    || pendingStreamRoute !== null || rulesStore.busy
+  readonly property bool directDeviceMutationBusy: sceneController.busy
+    || defaultSinkProc.running || defaultSourceProc.running
+  onDirectDeviceMutationBusyChanged: if (!directDeviceMutationBusy)
+    enforceOutputVolumeLimit()
+  readonly property bool sceneMutationBusy: sceneController.busy || routeMutationBusy
+    || streamOutputMenuOpen
 
   // The default is ordered first and named by behavior. Applications on that
   // option follow later default changes; all other choices are persistent.
@@ -228,34 +285,125 @@ Panel {
   // tuning fronts") is what keeps this correct when headphones or HDMI are
   // selected while a tuning still exists.
   property string volumeSinkName: ""
+  property bool volumeSinkResolvePending: false
 
   // Carry sub-notch touchpad deltas between wheel events.
   property real wheelAccumulator: 0
 
   readonly property var volumeSink: {
-    if (volumeSinkName === "" || !sink) return sink
-    if (volumeSinkName === String(sink.name)) return sink
-    for (var i = 0; i < nodes.length; i++) {
-      var n = nodes[i]
-      if (n && n.isSink && !n.isStream && String(n.name) === volumeSinkName && n.audio)
-        return n
+    try {
+      if (volumeSinkName === "" || !sink) return sink
+      if (volumeSinkName === Model.nodeName(sink)) return sink
+      var match = null
+      for (var i = 0; i < nodes.length && i < 4096; i++) {
+        var n = nodes[i]
+        if (!n || !n.isSink || n.isStream || Model.nodeName(n) !== volumeSinkName
+            || !n.audio) continue
+        if (match) return sink
+        match = n
+      }
+      return match || sink
+    } catch (_error) {
+      return sink
     }
-    return sink
   }
   onVolumeSinkChanged: enforceOutputVolumeLimit()
 
   // Re-resolve whenever the selected output changes; the timer below is only a
   // safety net for the tuning being applied or removed underneath us.
-  onSinkChanged: resolveVolumeSink()
-
-  function resolveVolumeSink() {
-    if (!volumeSinkProc.running) volumeSinkProc.running = true
+  onSinkChanged: {
+    // Never expose the physical endpoint resolved for the previous default
+    // while a newer asynchronous lookup is still in flight.
+    volumeSinkName = ""
+    resolveVolumeSink()
   }
 
-  readonly property real outputVolume: volumeSink && volumeSink.audio ? volumeSink.audio.volume : 0
-  readonly property bool outputMuted: volumeSink && volumeSink.audio ? volumeSink.audio.muted : false
-  readonly property real inputVolume: source && source.audio ? source.audio.volume : 0
-  readonly property bool inputMuted: source && source.audio ? source.audio.muted : false
+  function resolveVolumeSink() {
+    if (volumeSinkProc.running) {
+      volumeSinkResolvePending = true
+      return
+    }
+    volumeSinkResolvePending = false
+    volumeSinkProc.response = ""
+    volumeSinkProc.requestedDefaultName = Model.nodeName(sink)
+    volumeSinkProc.requestedDefaultObjectId = Model.nodeObjectId(sink)
+    volumeSinkProc.running = true
+  }
+
+  readonly property real outputVolume: audioNodeVolume(volumeSink)
+  readonly property bool outputMuted: audioNodeMuted(volumeSink)
+  readonly property real inputVolume: audioNodeVolume(source)
+  readonly property bool inputMuted: audioNodeMuted(source)
+
+  // A deferred display snapshot can outlive its PipeWire object. Resolve the
+  // object id back through the current graph before every direct mutation and
+  // reject duplicate ids, replacements, and nodes that are not fully bound.
+  function mutableAudioNode(node) {
+    try {
+      if (!node || node.ready !== true || !node.audio
+          || nodes.length > 4096) return false
+      var objectId = Model.nodeObjectId(node)
+      if (objectId === "") return false
+      var match = null
+      for (var i = 0; i < nodes.length; i++) {
+        var candidate = nodes[i]
+        if (!candidate || Model.nodeObjectId(candidate) !== objectId) continue
+        if (match) return false
+        match = candidate
+      }
+      return match === node
+    } catch (_error) {
+      return false
+    }
+  }
+
+  function audioNodeVolume(node) {
+    if (!mutableAudioNode(node)) return 0
+    try {
+      var value = Number(node.audio.volume)
+      return isFinite(value) ? value : 0
+    } catch (_error) {
+      return 0
+    }
+  }
+
+  function audioNodeMuted(node) {
+    if (!mutableAudioNode(node)) return false
+    try { return node.audio.muted === true } catch (_error) { return false }
+  }
+
+  function setAudioNodeVolume(node, value, maximum) {
+    var requested = Number(value)
+    var ceiling = Number(maximum)
+    if (!mutableAudioNode(node) || !isFinite(requested)
+        || !isFinite(ceiling) || ceiling < 0) return false
+    try {
+      node.audio.volume = Math.max(0, Math.min(ceiling, requested))
+      return true
+    } catch (_error) {
+      return false
+    }
+  }
+
+  function setAudioNodeMuted(node, muted) {
+    if (!mutableAudioNode(node)) return false
+    try {
+      node.audio.muted = muted === true
+      return true
+    } catch (_error) {
+      return false
+    }
+  }
+
+  function toggleAudioNodeMute(node) {
+    if (!mutableAudioNode(node)) return false
+    try {
+      node.audio.muted = node.audio.muted !== true
+      return true
+    } catch (_error) {
+      return false
+    }
+  }
 
   onRawAudioSinksChanged: if (rawAudioSinks.length > 0) cachedAudioSinks = rawAudioSinks
   onRawAudioSourcesChanged: if (rawAudioSources.length > 0) cachedAudioSources = rawAudioSources
@@ -283,8 +431,8 @@ Panel {
   // Only channels that actually exist get a vote. A box with no default source
   // would otherwise report "input unmuted" forever, leaving the hero switch
   // able to mute but never to unmute.
-  readonly property bool hasOutput: !!(volumeSink && volumeSink.audio)
-  readonly property bool hasInput: !!(source && source.audio)
+  readonly property bool hasOutput: mutableAudioNode(volumeSink)
+  readonly property bool hasInput: mutableAudioNode(source)
   readonly property bool anyAudible: (hasOutput && !outputMuted) || (hasInput && !inputMuted)
   readonly property string toggleHint: anyAudible ? "Mute" : "Unmute"
 
@@ -399,6 +547,7 @@ Panel {
   // — the cursor is on a discrete row, not on the slider, and silently
   // moving the global slider would surprise the user.
   function adjustVolume(delta) {
+    if (directDeviceMutationBusy) return
     if (focusSection === "output" && selectedIndex === -1) {
       setOutputVolume(outputVolume + delta)
       return
@@ -409,13 +558,14 @@ Panel {
     }
     if (focusSection === "streams" && selectedIndex >= 0 && selectedIndex < displayAudioStreams.length) {
       var s = displayAudioStreams[selectedIndex]
-      if (s && s.ready === true && s.audio) s.audio.volume = Math.max(0, Math.min(1.5, s.audio.volume + delta))
+      var playbackVolume = audioNodeVolume(s) + Number(delta)
+      if (isFinite(playbackVolume)) setAudioNodeVolume(s, playbackVolume, 1.5)
       return
     }
     if (focusSection === "recording" && selectedIndex >= 0 && selectedIndex < displayRecordingStreams.length) {
       var recording = displayRecordingStreams[selectedIndex]
-      if (recording && recording.ready === true && recording.audio)
-        recording.audio.volume = Math.max(0, Math.min(1.5, recording.audio.volume + delta))
+      var recordingVolume = audioNodeVolume(recording) + Number(delta)
+      if (isFinite(recordingVolume)) setAudioNodeVolume(recording, recordingVolume, 1.5)
     }
   }
 
@@ -444,30 +594,34 @@ Panel {
     }
     if (focusSection === "streams" && selectedIndex >= 0) {
       var row = streamRepeater.itemAt(selectedIndex)
-      if (row && displayAudioSinks.length > 1) row.toggleOutputMenu()
+      if (row && row.routeMenuAvailable) row.toggleOutputMenu()
       else {
         var st = displayAudioStreams[selectedIndex]
-        if (st && st.ready === true && st.audio) st.audio.muted = !st.audio.muted
+        if (!sceneController.busy) toggleAudioNodeMute(st)
       }
       return
     }
     if (focusSection === "recording" && selectedIndex >= 0) {
       var recordingRow = recordingStreamRepeater.itemAt(selectedIndex)
-      if (recordingRow && displayAudioSources.length > 1) recordingRow.toggleOutputMenu()
+      if (recordingRow && recordingRow.routeMenuAvailable) recordingRow.toggleOutputMenu()
       else {
         var recordingStream = displayRecordingStreams[selectedIndex]
-        if (recordingStream && recordingStream.ready === true && recordingStream.audio)
-          recordingStream.audio.muted = !recordingStream.audio.muted
+        if (!sceneController.busy) toggleAudioNodeMute(recordingStream)
       }
     }
   }
 
   function openAdvancedAudio() {
+    if (sceneMutationBusy) return
     controller.hide()
     if (bar && bar.shell && typeof bar.shell.summon === "function")
       bar.shell.summon("ssupt.audio-control", "{}")
     else
       Quickshell.execDetached(["omarchy-shell", "shell", "summon", "ssupt.audio-control", "{}"])
+  }
+
+  function updateStreamOutputMenu(open) {
+    streamOutputMenuCount = Math.max(0, streamOutputMenuCount + (open ? 1 : -1))
   }
 
   onOpenedChanged: {
@@ -484,7 +638,7 @@ Panel {
       cursorActive = false
       Qt.callLater(resetScroll)
     } else {
-      streamOutputMenuOpen = false
+      streamOutputMenuCount = 0
       clearDisplayAudioModels()
     }
   }
@@ -492,8 +646,14 @@ Panel {
   // Clamp / repair the cursor whenever any list refreshes underneath us.
   // Stream changes also re-run routing rules so a pinned application is
   // routed as soon as it appears, panel open or not.
-  onAudioSinksChanged: scheduleDisplayAudioModelRefresh()
-  onAudioSourcesChanged: scheduleDisplayAudioModelRefresh()
+  onAudioSinksChanged: {
+    scheduleDisplayAudioModelRefresh()
+    Qt.callLater(enforceRoutingRules)
+  }
+  onAudioSourcesChanged: {
+    scheduleDisplayAudioModelRefresh()
+    Qt.callLater(enforceRoutingRules)
+  }
   onAudioStreamsChanged: {
     scheduleDisplayAudioModelRefresh()
     Qt.callLater(enforceRoutingRules)
@@ -516,9 +676,21 @@ Panel {
     var parts = []
     for (var i = 0; i < list.length; i++) {
       var node = list[i]
-      parts.push(node ? Model.nodeSerial(node) : "")
+      try {
+        parts.push(node ? [
+          Model.nodeSerial(node),
+          Model.nodeObjectId(node),
+          Model.nodeName(node),
+          node.isSink === true,
+          node.isStream === true
+        ] : null)
+      } catch (_error) {
+        // Force a single model refresh when a cached native QObject vanished;
+        // the next current-graph signature will then replace this sentinel.
+        parts.push(["vanished", i])
+      }
     }
-    return parts.join(",")
+    return JSON.stringify(parts)
   }
 
   function refreshDisplayAudioModels() {
@@ -566,50 +738,49 @@ Panel {
   }
 
   function updateStreamRoutes(raw) {
-    try {
-      var routes = JSON.parse(String(raw || "{}"))
-      if (!routes || typeof routes !== "object") routes = ({})
-      var playback = routes.playback && typeof routes.playback === "object" ? routes.playback : ({})
-      var recording = routes.recording && typeof routes.recording === "object" ? routes.recording : ({})
-      if (pendingStreamRoute) {
-        var pendingRoutes = pendingStreamRoute.direction === "recording" ? recording : playback
-        pendingRoutes[pendingStreamRoute.stream] = {
-          target: pendingStreamRoute.target,
-          mode: pendingStreamRoute.mode
-        }
-      }
-      streamRoutes = playback
-      recordingStreamRoutes = recording
-      streamRouteReadError = ""
-    } catch (e) {
-      streamRoutes = ({})
-      recordingStreamRoutes = ({})
+    var response = Model.parseAudioStreamRoutes(raw)
+    if (!response.valid) {
       streamRouteReadError = "Could not read application routes"
+      return
     }
+    var playback = response.playback
+    var recording = response.recording
+    if (pendingStreamRoute) {
+      var pendingRoutes = pendingStreamRoute.direction === "recording" ? recording : playback
+      pendingRoutes[pendingStreamRoute.stream] = {
+        target: pendingStreamRoute.target,
+        mode: pendingStreamRoute.mode
+      }
+    }
+    streamRoutes = playback
+    recordingStreamRoutes = recording
+    streamRouteReadError = ""
   }
 
   function streamSerial(node) {
-    return Model.nodeSerial(node)
+    var group = Model.isRecordingStream(node) ? recordingStreams : audioStreams
+    return Model.uniqueNodeSerial(group, node)
   }
 
   function streamRoute(node) {
     var serial = streamSerial(node)
     if (serial === "") return null
-    var route = streamRoutes[serial]
+    var route = Model.mapValue(streamRoutes, serial, null)
     return route && typeof route === "object" ? route : null
   }
 
   function recordingStreamRoute(node) {
     var serial = streamSerial(node)
     if (serial === "") return null
-    var route = recordingStreamRoutes[serial]
+    var route = Model.mapValue(recordingStreamRoutes, serial, null)
     return route && typeof route === "object" ? route : null
   }
 
   function setStreamRoute(node, optionValue, direction) {
     var streamSerialValue = streamSerial(node)
     var route = Model.parseStreamOutputOption(optionValue)
-    if (streamSerialValue === "" || route.sink === "" || route.mode === "" || streamRouteSetProc.running) return
+    if (streamSerialValue === "" || route.sink === "" || route.mode === ""
+        || sceneController.busy || routeMutationBusy) return
 
     // Keep the offline rules layer in sync: when the edited application has
     // a stored rule, a manual choice rewrites that rule instead of being
@@ -630,7 +801,8 @@ Panel {
 
     var routes = direction === "recording" ? recordingStreamRoutes : streamRoutes
     var next = ({})
-    for (var key in routes) next[key] = routes[key]
+    for (var key in routes)
+      if (Model.hasOwn(routes, key)) next[key] = routes[key]
     next[streamSerialValue] = { target: route.sink, mode: route.mode }
     if (direction === "recording") recordingStreamRoutes = next
     else streamRoutes = next
@@ -641,24 +813,28 @@ Panel {
       target: route.sink,
       mode: route.mode
     }
-    streamRouteSetProc.command = [
-      runtime.script("audio-stream-route-set"),
+    streamRouteSetProc.command = runtime.scriptCommand("audio-stream-route-set", [
       direction,
       streamSerialValue,
       route.sink,
       route.mode
-    ]
+    ])
     streamRouteSetProc.running = true
   }
 
   property var lastManualRouteSync: null
 
   function deviceNameForSerial(list, serial) {
-    for (var i = 0; i < list.length; i++) {
+    var match = ""
+    var matches = 0
+    for (var i = 0; i < list.length && i < 512; i++) {
       var node = list[i]
-      if (node && Model.nodeSerial(node) === String(serial)) return String(node.name || "")
+      if (!node || Model.nodeSerial(node) !== String(serial)) continue
+      matches++
+      match = Model.nodeName(node)
+      if (matches > 1) return ""
     }
-    return ""
+    return matches === 1 ? match : ""
   }
 
   // Enforcement runs outside the panel too: rules matter most when an
@@ -670,39 +846,67 @@ Panel {
   ]
   property var enforcedStreamRoutes: ({})
 
+  function resetRoutingEnforcement() {
+    enforcedStreamRoutes = ({})
+  }
+
+  function pruneRoutingEnforcement() {
+    var live = ({})
+    for (var g = 0; g < enforceableGroups.length; g++) {
+      var group = enforceableGroups[g]
+      for (var i = 0; i < group.nodes.length; i++) {
+        var serial = Model.uniqueNodeSerial(group.nodes, group.nodes[i])
+        var objectId = Model.nodeObjectId(group.nodes[i])
+        var key = group.direction + ":" + serial + ":" + objectId
+        if (serial !== "" && objectId !== "" && Model.hasOwn(enforcedStreamRoutes, key))
+          live[key] = enforcedStreamRoutes[key]
+      }
+    }
+    enforcedStreamRoutes = live
+  }
+
   function enforceRoutingRules() {
-    if (!rulesLoaded || streamRouteSetProc.running || pendingStreamRoute || streamOutputMenuOpen) return
+    if (!rulesLoaded || rulesStore.busy || sceneController.busy
+        || defaultSinkProc.running || defaultSourceProc.running || streamRouteSetProc.running
+        || pendingStreamRoute || streamOutputMenuOpen) return
+    pruneRoutingEnforcement()
     for (var g = 0; g < enforceableGroups.length; g++) {
       var group = enforceableGroups[g]
       for (var i = 0; i < group.nodes.length; i++) {
         var node = group.nodes[i]
-        if (!node || !node.audio || node.ready !== true) continue
-        var serial = Model.nodeSerial(node)
-        if (serial === "") continue
+        if (!mutableAudioNode(node)) continue
+        var serial = Model.uniqueNodeSerial(group.nodes, node)
+        var streamObjectId = Model.nodeObjectId(node)
+        if (serial === "" || streamObjectId === "") continue
         var rule = Model.findAppRule(audioRules.appRules, group.direction, rawStreamLabel(node))
         if (!rule) continue
-        var cacheKey = group.direction + ":" + serial
-        if (enforcedStreamRoutes[cacheKey] === rule.target) continue
+        var cacheKey = group.direction + ":" + serial + ":" + streamObjectId
 
         var targetNode = null
+        var targetMatches = 0
         for (var d = 0; d < group.devices.length; d++) {
-          if (group.devices[d] && group.devices[d].name === rule.target) {
+          if (Model.nodeName(group.devices[d]) === rule.target) {
+            targetMatches++
             targetNode = group.devices[d]
-            break
+            if (targetMatches > 1) break
           }
         }
         // An absent target falls back to WirePlumber's own choice; the rule
         // is enforced the moment the device appears.
-        if (!targetNode || targetNode.ready !== true) continue
+        if (targetMatches !== 1 || !mutableAudioNode(targetNode)) continue
+        var targetSerial = Model.uniqueNodeSerial(group.devices, targetNode)
+        var targetObjectId = Model.nodeObjectId(targetNode)
+        if (targetSerial === "" || targetObjectId === "") continue
+        var targetIdentity = JSON.stringify([rule.target, targetSerial, targetObjectId])
+        if (Model.mapValue(enforcedStreamRoutes, cacheKey, "") === targetIdentity) continue
 
-        enforcedStreamRoutes[cacheKey] = rule.target
-        streamRouteSetProc.command = [
-          runtime.script("audio-stream-route-set"),
+        enforcedStreamRoutes[cacheKey] = targetIdentity
+        streamRouteSetProc.command = runtime.scriptCommand("audio-stream-route-set", [
           group.direction,
           serial,
-          Model.nodeSerial(targetNode),
+          targetSerial,
           "override"
-        ]
+        ])
         streamRouteSetProc.running = true
         return
       }
@@ -759,7 +963,7 @@ Panel {
   function outputIcon(volume) {
     // Match the old Waybar pulseaudio glyph set. The Material Design speaker
     // icons render visually smaller in JetBrainsMono Nerd Font.
-    if (!sink || !sink.audio) return ""
+    if (!hasOutput) return ""
     if (isHeadphones(sink)) return "󰋋"
     if (outputMuted) return ""
     var v = volume === undefined ? outputVolume : volume
@@ -770,7 +974,7 @@ Panel {
   }
 
   function inputIcon() {
-    if (!source || !source.audio) return "󰍭"
+    if (!hasInput) return "󰍭"
     return inputMuted ? "󰍭" : "󰍬"
   }
 
@@ -782,10 +986,11 @@ Panel {
   }
 
   function setOutputVolume(v) {
-    if (!volumeSink || !volumeSink.audio) return outputVolume
-    var volume = Math.max(0, Math.min(outputVolumeMaximum, v))
-    volumeSink.audio.volume = volume
-    return volume
+    if (directDeviceMutationBusy || !mutableAudioNode(volumeSink)) return outputVolume
+    var requested = Number(v)
+    if (!isFinite(requested)) return outputVolume
+    var volume = Math.max(0, Math.min(outputVolumeMaximum, requested))
+    return setAudioNodeVolume(volumeSink, volume, outputVolumeMaximum) ? volume : outputVolume
   }
 
   function enforceOutputVolumeLimit() {
@@ -808,61 +1013,69 @@ Panel {
   }
 
   function setInputVolume(v) {
-    if (!source || !source.audio) return
-    source.audio.volume = Math.max(0, Math.min(1, v))
+    if (directDeviceMutationBusy || !mutableAudioNode(source)) return inputVolume
+    var requested = Number(v)
+    if (!isFinite(requested)) return inputVolume
+    var volume = Math.max(0, Math.min(1, requested))
+    return setAudioNodeVolume(source, volume, 1) ? volume : inputVolume
   }
 
   function toggleOutputMute() {
-    if (volumeSink && volumeSink.audio) volumeSink.audio.muted = !volumeSink.audio.muted
+    if (!directDeviceMutationBusy) toggleAudioNodeMute(volumeSink)
   }
 
   function toggleInputMute() {
-    if (source && source.audio) source.audio.muted = !source.audio.muted
+    if (!directDeviceMutationBusy) toggleAudioNodeMute(source)
   }
 
   // The hero switch is the whole panel's on/off, so it carries both channels
   // at once. It reads as on while anything is still audible, which keeps
   // muting a single channel from the row below flipping the master switch.
   function toggleAllMuted() {
+    if (directDeviceMutationBusy) return
     var mute = anyAudible
-    if (hasOutput) volumeSink.audio.muted = mute
-    if (hasInput) source.audio.muted = mute
+    if (hasOutput) setAudioNodeMuted(volumeSink, mute)
+    if (hasInput) setAudioNodeMuted(source, mute)
   }
 
   function setDefaultSink(node) {
-    if (!node || node.id === undefined || !node.name || defaultSinkProc.running) return
-    var previousSinkName = sink && sink.name ? String(sink.name) : ""
-    previousDefaultSink = sink
-    Pipewire.preferredDefaultAudioSink = node
+    var objectId = Model.nodeObjectId(node)
+    var name = Model.nodeName(node)
+    if (!mutableAudioNode(node) || objectId === "" || name === ""
+        || sceneController.busy || routeMutationBusy) return
+    var previousSinkName = Model.nodeName(sink)
+    var previousSinkObjectId = Model.nodeObjectId(sink)
     defaultOutputError = ""
-    defaultSinkProc.command = [
-      runtime.script("audio-output-set-default"),
-      String(node.id),
-      String(node.name),
-      previousSinkName
-    ]
+    defaultSinkProc.command = runtime.scriptCommand("audio-output-set-default", [
+      objectId,
+      name,
+      previousSinkName,
+      previousSinkObjectId
+    ])
     defaultSinkProc.running = true
   }
 
   function setDefaultSource(node) {
-    if (!node || node.id === undefined || !node.name || defaultSourceProc.running) return
-    var previousSourceName = source && source.name ? String(source.name) : ""
-    previousDefaultSource = source
-    Pipewire.preferredDefaultAudioSource = node
+    var objectId = Model.nodeObjectId(node)
+    var name = Model.nodeName(node)
+    if (!mutableAudioNode(node) || objectId === "" || name === ""
+        || sceneController.busy || routeMutationBusy) return
+    var previousSourceName = Model.nodeName(source)
+    var previousSourceObjectId = Model.nodeObjectId(source)
     defaultInputError = ""
-    defaultSourceProc.command = [
-      runtime.script("audio-input-set-default"),
-      String(node.id),
-      String(node.name),
-      previousSourceName
-    ]
+    defaultSourceProc.command = runtime.scriptCommand("audio-input-set-default", [
+      objectId,
+      name,
+      previousSourceName,
+      previousSourceObjectId
+    ])
     defaultSourceProc.running = true
   }
 
   function sinkAvailable(node) {
-    if (!node || !node.name || !sinkAvailabilityLoaded) return true
-    var name = String(node.name)
-    return sinkAvailability[name] !== false
+    var name = Model.nodeName(node)
+    if (name === "" || !sinkAvailabilityLoaded) return true
+    return Model.mapValue(sinkAvailability, name, true) !== false
   }
 
   function updateSinkAvailability(raw) {
@@ -883,8 +1096,9 @@ Panel {
   }
 
   function nodeLabel(node) {
-    if (node && node.name) {
-      var alias = deviceAlias(node.name)
+    var name = Model.nodeName(node)
+    if (name !== "") {
+      var alias = deviceAlias(name)
       if (alias !== "") return alias
     }
     return Model.nodeLabel(node)
@@ -960,11 +1174,10 @@ Panel {
   function streamIconSource(node) {
     var name = Model.streamIconName(node, mprisPlayers, displayAudioStreams)
     if (!name) return ""
-    if (name.indexOf("file://") === 0 || name.indexOf("image://") === 0) return name
-    if (name.charAt(0) === "/") return Util.fileUrl(name)
     var themed = Quickshell.iconPath(name, true)
     if (themed) return themed
-    if (appLibrary && appLibrary.iconIndex && appLibrary.iconIndex[name]
+    if (appLibrary && appLibrary.iconIndex
+        && Model.mapValue(appLibrary.iconIndex, name, null)
         && typeof appLibrary.iconSource === "function") return appLibrary.iconSource(name)
     return ""
   }
@@ -987,8 +1200,22 @@ Panel {
     path: runtime.settingsPath
     watchChanges: true
     printErrors: false
-    onLoaded: root.loadAudioControlSettings(text())
-    onLoadFailed: root.loadAudioControlSettings("")
+    onLoaded: function() {
+      var raw = text()
+      if (!Model.isAudioControlSettingsDocument(raw)) {
+        if (!root.audioControlSettingsLoaded) {
+          root.loadAudioControlSettings("")
+          root.audioControlSettingsLoaded = true
+        }
+        return
+      }
+      root.loadAudioControlSettings(raw)
+      root.audioControlSettingsLoaded = true
+    }
+    onLoadFailed: if (!root.audioControlSettingsLoaded) {
+      root.loadAudioControlSettings("")
+      root.audioControlSettingsLoaded = true
+    }
     onFileChanged: reload()
   }
 
@@ -996,8 +1223,22 @@ Panel {
     path: runtime.preferencesPath
     watchChanges: true
     printErrors: false
-    onLoaded: root.loadAudioPreferences(text())
-    onLoadFailed: root.loadAudioPreferences("")
+    onLoaded: function() {
+      var raw = text()
+      if (!Model.isAudioPreferencesDocument(raw)) {
+        if (!root.audioPreferencesLoaded) {
+          root.loadAudioPreferences("")
+          root.audioPreferencesLoaded = true
+        }
+        return
+      }
+      root.loadAudioPreferences(raw)
+      root.audioPreferencesLoaded = true
+    }
+    onLoadFailed: if (!root.audioPreferencesLoaded) {
+      root.loadAudioPreferences("")
+      root.audioPreferencesLoaded = true
+    }
     onFileChanged: reload()
   }
 
@@ -1006,10 +1247,18 @@ Panel {
     watchChanges: true
     printErrors: false
     onLoaded: function() {
-      root.audioScenes = Model.parseAudioScenes(text()).scenes
+      var raw = text()
+      if (!Model.isAudioScenesDocument(raw)) {
+        if (!root.audioScenesLoaded) root.audioScenes = []
+        root.audioScenesLoaded = true
+        return
+      }
+      root.audioScenes = Model.parseAudioScenes(raw).scenes
+      root.audioScenesLoaded = true
     }
     onLoadFailed: function() {
-      root.audioScenes = []
+      if (!root.audioScenesLoaded) root.audioScenes = []
+      root.audioScenesLoaded = true
     }
     onFileChanged: reload()
   }
@@ -1017,6 +1266,7 @@ Panel {
   AudioSceneController {
     id: sceneController
     scriptsDir: runtime.scriptsDir
+    outputVolumeMaximum: root.outputVolumeMaximum
     onApplyFinished: function(result) {
       var text = "Applied scene '" + result.name + "'"
       if (result.errors.length > 0)
@@ -1042,16 +1292,21 @@ Panel {
 
   function applySceneAt(index) {
     var scene = index >= 0 ? audioScenes[index] : null
-    if (!scene || sceneController.busy) return
+    if (!scene || sceneMutationBusy) return
     sceneController.apply(scene)
   }
 
   Process {
     id: sinkAvailabilityProc
-    command: ["omarchy-audio-sink-availability"]
+    command: runtime.scriptCommand("audio-sink-availability")
     stdout: StdioCollector {
       waitForEnd: true
-      onStreamFinished: root.updateSinkAvailability(text)
+      onStreamFinished: sinkAvailabilityProc.response = String(text || "")
+    }
+    property string response: ""
+    onExited: function(exitCode) {
+      if (exitCode === 0) root.updateSinkAvailability(response)
+      response = ""
     }
   }
 
@@ -1060,16 +1315,34 @@ Panel {
   Process {
     id: notificationProbeProc
     running: true
-    command: ["sh", "-c", "command -v notify-send >/dev/null 2>&1"]
+    command: ["/bin/sh", "-c", "command -v notify-send >/dev/null 2>&1"]
     onExited: function(exitCode) { root.notificationsAvailable = exitCode === 0 }
   }
 
   Process {
     id: volumeSinkProc
-    command: ["omarchy-audio-output-sink"]
+    property string response: ""
+    property string requestedDefaultName: ""
+    property string requestedDefaultObjectId: ""
+    command: runtime.scriptCommand("audio-resolve-output-sink")
     stdout: StdioCollector {
       waitForEnd: true
-      onStreamFinished: root.volumeSinkName = String(text).trim()
+      onStreamFinished: volumeSinkProc.response = String(text || "").trim()
+    }
+    onExited: function(exitCode) {
+      var resolved = Model.sanitizeIdentifier(response, 160)
+      var currentDefaultName = Model.nodeName(root.sink)
+      var currentDefaultObjectId = Model.nodeObjectId(root.sink)
+      var requestStillCurrent = requestedDefaultName === currentDefaultName
+        && requestedDefaultObjectId === currentDefaultObjectId
+      var retry = root.volumeSinkResolvePending || !requestStillCurrent
+      if (requestStillCurrent)
+        root.volumeSinkName = exitCode === 0 && resolved !== "" ? resolved : ""
+      response = ""
+      requestedDefaultName = ""
+      requestedDefaultObjectId = ""
+      root.volumeSinkResolvePending = false
+      if (retry) Qt.callLater(root.resolveVolumeSink)
     }
   }
 
@@ -1078,10 +1351,8 @@ Panel {
     onExited: function(exitCode) {
       root.defaultOutputError = exitCode === 0 ? ""
         : (exitCode === 2 ? "Default output changed, but its preference could not be saved"
-          : "Could not change the default audio output")
-      if (exitCode !== 0 && exitCode !== 2 && root.previousDefaultSink)
-        Pipewire.preferredDefaultAudioSink = root.previousDefaultSink
-      root.previousDefaultSink = null
+          : (exitCode === 4 ? "Default output change could not be fully restored"
+            : "Could not change the default audio output"))
     }
   }
 
@@ -1090,21 +1361,22 @@ Panel {
     onExited: function(exitCode) {
       root.defaultInputError = exitCode === 0 ? ""
         : (exitCode === 2 ? "Default input changed, but its preference could not be saved"
-          : "Could not change the default audio input")
-      if (exitCode !== 0 && exitCode !== 2 && root.previousDefaultSource)
-        Pipewire.preferredDefaultAudioSource = root.previousDefaultSource
-      root.previousDefaultSource = null
+          : (exitCode === 4 ? "Default input change could not be fully restored"
+            : "Could not change the default audio input"))
     }
   }
 
   Process {
     id: streamRoutesProc
-    command: [runtime.script("audio-stream-routes")]
+    property string response: ""
+    command: runtime.scriptCommand("audio-stream-routes")
     stdout: StdioCollector {
       waitForEnd: true
-      onStreamFinished: root.updateStreamRoutes(text)
+      onStreamFinished: streamRoutesProc.response = String(text || "")
     }
     onExited: function(exitCode) {
+      if (exitCode === 0) root.updateStreamRoutes(response)
+      response = ""
       if (exitCode !== 0 && root.opened
           && (root.displayAudioStreams.length > 0 || root.displayRecordingStreams.length > 0))
         root.streamRouteReadError = "Could not read application routes"
@@ -1114,7 +1386,9 @@ Panel {
   Process {
     id: streamRouteSetProc
     onExited: function(exitCode) {
-      if (exitCode !== 0) root.streamRouteSetError = "Could not change the application route"
+      if (exitCode === 4)
+        root.streamRouteSetError = "Application route changed and its previous state could not be fully restored"
+      else if (exitCode !== 0) root.streamRouteSetError = "Could not change the application route"
       else root.streamRouteSetError = ""
       root.pendingStreamRoute = null
 
@@ -1124,15 +1398,16 @@ Panel {
       root.lastManualRouteSync = null
       if (exitCode === 0 && sync) {
         var args = sync.target === ""
-          ? [runtime.script("audio-app-rules"), "del-app", sync.app, sync.direction]
-          : [runtime.script("audio-app-rules"), "set-app", sync.app, sync.direction, sync.target]
-        Quickshell.execDetached(args)
+          ? ["del-app", sync.app, sync.direction]
+          : ["set-app", sync.app, sync.direction, sync.target]
+        if (!rulesStore.write(args)) {
+          root.streamRouteSetError = "Application route changed, but its saved rule could not be updated"
+          root.resetRoutingEnforcement()
+        }
       }
 
       // A failed enforcement would otherwise stay cached as satisfied.
-      if (exitCode !== 0 && !root.pendingStreamRoute) {
-        for (var key in root.enforcedStreamRoutes) delete root.enforcedStreamRoutes[key]
-      }
+      if (exitCode !== 0) root.resetRoutingEnforcement()
       streamRouteRefreshTimer.restart()
       Qt.callLater(root.enforceRoutingRules)
     }
@@ -1278,7 +1553,7 @@ Panel {
               ? root.displayRecordingStreams : root.displayAudioStreams
             if (root.selectedIndex >= streams.length) return
             var s = streams[root.selectedIndex]
-            if (s && s.audio) s.audio.muted = !s.audio.muted
+            if (!sceneController.busy) root.toggleAudioNodeMute(s)
           } else if (root.focusSection === "input") {
             root.toggleInputMute()
           } else if (root.focusSection !== "scenes") {
@@ -1351,6 +1626,7 @@ Panel {
                 horizontalPadding: Style.space(5)
                 verticalPadding: Style.space(2)
                 hasCursor: root.settingsHeaderHasCursor
+                enabled: !root.sceneMutationBusy
                 anchors.verticalCenter: parent.verticalCenter
                 onHovered: function(on) { if (on) root.setHeaderCursor(0) }
                 onClicked: root.openAdvancedAudio()
@@ -1460,7 +1736,7 @@ Panel {
 
                   MouseArea {
                     anchors.fill: parent
-                    enabled: !sceneController.busy
+                    enabled: !root.sceneMutationBusy
                     hoverEnabled: true
                     cursorShape: enabled ? Qt.PointingHandCursor : Qt.ArrowCursor
                     onContainsMouseChanged: if (containsMouse) {
@@ -1542,7 +1818,7 @@ Panel {
                 step: 0.05
                 value: root.outputVolume
                 opacity: root.outputMuted ? 0.5 : 1.0
-                enabled: !!root.sink
+                enabled: root.hasOutput && !root.directDeviceMutationBusy
 
                 onMoved: function(v) { root.setOutputVolume(v) }
                 onRightClicked: root.toggleOutputMute()
@@ -1570,7 +1846,7 @@ Panel {
                 bar: root.bar
                 preferredName: root.preferredOutputName
                 label: root.nodeLabel(sinkDelegate.node)
-                defaultSetBusy: defaultSinkProc.running
+                defaultSetBusy: root.sceneMutationBusy
                 hasCursor: root.cursorActive && root.focusSection === "output"
                   && root.selectedIndex === sinkDelegate.rowIndex
                 onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(sinkDelegate)
@@ -1653,7 +1929,7 @@ Panel {
                   step: 0.05
                   value: root.inputVolume
                   opacity: root.inputMuted ? 0.5 : 1.0
-                  enabled: !!root.source
+                  enabled: root.hasInput && !root.directDeviceMutationBusy
 
                   onMoved: function(v) { root.setInputVolume(v) }
                   onRightClicked: root.toggleInputMute()
@@ -1706,7 +1982,7 @@ Panel {
                 bar: root.bar
                 preferredName: root.preferredInputName
                 label: root.nodeLabel(sourceDelegate.node)
-                defaultSetBusy: defaultSourceProc.running
+                defaultSetBusy: root.sceneMutationBusy
                 hasCursor: root.cursorActive && root.focusSection === "input"
                   && root.selectedIndex === sourceDelegate.rowIndex
                 onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(sourceDelegate)
@@ -1750,6 +2026,7 @@ Panel {
                 required property int index
                 width: panelColumn.width
                 node: modelData
+                nodeLive: root.mutableAudioNode(streamDelegate.node)
                 rowIndex: index
                 recording: false
                 bar: root.bar
@@ -1758,8 +2035,6 @@ Panel {
                 currentRoute: streamDelegate.recording
                   ? root.recordingStreamRoute(streamDelegate.node)
                   : root.streamRoute(streamDelegate.node)
-                targetCount: streamDelegate.recording
-                  ? root.displayAudioSources.length : root.displayAudioSinks.length
                 routeOptions: streamDelegate.recording
                   ? root.recordingInputOptions : root.streamOutputOptions
                 streamLabel: streamDelegate.recording
@@ -1768,6 +2043,9 @@ Panel {
                 iconSource: root.streamIconSource(streamDelegate.node)
                 routeAvailable: root.streamSerial(streamDelegate.node) !== ""
                 routeSetBusy: streamRouteSetProc.running
+                  || defaultSinkProc.running || defaultSourceProc.running
+                  || root.pendingStreamRoute !== null || rulesStore.busy
+                mutationBlocked: sceneController.busy
                 hasCursor: root.cursorActive
                   && root.focusSection === (streamDelegate.recording ? "recording" : "streams")
                   && root.selectedIndex === streamDelegate.rowIndex
@@ -1779,12 +2057,16 @@ Panel {
                   root.focusSection = section
                   root.selectedIndex = index
                 }
+                onVolumeRequested: function(value) {
+                  root.setAudioNodeVolume(streamDelegate.node, value, 1.5)
+                }
+                onMuteRequested: root.toggleAudioNodeMute(streamDelegate.node)
                 onRouteChosen: function(route) {
                   root.setStreamRoute(streamDelegate.node, route,
                     streamDelegate.recording ? "recording" : "playback")
                 }
                 onPopupToggled: function(open) {
-                  root.streamOutputMenuOpen = open
+                  root.updateStreamOutputMenu(open)
                   if (!open) Qt.callLater(function() { keyCatcher.forceActiveFocus() })
                 }
               }
@@ -1817,6 +2099,7 @@ Panel {
                 required property int index
                 width: panelColumn.width
                 node: modelData
+                nodeLive: root.mutableAudioNode(recordingStreamDelegate.node)
                 rowIndex: index
                 recording: true
                 bar: root.bar
@@ -1825,8 +2108,6 @@ Panel {
                 currentRoute: recordingStreamDelegate.recording
                   ? root.recordingStreamRoute(recordingStreamDelegate.node)
                   : root.streamRoute(recordingStreamDelegate.node)
-                targetCount: recordingStreamDelegate.recording
-                  ? root.displayAudioSources.length : root.displayAudioSinks.length
                 routeOptions: recordingStreamDelegate.recording
                   ? root.recordingInputOptions : root.streamOutputOptions
                 streamLabel: recordingStreamDelegate.recording
@@ -1835,6 +2116,9 @@ Panel {
                 iconSource: root.streamIconSource(recordingStreamDelegate.node)
                 routeAvailable: root.streamSerial(recordingStreamDelegate.node) !== ""
                 routeSetBusy: streamRouteSetProc.running
+                  || defaultSinkProc.running || defaultSourceProc.running
+                  || root.pendingStreamRoute !== null || rulesStore.busy
+                mutationBlocked: sceneController.busy
                 hasCursor: root.cursorActive
                   && root.focusSection === (recordingStreamDelegate.recording ? "recording" : "streams")
                   && root.selectedIndex === recordingStreamDelegate.rowIndex
@@ -1846,12 +2130,16 @@ Panel {
                   root.focusSection = section
                   root.selectedIndex = index
                 }
+                onVolumeRequested: function(value) {
+                  root.setAudioNodeVolume(recordingStreamDelegate.node, value, 1.5)
+                }
+                onMuteRequested: root.toggleAudioNodeMute(recordingStreamDelegate.node)
                 onRouteChosen: function(route) {
                   root.setStreamRoute(recordingStreamDelegate.node, route,
                     recordingStreamDelegate.recording ? "recording" : "playback")
                 }
                 onPopupToggled: function(open) {
-                  root.streamOutputMenuOpen = open
+                  root.updateStreamOutputMenu(open)
                   if (!open) Qt.callLater(function() { keyCatcher.forceActiveFocus() })
                 }
               }

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "ssupt.audio-control",
   "name": "Advanced Audio Control",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "author": "ssupt",
   "description": "Advanced PipeWire and WirePlumber audio mixer for Omarchy: devices, Bluetooth codecs, safety policies, microphone privacy, audio scenes, persistent routing rules, graph and service diagnostics, channel tests, support reports, and guarded recovery",
   "kinds": [

--- a/scripts/.audio-common
+++ b/scripts/.audio-common
@@ -1,0 +1,167 @@
+#!/bin/bash
+
+# Shared runtime setup for helpers that talk to PipeWire. The XDG runtime
+# directory is normally private; the /tmp fallback must create its own
+# user-owned directory so another local user cannot pre-place a FIFO or symlink
+# at a predictable lock/capture path and stall a shell process on open.
+audio_prepare_private_runtime() {
+  local runtime_base mode permissions
+  if [[ -n ${AUDIO_CONTROL_PRIVATE_RUNTIME_DIR:-} ]]; then
+    runtime_base=$AUDIO_CONTROL_PRIVATE_RUNTIME_DIR
+  elif [[ -n ${XDG_RUNTIME_DIR:-} ]]; then
+    runtime_base=$XDG_RUNTIME_DIR
+  else
+    runtime_base=/tmp/omarchy-audio-control-${UID}
+    if [[ ! -e $runtime_base && ! -L $runtime_base ]]; then
+      mkdir -m 700 -- "$runtime_base" 2>/dev/null || true
+    fi
+    if [[ -L $runtime_base || ! -d $runtime_base || ! -O $runtime_base ]]; then
+      echo "Could not create a private audio runtime directory" >&2
+      return 1
+    fi
+    chmod 700 -- "$runtime_base" || return 1
+  fi
+
+  if [[ -L $runtime_base || ! -d $runtime_base || ! -O $runtime_base ]]; then
+    echo "The audio runtime directory is not private to this user" >&2
+    return 1
+  fi
+  mode=$(stat -Lc '%a' -- "$runtime_base" 2>/dev/null) || return 1
+  permissions=${mode: -3}
+  if [[ ! $permissions =~ ^[0-7]{3}$ ]] || (( (8#$permissions & 0022) != 0 )); then
+    echo "The audio runtime directory is writable by another user" >&2
+    return 1
+  fi
+
+  AUDIO_CONTROL_PRIVATE_RUNTIME_DIR=$runtime_base
+}
+
+# Open a persistent lock without following a pre-placed symlink or blocking on
+# a FIFO. Noclobber makes first creation atomic; the descriptor/path identity
+# checks protect the subsequent append open in normal private or sticky dirs.
+audio_open_lock_path() {
+  local lock_path=${1:-}
+  local descriptor=${2:-}
+  local busy_message=${3:-Another audio change is still finishing; try again}
+  local wait_seconds=${4:-5}
+  local lock_dir directory_mode directory_permissions directory_sticky
+  local owner links path_identity descriptor_identity
+  [[ -n $lock_path && $descriptor =~ ^[89]$
+      && $wait_seconds =~ ^[0-9]+([.][0-9]+)?$ ]] || return 1
+  lock_dir=$(dirname -- "$lock_path") || return 1
+  [[ ! -L $lock_dir && -d $lock_dir ]] || {
+    echo "The audio lock directory is not safe" >&2
+    return 1
+  }
+  directory_mode=$(stat -Lc '%a' -- "$lock_dir" 2>/dev/null) || return 1
+  directory_permissions=${directory_mode: -3}
+  directory_sticky=0
+  (( (8#$directory_mode & 01000) != 0 )) && directory_sticky=1
+  if [[ ! $directory_permissions =~ ^[0-7]{3}$ ]] ||
+      { (( (8#$directory_permissions & 0022) != 0 )) && (( directory_sticky == 0 )); }; then
+    echo "The audio lock directory is writable by another user" >&2
+    return 1
+  fi
+
+  if [[ ! -e $lock_path && ! -L $lock_path ]]; then
+    (umask 077; set -o noclobber; : >"$lock_path") 2>/dev/null || true
+  fi
+  if [[ -L $lock_path || ! -f $lock_path ]]; then
+    echo "The audio lock is not a regular file" >&2
+    return 1
+  fi
+  read -r owner links < <(stat -Lc '%u %h' -- "$lock_path" 2>/dev/null) || return 1
+  if [[ $owner != "$UID" || $links != 1 ]]; then
+    echo "The audio lock is not private to this user" >&2
+    return 1
+  fi
+
+  if [[ $descriptor == 9 ]]; then
+    exec 9>>"$lock_path" || return 1
+  else
+    exec 8>>"$lock_path" || return 1
+  fi
+  path_identity=$(stat -Lc '%d:%i:%u:%h' -- "$lock_path" 2>/dev/null) || return 1
+  descriptor_identity=$(stat -Lc '%d:%i:%u:%h' \
+    -- "/proc/$$/fd/$descriptor" 2>/dev/null) || return 1
+  if [[ $path_identity != "$descriptor_identity" ||
+      $descriptor_identity != *":$UID:1" || ! -f /proc/$$/fd/$descriptor ]]; then
+    echo "The audio lock changed while it was being opened" >&2
+    return 1
+  fi
+  chmod 600 -- "/proc/$$/fd/$descriptor" || return 1
+  flock -w "$wait_seconds" "$descriptor" || {
+    echo "$busy_message" >&2
+    return 1
+  }
+}
+
+audio_open_lock() {
+  local lock_name=${1:-}
+  local descriptor=${2:-}
+  local busy_message=${3:-Another audio change is still finishing; try again}
+  local lock_path
+  [[ $lock_name =~ ^[a-z0-9-]+$ && $descriptor =~ ^[89]$ ]] || return 1
+  audio_prepare_private_runtime || return 1
+
+  lock_path=$AUDIO_CONTROL_PRIVATE_RUNTIME_DIR/$lock_name.lock
+  audio_open_lock_path "$lock_path" "$descriptor" "$busy_message"
+}
+
+audio_acquire_mutation_lock() {
+  audio_open_lock omarchy-audio-mutation 9 \
+    "${1:-Another audio change is still finishing; try again}"
+}
+
+audio_acquire_settings_lock() {
+  audio_open_lock omarchy-audio-settings 8 \
+    "${1:-Another audio setting change is still finishing; try again}"
+}
+
+# Capture command output without allowing a malfunctioning audio service to
+# grow an unbounded shell variable. The producer and limiter are both checked;
+# output one byte over the ceiling is rejected rather than silently truncated.
+audio_capture_bounded() {
+  local __audio_destination=${1:-}
+  local __audio_maximum=${2:-}
+  shift 2 || return 1
+  [[ $__audio_destination =~ ^[A-Za-z_][A-Za-z0-9_]*$ \
+      && $__audio_maximum =~ ^[1-9][0-9]*$ \
+      && -n ${AUDIO_CONTROL_PRIVATE_RUNTIME_DIR:-} ]] || return 1
+
+  local __audio_capture __audio_size __audio_value
+  local -a __audio_pipeline_status
+  __audio_capture=$(mktemp \
+    "$AUDIO_CONTROL_PRIVATE_RUNTIME_DIR/.audio-capture.XXXXXX") || return 1
+  # Inspect both commands explicitly instead of relying on the caller to have
+  # enabled pipefail before sourcing this file.
+  { "$@" 2>/dev/null | head -c "$((__audio_maximum + 1))" >"$__audio_capture"
+    __audio_pipeline_status=("${PIPESTATUS[@]}")
+  } || true
+  if (( ${#__audio_pipeline_status[@]} != 2
+      || __audio_pipeline_status[0] != 0
+      || __audio_pipeline_status[1] != 0 )); then
+    rm -f -- "$__audio_capture"
+    return 1
+  fi
+  __audio_size=$(stat -c '%s' -- "$__audio_capture" 2>/dev/null) || {
+    rm -f -- "$__audio_capture"
+    return 1
+  }
+  if (( __audio_size > __audio_maximum )); then
+    rm -f -- "$__audio_capture"
+    return 1
+  fi
+  # Bash variables cannot represent NUL bytes and command substitution would
+  # silently delete them. Reject binary output before importing it; otherwise
+  # two distinct PipeWire identifiers separated by NUL could collapse into a
+  # third string that passes later identity checks.
+  if ! LC_ALL=C tr -d '\000' <"$__audio_capture" |
+      cmp -s -- "$__audio_capture" -; then
+    rm -f -- "$__audio_capture"
+    return 1
+  fi
+  __audio_value=$(<"$__audio_capture")
+  rm -f -- "$__audio_capture"
+  printf -v "$__audio_destination" '%s' "$__audio_value"
+}

--- a/scripts/audio-app-rules
+++ b/scripts/audio-app-rules
@@ -6,8 +6,11 @@
 
 set -euo pipefail
 
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+source "$script_dir/.audio-common"
 rules_file=${OMARCHY_AUDIO_RULES_FILE:-${XDG_CONFIG_HOME:-${HOME:?}/.config}/omarchy/audio-rules.json}
 action=${1:-}
+maximum_store_bytes=1048576
 
 usage() {
   echo "Usage: audio-app-rules set-app <app> <playback|recording> <target>" >&2
@@ -18,17 +21,76 @@ usage() {
 }
 
 read_rules() {
-  if [[ ! -s $rules_file ]]; then
+  if [[ -L $rules_file || (-e $rules_file && ! -f $rules_file) ]]; then
+    echo "Audio rules are not stored in a regular file" >&2
+    return 1
+  elif [[ ! -s $rules_file ]]; then
     printf '%s\n' '{"version":1,"appRules":[],"devices":{"aliases":{},"favorites":[],"hidden":[]}}'
-  elif jq -e 'type == "object"' "$rules_file" >/dev/null 2>&1; then
-    jq -c '
-      .version = 1
-      | .appRules = (if (.appRules | type) == "array" then .appRules else [] end)
-      | .devices = (if (.devices | type) == "object" then .devices else {} end)
-      | .devices.aliases = (if (.devices.aliases | type) == "object" then .devices.aliases else {} end)
-      | .devices.favorites = (if (.devices.favorites | type) == "array" then .devices.favorites else [] end)
-      | .devices.hidden = (if (.devices.hidden | type) == "array" then .devices.hidden else [] end)
+  elif (( $(stat -c %s -- "$rules_file" 2>/dev/null || printf '%s' "$((maximum_store_bytes + 1))") > maximum_store_bytes )); then
+    echo "Audio rules are too large; refusing to overwrite them" >&2
+    return 1
+  elif jq -se 'length == 1 and (.[0] | type) == "object"
+      and ((.[0] | has("version") | not) or .[0].version == 1)' \
+      "$rules_file" >/dev/null 2>&1; then
+    jq -cs '
+      def clean($maximum):
+        tostring
+        | gsub("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]"; " ")
+        | gsub(" +"; " ")
+        | sub("^ +"; "") | sub(" +$"; "")
+        | .[0:$maximum];
+      def identifier($maximum):
+        select(type == "string")
+        | select(length > 0 and length <= $maximum)
+        | select(test("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]") | not);
+      def raw_devices:
+        if (.devices | type) == "object" then .devices else {} end;
+      def ordered_strings($value; $maximum):
+        reduce ([(if ($value | type) == "array" then $value else [] end)[:256][]?
+          | identifier(160)][]) as $entry
+          ({seen: {}, values: []};
+            if (.seen | has($entry)) or (.values | length) >= $maximum then .
+            else .seen[$entry] = true | .values += [$entry] end)
+        | .values;
+      def normalized_rules:
+        reduce ([((if (.appRules | type) == "array" then .appRules else [] end)[:256][]?
+          | select(type == "object")
+          | ((.app // "") | clean(120) | ascii_downcase) as $app
+          | ((.target // "") | identifier(160)) as $target
+          | select($app != "" and $target != ""
+              and (.direction == "playback" or .direction == "recording"))
+          | {app: $app, direction: .direction, target: $target})][]) as $rule
+          ({seen: {}, values: []};
+            ($rule.direction + ":" + $rule.app) as $key
+            | if (.seen | has($key)) or (.values | length) >= 64 then .
+              else .seen[$key] = true | .values += [$rule] end)
+        | .values;
+      def normalized_aliases:
+        reduce ([((raw_devices
+          | if (.aliases | type) == "object" then .aliases else {} end)
+          | to_entries[:256][]?
+          | (.key | identifier(160)) as $node
+          | (.value | clean(80)) as $label
+          | select($node != "" and $label != "")
+          | {key: $node, value: $label})][]) as $entry
+          ({}; if length >= 128 or has($entry.key) then . else .[$entry.key] = $entry.value end);
+      .[0]
+      | {
+        version: 1,
+        appRules: normalized_rules,
+        devices: {
+          aliases: normalized_aliases,
+          favorites: ordered_strings(
+            (raw_devices | if (.favorites | type) == "array" then .favorites else [] end); 64),
+          hidden: ordered_strings(
+            (raw_devices | if (.hidden | type) == "array" then .hidden else [] end); 64)
+        }
+      }
     ' "$rules_file"
+  elif jq -se 'length == 1 and (.[0] | type) == "object"' \
+      "$rules_file" >/dev/null 2>&1; then
+    echo "Audio rules use an unsupported schema version; refusing to overwrite them" >&2
+    return 1
   else
     echo "Audio rules contain invalid JSON; refusing to overwrite them" >&2
     return 1
@@ -42,8 +104,8 @@ write_rules() {
   local rules_dir temporary_file
   rules_dir=$(dirname -- "$rules_file")
   mkdir -p -- "$rules_dir"
-  exec 9>"${rules_file}.lock"
-  flock 9
+  audio_open_lock_path "${rules_file}.lock" 9 \
+    "Audio rules are busy; try again" || return 1
 
   temporary_file=$(mktemp "$rules_dir/.audio-rules.XXXXXX")
   trap 'rm -f -- "$temporary_file"' EXIT
@@ -60,7 +122,30 @@ write_rules() {
 normalize_app() {
   # Rules match against the labels applications publish, compared without
   # case so Firefox, firefox, and firefox-bin style differences still hit.
-  printf '%s' "${1,,}" | tr -d '[:cntrl:]'
+  local value
+  local LC_ALL=C
+  value=$(normalize_string "$1" 120) || return 1
+  printf '%s' "${value,,}"
+}
+
+normalize_string() {
+  local value=$1 maximum=$2
+  jq -nr --arg value "$value" --argjson maximum "$maximum" '
+    $value
+    | gsub("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]"; " ")
+    | gsub(" +"; " ")
+    | sub("^ +"; "") | sub(" +$"; "")
+    | .[0:$maximum]
+  '
+}
+
+validate_identifier() {
+  local value=$1 maximum=$2
+  jq -ner --arg value "$value" --argjson maximum "$maximum" '
+    $value
+    | select(length > 0 and length <= $maximum)
+    | select(test("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]") | not)
+  '
 }
 
 case "$action" in
@@ -68,13 +153,14 @@ case "$action" in
     (( $# == 4 )) || usage
     app=$(normalize_app "$2")
     direction=$3
-    target=$4
+    target=$(validate_identifier "$4" 160) || usage
     [[ -n $app && -n $target ]] || usage
     [[ $direction == playback || $direction == recording ]] || usage
     write_rules '
       .version = 1
       | .appRules = (
-          (.appRules | map(select(.direction != $direction or .app != $app)))
+          (.appRules | map(select(.direction != $direction
+            or .app != $app)))
           + [{app: $app, direction: $direction, target: $target}]
           | .[-64:]
         )
@@ -87,16 +173,21 @@ case "$action" in
     [[ -n $app ]] || usage
     [[ $direction == playback || $direction == recording ]] || usage
     write_rules '.version = 1
-      | .appRules |= map(select(.direction != $direction or .app != $app))' \
+      | .appRules |= map(select(.direction != $direction
+        or .app != $app))' \
       --arg app "$app" --arg direction "$direction"
     ;;
   set-alias)
     (( $# == 3 )) || usage
-    node=${2:-}
-    label=${3:-}
+    node=$(validate_identifier "${2:-}" 160) || usage
+    label=$(normalize_string "${3:-}" 80)
     [[ -n $node ]] || usage
     if [[ -n $label ]]; then
-      write_rules '.version = 1 | .devices.aliases[$node] = $label' \
+      write_rules '.version = 1
+        | .devices.aliases = (
+            (.devices.aliases | del(.[$node])) + {($node): $label}
+            | to_entries | .[-128:] | from_entries
+          )' \
         --arg node "$node" --arg label "$label"
     else
       write_rules '.version = 1 | .devices.aliases |= del(.[$node])' \
@@ -105,7 +196,7 @@ case "$action" in
     ;;
   set-flag)
     (( $# == 4 )) || usage
-    node=${2:-}
+    node=$(validate_identifier "${2:-}" 160) || usage
     flag=$3
     value=$4
     [[ -n $node ]] || usage
@@ -119,7 +210,7 @@ case "$action" in
           (if (.devices[$flag] | type) == "array" then .devices[$flag] else [] end)
           | (if $on then (map(select(. != $node)) + [$node])
              else map(select(. != $node)) end)
-          | unique
+          | .[-64:]
         )
     ' --arg node "$node" --arg flag "$flag_key" \
       --argjson on "$( [[ $value == true ]] && echo true || echo false )"

--- a/scripts/audio-bluetooth-autoswitch
+++ b/scripts/audio-bluetooth-autoswitch
@@ -7,19 +7,58 @@
 setting=bluetooth.autoswitch-to-headset-profile
 action=${1:-}
 
+set -u -o pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+source "$script_dir/.audio-common"
+
+read_setting() {
+  local output
+  audio_capture_bounded output 65536 timeout 3 wpctl settings "$setting" || return 1
+  awk '
+    $1 == "Value:" { count++; value=$2 }
+    END {
+      if (count != 1 || (value != "true" && value != "false")) exit 1
+      print value
+    }
+  ' <<<"$output"
+}
+
 if (( $# > 1 )); then
   echo "Usage: omarchy-audio-bluetooth-autoswitch [on|off]" >&2
   exit 1
 fi
 
+audio_prepare_private_runtime || exit 1
+audio_acquire_settings_lock || exit 1
+
+old_value=$(read_setting) || exit 1
+
 case "$action" in
-  "") ;;
-  on) wpctl settings --save "$setting" true >/dev/null || exit 1 ;;
-  off) wpctl settings --save "$setting" false >/dev/null || exit 1 ;;
+  "") printf '%s\n' "$old_value"; exit 0 ;;
+  on) requested_value=true ;;
+  off) requested_value=false ;;
   *)
     echo "Usage: omarchy-audio-bluetooth-autoswitch [on|off]" >&2
     exit 1
     ;;
 esac
 
-wpctl settings "$setting" 2>/dev/null | awk '$1 == "Value:" && ($2 == "true" || $2 == "false") { print $2; found=1 } END { exit !found }'
+[[ $requested_value == "$old_value" ]] && { printf '%s\n' "$old_value"; exit 0; }
+
+timeout 3 wpctl settings --save "$setting" "$requested_value" >/dev/null || true
+confirmed_value=$(read_setting) || confirmed_value=
+if [[ $confirmed_value != "$requested_value" ]]; then
+  [[ $confirmed_value == "$old_value" ]] && {
+    echo "Bluetooth autoswitch change was not applied" >&2
+    exit 1
+  }
+  rollback_complete=false
+  timeout 3 wpctl settings --save "$setting" "$old_value" >/dev/null 2>&1 || true
+  restored_value=$(read_setting) || restored_value=
+  [[ $restored_value == "$old_value" ]] && rollback_complete=true
+  echo "Bluetooth autoswitch change could not be verified" >&2
+  [[ $rollback_complete == true ]] || exit 4
+  exit 1
+fi
+printf '%s\n' "$confirmed_value"

--- a/scripts/audio-bluetooth-profile-preference
+++ b/scripts/audio-bluetooth-profile-preference
@@ -7,19 +7,52 @@
 setting=bluetooth.profile-preference
 preference=${1:-}
 
+set -u -o pipefail
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+source "$script_dir/.audio-common"
+
+read_setting() {
+  local output
+  audio_capture_bounded output 65536 timeout 3 wpctl settings "$setting" || return 1
+  awk '
+    $1 == "Value:" {
+      count++
+      gsub(/^"|"$/, "", $2)
+      value=$2
+    }
+    END {
+      if (count != 1 || (value != "quality" && value != "latency")) exit 1
+      print value
+    }
+  ' <<<"$output"
+}
+
 if (( $# > 1 )) || [[ -n $preference && $preference != "quality" && $preference != "latency" ]]; then
   echo "Usage: audio-bluetooth-profile-preference [quality|latency]" >&2
   exit 1
 fi
 
-if [[ -n $preference ]]; then
-  wpctl settings --save "$setting" "$preference" >/dev/null || exit 1
-fi
+audio_prepare_private_runtime || exit 1
+audio_acquire_settings_lock || exit 1
 
-wpctl settings "$setting" 2>/dev/null | awk '
-  $1 == "Value:" {
-    gsub(/^"|"$/, "", $2)
-    if ($2 == "quality" || $2 == "latency") { print $2; found=1 }
+old_preference=$(read_setting) || exit 1
+[[ -z $preference ]] && { printf '%s\n' "$old_preference"; exit 0; }
+[[ $preference == "$old_preference" ]] && { printf '%s\n' "$old_preference"; exit 0; }
+
+timeout 3 wpctl settings --save "$setting" "$preference" >/dev/null || true
+confirmed_preference=$(read_setting) || confirmed_preference=
+if [[ $confirmed_preference != "$preference" ]]; then
+  [[ $confirmed_preference == "$old_preference" ]] && {
+    echo "Bluetooth profile preference change was not applied" >&2
+    exit 1
   }
-  END { exit !found }
-'
+  rollback_complete=false
+  timeout 3 wpctl settings --save "$setting" "$old_preference" >/dev/null 2>&1 || true
+  restored_preference=$(read_setting) || restored_preference=
+  [[ $restored_preference == "$old_preference" ]] && rollback_complete=true
+  echo "Bluetooth profile preference change could not be verified" >&2
+  [[ $rollback_complete == true ]] || exit 4
+  exit 1
+fi
+printf '%s\n' "$confirmed_preference"

--- a/scripts/audio-diagnostics
+++ b/scripts/audio-diagnostics
@@ -15,6 +15,7 @@ recovery_command=${AUDIO_CONTROL_RECOVERY_COMMAND:-omarchy-restart-audio}
 recovery_launcher=${AUDIO_CONTROL_RECOVERY_LAUNCHER:-omarchy-launch-floating-terminal-with-presentation}
 speaker_command=${AUDIO_CONTROL_SPEAKER_TEST_COMMAND:-speaker-test}
 clipboard_command=${AUDIO_CONTROL_CLIPBOARD_COMMAND:-wl-copy}
+maximum_capture_bytes=16777216
 
 usage() {
   echo "Usage: audio-diagnostics [snapshot | report | copy-report]" >&2
@@ -47,13 +48,24 @@ capture() {
   local destination="$work_dir/$key"
   local fixture="${fixture_dir:+$fixture_dir/$key}"
 
-  if [[ -n $fixture && -f $fixture && ! -L $fixture ]]; then
-    cp -- "$fixture" "$destination"
-    return 0
+  if [[ -n $fixture && ( -e $fixture || -L $fixture ) ]]; then
+    if [[ -f $fixture && ! -L $fixture ]] &&
+        (( $(stat -c %s -- "$fixture" 2>/dev/null || printf '%s' "$((maximum_capture_bytes + 1))") <= maximum_capture_bytes )); then
+      cp -- "$fixture" "$destination"
+      return 0
+    fi
+    : >"$destination"
+    return 1
   fi
 
-  if timeout 4s "$@" >"$destination" 2>"$destination.error"; then
-    return 0
+  # Command errors are summarized as curated warnings below. Discard raw
+  # stderr so a malfunctioning service cannot fill the temporary directory
+  # while stdout is correctly bounded.
+  if timeout 4s "$@" 2>/dev/null |
+      head -c "$((maximum_capture_bytes + 1))" >"$destination"; then
+    if (( $(stat -c %s -- "$destination" 2>/dev/null || printf '%s' "$((maximum_capture_bytes + 1))") <= maximum_capture_bytes )); then
+      return 0
+    fi
   fi
 
   : >"$destination"
@@ -68,7 +80,8 @@ metadata_value() {
 
 numeric_or_zero() {
   local value=$1
-  [[ $value =~ ^[0-9]+$ ]] && printf '%s\n' "$value" || printf '%s\n' 0
+  [[ $value =~ ^[0-9]+$ && ${#value} -le 12 ]] &&
+    printf '%s\n' "$value" || printf '%s\n' 0
 }
 
 version_from() {
@@ -81,7 +94,8 @@ service_snapshot() {
   local output active sub_state load_state restarts
 
   if output=$(timeout 3s systemctl --user show "$unit" \
-      --property=LoadState,ActiveState,SubState,NRestarts --no-pager 2>/dev/null); then
+      --property=LoadState,ActiveState,SubState,NRestarts --no-pager 2>/dev/null |
+      head -c 65537) && (( ${#output} <= 65536 )); then
     load_state=$(sed -n 's/^LoadState=//p' <<<"$output")
     active=$(sed -n 's/^ActiveState=//p' <<<"$output")
     sub_state=$(sed -n 's/^SubState=//p' <<<"$output")
@@ -109,33 +123,61 @@ service_snapshot() {
 
 build_routes() {
   jq '
+    def valid_id:
+      (type == "number" and isfinite and floor == . and . >= 0 and . <= 99999999999999999999)
+      or (type == "string" and test("^[0-9]{1,20}$"));
+    def clean($fallback):
+      (tostring
+        | gsub("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]"; " ")
+        | gsub(" +"; " ") | sub("^ +"; "") | sub(" +$"; "") | .[:160])
+      | if length > 0 then . else $fallback end;
     def props: (.info.props // {});
-    [ .[]
+    [ .[:16384][]
       | select(.type == "PipeWire:Interface:Node")
+      | select(.id | valid_id)
       | {
-          id: .id,
+          id: (.id | tostring),
           class: (props["media.class"] // ""),
           internal: ((props["application.id"] // "") == "ssupt.audio-control"),
           # Media titles and raw node names can contain private content or
           # hardware identifiers. A route needs roles, not those identifiers.
-          label: ((props["application.name"] // props["node.description"]
-            // props["node.nick"]
-            // (if ((props["media.class"] // "") | startswith("Stream/"))
-              then "Audio application" else "Audio node" end)) | tostring)
+          label: (
+            if ((props["media.class"] // "") | startswith("Stream/")) then
+              (props["application.name"] // "Audio application")
+            else
+              (props["node.description"] // props["node.nick"] // "Audio node")
+            end
+            | clean("Audio node")
+          )
         }
-    ] as $nodes
-    | [ .[]
+    ][:4096] as $nodes
+    | [ .[:16384][]
         | select(.type == "PipeWire:Interface:Link"
           and (.info.state == "active" or .info.state == "paused"))
-        | { from: .info["output-node-id"], to: .info["input-node-id"] }
-      ] | unique_by([.from, .to]) as $links
+        | select((.info["output-node-id"] | valid_id)
+          and (.info["input-node-id"] | valid_id))
+        | {
+            from: (.info["output-node-id"] | tostring),
+            to: (.info["input-node-id"] | tostring)
+          }
+      ][:8192] | unique_by([.from, .to]) as $links
+    | reduce $nodes[] as $node ({};
+        if has($node.id) then . else .[$node.id] = $node.label end) as $labels
+    | def add_neighbour($key; $value):
+        (.[$key] // []) as $current
+        | if ($current | index($value)) != null or ($current | length) >= 16
+          then . else .[$key] = ($current + [$value]) end;
+      reduce $links[] as $link ({ forward: {}, reverse: {} };
+        .forward |= add_neighbour($link.from; $link.to)
+        | .reverse |= add_neighbour($link.to; $link.from)
+      ) as $adjacency
     | def node_label($id):
-        first($nodes[] | select(.id == $id) | .label) // "Unavailable audio node";
+        $labels[$id] // "Unavailable audio node";
       def neighbours($id; $reverse):
         if $reverse then
-          [ $links[] | select(.to == $id) | .from ]
+          ($adjacency.reverse[$id] // [])
         else
-          [ $links[] | select(.from == $id) | .to ]
+          ($adjacency.forward[$id] // [])
         end;
       def walk($id; $reverse; $seen):
         if ($seen | index($id)) != null or ($seen | length) >= 15 then [$id]
@@ -146,16 +188,20 @@ build_routes() {
               | [$id] + walk($candidate; $reverse; $seen + [$id])
             end
         end;
-      ([ $nodes[]
-         | select(.class == "Stream/Output/Audio" and (.internal | not))
-         | .id as $start
-         | { direction: "playback", ids: walk($start; false; []) }
+      ([ [ $nodes[]
+           | select(.class == "Stream/Output/Audio" and (.internal | not))
+           | .id
+         ][:64][] as $start
+         | limit(8; walk($start; false; [])) as $path
+         | { direction: "playback", ids: $path }
        ]
        +
-       [ $nodes[]
-         | select(.class == "Stream/Input/Audio" and (.internal | not))
-         | .id as $start
-         | { direction: "recording", ids: walk($start; true; []) }
+       [ [ $nodes[]
+           | select(.class == "Stream/Input/Audio" and (.internal | not))
+           | .id
+         ][:64][] as $start
+         | limit(8; walk($start; true; [])) as $path
+         | { direction: "recording", ids: $path }
        ])
     | map(. + { labels: [ .ids[] | node_label(.) ] } | del(.ids))
     | map(select((.labels | length) > 1))
@@ -182,8 +228,10 @@ build_snapshot() {
     warn "Recording devices could not be inspected."
   }
   if $sinks_ok && $sources_ok &&
-      jq -e 'type == "array"' "$work_dir/sinks.json" >/dev/null 2>&1 &&
-      jq -e 'type == "array"' "$work_dir/sources.json" >/dev/null 2>&1; then
+      jq -e 'type == "array" and length <= 512' \
+        "$work_dir/sinks.json" >/dev/null 2>&1 &&
+      jq -e 'type == "array" and length <= 512' \
+        "$work_dir/sources.json" >/dev/null 2>&1; then
     endpoints_ok=true
   else
     printf '[]\n' >"$work_dir/sinks.json"
@@ -194,7 +242,8 @@ build_snapshot() {
   fi
   capture pactl-info.txt pactl info || :
   if capture dump.json pw-dump; then
-    if jq -e 'type == "array"' "$work_dir/dump.json" >/dev/null 2>&1; then
+    if jq -e 'type == "array" and length <= 16384' \
+        "$work_dir/dump.json" >/dev/null 2>&1; then
       dump_ok=true
     else
       printf '[]\n' >"$work_dir/dump.json"
@@ -219,25 +268,26 @@ build_snapshot() {
   configured_quantum=$(numeric_or_zero "$(metadata_value clock.quantum)")
 
   jq -r '
-    .[]
-    | select(.type == "PipeWire:Interface:Node")
-    | select(((.info.props["media.class"] // "") | contains("Audio")))
-    | .id
+    [ .[:16384][]
+      | select(.type == "PipeWire:Interface:Node")
+      | select(((.info.props["media.class"] // "") | contains("Audio")))
+      | .id
+    ][:4096][]
   ' "$work_dir/dump.json" 2>/dev/null >"$work_dir/audio-node-ids.txt" ||
     : >"$work_dir/audio-node-ids.txt"
 
   awk '
     BEGIN { load = -1; errors = 0; active = 0; rate = 0; quantum = 0; audioCount = 0 }
     FILENAME == ARGV[1] {
-      if ($1 ~ /^[0-9]+$/) { audio[$1] = 1; audioCount++ }
+      if (length($1) <= 12 && $1 ~ /^[0-9]+$/) { audio[$1] = 1; audioCount++ }
       next
     }
     FNR > 1 && $2 ~ /^[0-9]+$/ {
       if (audioCount > 0 && !($2 in audio)) next
       if ($1 ~ /^[RrTt]$/) active++
-      if ($7 ~ /^[0-9]+([.][0-9]+)?$/ && ($7 + 0) > load) load = $7 + 0
-      if ($9 ~ /^[0-9]+$/) errors += $9
-      if (rate == 0 && $1 ~ /^[RrTt]$/ && $3 ~ /^[1-9][0-9]*$/ && $4 ~ /^[1-9][0-9]*$/) {
+      if (length($7) <= 20 && $7 ~ /^[0-9]+([.][0-9]+)?$/ && ($7 + 0) > load) load = $7 + 0
+      if (length($9) <= 12 && $9 ~ /^[0-9]+$/) errors += $9
+      if (rate == 0 && $1 ~ /^[RrTt]$/ && length($3) <= 12 && length($4) <= 12 && $3 ~ /^[1-9][0-9]*$/ && $4 ~ /^[1-9][0-9]*$/) {
         quantum = $3 + 0
         rate = $4 + 0
       }
@@ -247,7 +297,11 @@ build_snapshot() {
     }
   ' "$work_dir/audio-node-ids.txt" "$work_dir/pw-top.txt" >"$work_dir/top.json"
 
-  if [[ -n $fixture_dir && -f $fixture_dir/services.json && ! -L $fixture_dir/services.json ]]; then
+  if [[ -n $fixture_dir && -f $fixture_dir/services.json && ! -L $fixture_dir/services.json ]] &&
+      (( $(stat -c %s -- "$fixture_dir/services.json" 2>/dev/null ||
+          printf '%s' "$((maximum_capture_bytes + 1))") <= 1048576 )) &&
+      jq -e 'type == "array" and length <= 8' \
+        "$fixture_dir/services.json" >/dev/null 2>&1; then
     cp -- "$fixture_dir/services.json" "$work_dir/services.json"
   else
     {
@@ -256,8 +310,32 @@ build_snapshot() {
       service_snapshot pipewire-pulse.service "PipeWire Pulse"
     } | jq -s '.' >"$work_dir/services.json"
   fi
-  jq -e 'type == "array"' "$work_dir/services.json" >/dev/null 2>&1 ||
+  jq -e 'type == "array" and length <= 8' \
+    "$work_dir/services.json" >/dev/null 2>&1 ||
     printf '[]\n' >"$work_dir/services.json"
+  jq '
+    def clean($fallback; $maximum):
+      (tostring
+        | gsub("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]"; " ")
+        | gsub(" +"; " ") | sub("^ +"; "") | sub(" +$"; "") | .[:$maximum])
+      | if length > 0 then . else $fallback end;
+    [ .[:8][]
+      | select(type == "object")
+      | ((.name // "") | clean(""; 80)) as $name
+      | select($name != "")
+      | {
+          name: $name,
+          label: ((.label // $name) | clean($name; 80)),
+          loadState: ((.loadState // "unknown") | clean("unknown"; 32)),
+          activeState: ((.activeState // "unknown") | clean("unknown"; 32)),
+          subState: ((.subState // "unknown") | clean("unknown"; 32)),
+          active: (.active == true),
+          restarts: (if (.restarts | type) == "number" and .restarts >= 0
+              and .restarts <= 1000000 then (.restarts | floor) else 0 end)
+        }
+    ]
+  ' "$work_dir/services.json" >"$work_dir/services-normalized.json"
+  mv -f -- "$work_dir/services-normalized.json" "$work_dir/services.json"
 
   if ! jq -e 'length == 3 and all(.[]; .active == true)' "$work_dir/services.json" >/dev/null; then
     warn "One or more audio services are not running normally."
@@ -265,65 +343,110 @@ build_snapshot() {
 
   default_sink=$(sed -n 's/^Default Sink:[[:space:]]*//p' "$work_dir/pactl-info.txt" | head -n 1)
   default_source=$(sed -n 's/^Default Source:[[:space:]]*//p' "$work_dir/pactl-info.txt" | head -n 1)
+  jq -ne --arg value "$default_sink" '
+    ($value | length) > 0 and ($value | length) <= 160
+    and ($value | test("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]") | not)
+  ' >/dev/null 2>&1 || default_sink=""
+  jq -ne --arg value "$default_source" '
+    ($value | length) > 0 and ($value | length) <= 160
+    and ($value | test("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]") | not)
+  ' >/dev/null 2>&1 || default_source=""
   if [[ -n $default_source ]] && jq -e --arg source "$default_source" '
-      any(.[]; .name == $source and ((.monitor_source // "") != ""
-        or (.properties["device.class"] // "") == "monitor"))
+      any(.[:512][]?;
+        type == "object" and .name == $source
+        and ((.monitor_source // "") != ""
+          or ((.properties | if type == "object" then . else {} end)
+            | (."device.class" // "")) == "monitor"))
     ' "$work_dir/sources.json" >/dev/null; then
     default_source=""
   fi
 
   jq --arg defaultSink "$default_sink" '
+    def clean($fallback; $maximum):
+      (tostring
+        | gsub("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]"; " ")
+        | gsub(" +"; " ") | sub("^ +"; "") | sub(" +$"; "") | .[:$maximum])
+      | if length > 0 then . else $fallback end;
+    def identifier:
+      if type == "string" and length > 0 and length <= 160
+          and (test("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]") | not)
+        then . else "" end;
     def channel_count:
       try ((.sample_specification // "")
         | capture("(?<count>[0-9]+)ch").count | tonumber) catch 0;
-    [ .[] | {
+    [ .[:512][]
+      | select(type == "object")
+      | . as $endpoint
+      | (($endpoint.name // "") | identifier) as $name
+      | select($name != "")
+      | ($endpoint.properties
+          | if type == "object" then . else {} end) as $properties
+      | {
         direction: "output",
-        name: ((.name // "") | tostring),
-        label: ((.description // .name // "Unknown output") | tostring),
-        state: ((.state // "unknown") | ascii_downcase),
-        format: ((.sample_specification // "") | tostring),
-        channelMap: ((.channel_map // "") | tostring),
-        channels: channel_count,
-        port: (if (.active_port | type) == "object"
-          then ((.active_port.description // .active_port.name // "") | tostring)
-          else ((.active_port // "") | tostring) end),
-        profile: ((.properties["device.profile.description"]
-          // .properties["device.profile.name"] // "") | tostring),
-        codec: ((.properties["bluetooth.codec"] // .properties["api.bluez5.codec"]
-          // .properties["bluez5.codec"] // "") | tostring),
-        bluetooth: ((.properties["device.bus"] // "") == "bluetooth"
-          or ((.name // "") | startswith("bluez_"))),
-        default: ((.name // "") == $defaultSink)
-      } ]
+        name: $name,
+        label: (($endpoint.description // $name) | clean($name; 160)),
+        state: (($endpoint.state // "unknown") | clean("unknown"; 32) | ascii_downcase),
+        format: (($endpoint.sample_specification // "") | clean(""; 96)),
+        channelMap: (($endpoint.channel_map // "") | clean(""; 240)),
+        channels: ($endpoint | channel_count),
+        port: (if ($endpoint.active_port | type) == "object"
+          then (($endpoint.active_port.description // $endpoint.active_port.name // "")
+            | clean(""; 160))
+          else (($endpoint.active_port // "") | clean(""; 160)) end),
+        profile: (($properties["device.profile.description"]
+          // $properties["device.profile.name"] // "") | clean(""; 160)),
+        codec: (($properties["bluetooth.codec"] // $properties["api.bluez5.codec"]
+          // $properties["bluez5.codec"] // "") | clean(""; 64)),
+        bluetooth: (($properties["device.bus"] // "") == "bluetooth"
+          or ($name | startswith("bluez_"))),
+        default: ($name == $defaultSink)
+      }
+    ][:64]
   ' "$work_dir/sinks.json" >"$work_dir/output-devices.json"
 
   jq --arg defaultSource "$default_source" '
+    def clean($fallback; $maximum):
+      (tostring
+        | gsub("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]"; " ")
+        | gsub(" +"; " ") | sub("^ +"; "") | sub(" +$"; "") | .[:$maximum])
+      | if length > 0 then . else $fallback end;
+    def identifier:
+      if type == "string" and length > 0 and length <= 160
+          and (test("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]") | not)
+        then . else "" end;
     def channel_count:
       try ((.sample_specification // "")
         | capture("(?<count>[0-9]+)ch").count | tonumber) catch 0;
-    [ .[]
-      | select((.monitor_source // "") == ""
-        and (.properties["device.class"] // "") != "monitor")
+    [ .[:512][]
+      | select(type == "object")
+      | . as $endpoint
+      | (($endpoint.name // "") | identifier) as $name
+      | select($name != "")
+      | ($endpoint.properties
+          | if type == "object" then . else {} end) as $properties
+      | select(($endpoint.monitor_source // "") == ""
+        and ($properties["device.class"] // "") != "monitor")
       | {
           direction: "input",
-          name: ((.name // "") | tostring),
-          label: ((.description // .name // "Unknown input") | tostring),
-          state: ((.state // "unknown") | ascii_downcase),
-          format: ((.sample_specification // "") | tostring),
-          channelMap: ((.channel_map // "") | tostring),
-          channels: channel_count,
-          port: (if (.active_port | type) == "object"
-            then ((.active_port.description // .active_port.name // "") | tostring)
-            else ((.active_port // "") | tostring) end),
-          profile: ((.properties["device.profile.description"]
-            // .properties["device.profile.name"] // "") | tostring),
-          codec: ((.properties["bluetooth.codec"] // .properties["api.bluez5.codec"]
-            // .properties["bluez5.codec"] // "") | tostring),
-          bluetooth: ((.properties["device.bus"] // "") == "bluetooth"
-            or ((.name // "") | startswith("bluez_"))),
-          default: ((.name // "") == $defaultSource)
+          name: $name,
+          label: (($endpoint.description // $name) | clean($name; 160)),
+          state: (($endpoint.state // "unknown") | clean("unknown"; 32) | ascii_downcase),
+          format: (($endpoint.sample_specification // "") | clean(""; 96)),
+          channelMap: (($endpoint.channel_map // "") | clean(""; 240)),
+          channels: ($endpoint | channel_count),
+          port: (if ($endpoint.active_port | type) == "object"
+            then (($endpoint.active_port.description // $endpoint.active_port.name // "")
+              | clean(""; 160))
+            else (($endpoint.active_port // "") | clean(""; 160)) end),
+          profile: (($properties["device.profile.description"]
+            // $properties["device.profile.name"] // "") | clean(""; 160)),
+          codec: (($properties["bluetooth.codec"] // $properties["api.bluez5.codec"]
+            // $properties["bluez5.codec"] // "") | clean(""; 64)),
+          bluetooth: (($properties["device.bus"] // "") == "bluetooth"
+            or ($name | startswith("bluez_"))),
+          default: ($name == $defaultSource)
         }
-    ]
+    ][:64]
   ' "$work_dir/sources.json" >"$work_dir/input-devices.json"
 
   jq -s 'add | sort_by(.direction, (.default | not), (.label | ascii_downcase))' \
@@ -372,7 +495,10 @@ build_snapshot() {
           generatedAt: $generatedAt,
           healthy: (($services[0] | length) == 3
             and all($services[0][]; .active == true)
-            and $endpointsAvailable),
+            and $endpointsAvailable
+            and ($metadataAvailable or $topAvailable)
+            and $defaultOutput != ""
+            and ($stats.errors // 0) == 0),
           versions: {
             plugin: $pluginVersion,
             pipewire: $pipewireVersion,
@@ -407,40 +533,64 @@ build_snapshot() {
 }
 
 print_report() {
-  jq -r '
+  local report_user report_host
+  report_user=${USER:-${LOGNAME:-}}
+  report_host=${HOSTNAME:-}
+  [[ -n $report_host ]] || report_host=$(hostname 2>/dev/null || true)
+  report_user=${report_user:0:256}
+  report_host=${report_host:0:256}
+
+  jq -r --arg reportUser "$report_user" --arg reportHost "$report_host" '
     def shown($value): if ($value // "") == "" then "unknown" else $value end;
+    def redact_literal($needle; $replacement):
+      if ($needle | length) == 0 then .
+      elif . == $needle then $replacement
+      elif ($needle | length) >= 3 then split($needle) | join($replacement)
+      else . end;
     def safe: tostring
-      | gsub("([0-9A-Fa-f]{2}[:-]){5}[0-9A-Fa-f]{2}"; "[redacted-address]");
+      | gsub("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]"; " ")
+      | gsub(" +"; " ")
+      | redact_literal($reportUser; "[redacted-user]")
+      | redact_literal($reportHost; "[redacted-host]")
+      | gsub("(?i)([0-9a-f]{2}[:_-]){5}[0-9a-f]{2}"; "[redacted-address]")
+      | gsub("(?i)[0-9a-f]{12}"; "[redacted-address]")
+      | .[0:240];
     def load:
       if .graph.loadPercent >= 0 then ((.graph.loadPercent * 10 | round) / 10 | tostring) + "%"
       else "idle/unavailable" end;
     [
       "Advanced Audio Control support report",
-      "Generated: " + shown(.generatedAt),
+      "Generated: " + (shown(.generatedAt) | safe),
       "",
       "Versions",
-      "  Advanced Audio Control: " + shown(.versions.plugin),
-      "  PipeWire: " + shown(.versions.pipewire),
-      "  WirePlumber: " + shown(.versions.wireplumber),
+      "  Advanced Audio Control: " + (shown(.versions.plugin) | safe),
+      "  PipeWire: " + (shown(.versions.pipewire) | safe),
+      "  WirePlumber: " + (shown(.versions.wireplumber) | safe),
       "",
       "Graph",
       "  Health: " + (if .healthy then "healthy" else "attention required" end),
-      "  Rate / quantum (" + .graph.source + "): " + (.graph.rate | tostring)
+      "  Rate / quantum (" + (.graph.source | safe) + "): " + (.graph.rate | tostring)
         + " Hz / " + (.graph.quantum | tostring),
       "  Scheduling latency: " + (.graph.latencyMs | tostring) + " ms",
       "  Peak DSP load: " + load,
       "  XRUNs/errors: " + (.graph.errors | tostring),
       "",
       "Services",
-      (.services[]? | "  " + .label + ": " + .activeState + "/" + .subState
+      (.services[]? | "  " + (.label | safe) + ": " + (.activeState | safe)
+        + "/" + (.subState | safe)
         + " (restarts " + (.restarts | tostring) + ")"),
       "",
       "Devices",
-      (.devices[]? | "  " + (if .direction == "output" then "Output" else "Input" end)
-        + (if .default then " [default]" else "" end) + ": " + (.label | safe)
-        + " · " + shown(.format) + " · " + shown(.channelMap)
-        + (if .profile != "" then " · " + .profile else "" end)
-        + (if .codec != "" then " · codec " + .codec else "" end)),
+      (.devices[]? as $device
+        | "  " + (if $device.direction == "output" then "Output" else "Input" end)
+        + (if $device.default then " [default]" else "" end) + ": "
+        + (if $device.label == $device.name
+            or ($device.name != "" and ($device.label | contains($device.name))) then
+            (if $device.direction == "output" then "Unnamed output device" else "Unnamed input device" end)
+          else ($device.label | safe) end)
+        + " · " + (shown($device.format) | safe) + " · " + (shown($device.channelMap) | safe)
+        + (if $device.profile != "" then " · " + ($device.profile | safe) else "" end)
+        + (if $device.codec != "" then " · codec " + ($device.codec | safe) else "" end)),
       "",
       "Active routes",
       (if (.routes | length) == 0 then "  None reported"
@@ -448,7 +598,7 @@ print_report() {
       "",
       "Warnings",
       (if (.warnings | length) == 0 then "  None"
-        else (.warnings[] | "  " + .) end),
+        else (.warnings[] | "  " + (. | safe)) end),
       "",
       "This report omits logs, usernames, hostnames, configuration files and internal device identifiers."
     ] | .[]

--- a/scripts/audio-diagnostics
+++ b/scripts/audio-diagnostics
@@ -161,16 +161,16 @@ build_routes() {
             to: (.info["input-node-id"] | tostring)
           }
       ][:8192] | unique_by([.from, .to]) as $links
-    | reduce $nodes[] as $node ({};
-        if has($node.id) then . else .[$node.id] = $node.label end) as $labels
+    | (reduce $nodes[] as $node ({};
+        if has($node.id) then . else .[$node.id] = $node.label end)) as $labels
     | def add_neighbour($key; $value):
         (.[$key] // []) as $current
         | if ($current | index($value)) != null or ($current | length) >= 16
           then . else .[$key] = ($current + [$value]) end;
-      reduce $links[] as $link ({ forward: {}, reverse: {} };
+      (reduce $links[] as $link ({ forward: {}, reverse: {} };
         .forward |= add_neighbour($link.from; $link.to)
         | .reverse |= add_neighbour($link.to; $link.from)
-      ) as $adjacency
+      )) as $adjacency
     | def node_label($id):
         $labels[$id] // "Unavailable audio node";
       def neighbours($id; $reverse):

--- a/scripts/audio-input-set-default
+++ b/scripts/audio-input-set-default
@@ -1,70 +1,385 @@
 #!/bin/bash
 
 # omarchy:summary=Set the default audio input and move streams following it
-# omarchy:args=<node-id> <source-name> [current-source-name]
+# omarchy:args=<node-id> <source-name> [current-source-name] [current-source-id]
+
+set -u -o pipefail
 
 node_id=${1:-}
 source_name=${2:-}
 old_source_name=${3:-}
+expected_old_source_name=$old_source_name
+expected_old_source_object=${4:-}
 
-if (( $# < 2 || $# > 3 )) || [[ -z $node_id || -z $source_name ]]; then
-  echo "Usage: audio-input-set-default <node-id> <source-name> [current-source-name]" >&2
+if (( $# < 2 || $# > 4 )) || [[ ! $node_id =~ ^[0-9]{1,20}$ || -z $source_name ]] ||
+    [[ -n $expected_old_source_object && ! $expected_old_source_object =~ ^[0-9]{1,20}$ ]]; then
+  echo "Usage: audio-input-set-default <node-id> <source-name> [current-source-name] [current-source-id]" >&2
   exit 1
 fi
 
 preferences_file=${OMARCHY_AUDIO_PREFERENCES_FILE:-${XDG_CONFIG_HOME:-${HOME:?}/.config}/omarchy/audio-preferences.json}
 mkdir -p -- "$(dirname -- "$preferences_file")" || exit 1
-exec 8>"${preferences_file}.input.lock" || exit 1
-flock 8 || exit 1
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
-"$script_dir/audio-preferences" show >/dev/null || exit 1
+source "$script_dir/.audio-common"
+audio_acquire_mutation_lock || exit 1
+audio_open_lock_path "${preferences_file}.input.lock" 8 \
+  "Audio input preferences are busy; try again" || exit 1
+/bin/bash "$script_dir/audio-preferences" show >/dev/null || exit 1
 
-live_source_name=$(timeout 2 pactl get-default-source 2>/dev/null || true)
-if [[ -n $live_source_name && $live_source_name != "$source_name" ]]; then
-  old_source_name=$live_source_name
-elif [[ -z $old_source_name ]]; then
-  old_source_name=$live_source_name
+valid_identifier() {
+  local value=$1
+  jq -ne --arg value "$value" '
+    ($value | length) > 0 and ($value | length) <= 160
+    and ($value | test("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]") | not)
+  ' >/dev/null
+}
+
+resolve_source_index() {
+  local identity_name=$1 identity_object=$2 endpoint_json
+  audio_capture_bounded endpoint_json 16777216 \
+    timeout 2 pactl -f json list sources || return 1
+  jq -er --arg name "$identity_name" --arg object "$identity_object" '
+    if type != "array" or length > 512 then error("invalid source list") else . end
+    | [ .[] | select(.name == $name) ] as $named
+    | [ .[]
+        | select(((.properties."object.id" // "") | tostring) == $object)
+      ] as $identified
+    | if ($named | length) != 1 or ($identified | length) != 1
+        or (($named[0].properties."object.id" // "") | tostring) != $object
+      then error("ambiguous source identity")
+      else ($named[0].index | tostring)
+      end
+    | select(test("^[0-9]{1,20}$"))
+  ' <<<"$endpoint_json" 2>/dev/null
+}
+
+valid_identifier "$source_name" || {
+  echo "Invalid audio input identifier" >&2
+  exit 1
+}
+if [[ -n $old_source_name ]]; then
+  valid_identifier "$old_source_name" || {
+    echo "Invalid previous audio input identifier" >&2
+    exit 1
+  }
 fi
-old_source_index=$(timeout 2 pactl -f json list sources 2>/dev/null |
-  jq -r --arg name "$old_source_name" 'map(select(.name == $name))[0].index // empty' || true)
 
-following_outputs=()
-if [[ -n $old_source_index && $old_source_name != "$source_name" ]]; then
-  if metadata=$(timeout 2 pw-metadata -n default 2>/dev/null); then
-    declare -A explicitly_targeted=()
-    while IFS=$'\t' read -r object_id target; do
-      if [[ $object_id =~ ^[0-9]+$ && $target != "-1" ]]; then
-        explicitly_targeted["$object_id"]=1
-      fi
-    done < <(sed -n "s/^update: id:\([0-9][0-9]*\) key:'target\.\(object\|node\)' value:'\([^']*\)'.*/\1\t\3/p" <<<"$metadata")
+audio_capture_bounded live_source_name 1024 timeout 2 pactl get-default-source || {
+  echo "Could not determine the current default audio input" >&2
+  exit 1
+}
+valid_identifier "$live_source_name" || {
+  echo "The current default audio input has an invalid identifier" >&2
+  exit 1
+}
+if [[ -n $expected_old_source_name && $live_source_name != "$expected_old_source_name" ]]; then
+  echo "The default audio input changed before the request could begin" >&2
+  exit 1
+fi
+old_source_name=$live_source_name
 
-    while IFS=$'\t' read -r output object_id; do
-      [[ -n $output ]] || continue
-      if [[ -z $object_id || -z ${explicitly_targeted[$object_id]:-} ]]; then
-        following_outputs+=("$output")
-      fi
-    done < <(timeout 2 pactl -f json list source-outputs 2>/dev/null |
-      jq -r --arg source "$old_source_index" '.[]
-        | select((.source | tostring) == $source)
-        | [.index, (.properties."object.id" // "")]
-        | @tsv' || true)
+audio_capture_bounded sources_json 16777216 timeout 2 pactl -f json list sources || {
+  echo "Could not inspect audio inputs before changing the default" >&2
+  exit 1
+}
+target_source_record=$(jq -cer --arg name "$source_name" '
+  if type != "array" or length > 512 then error("invalid source list")
+  else [.[] | select(.name == $name)] as $matches
+    | if ($matches | length) == 1 then $matches[0]
+      else error("ambiguous source identity") end
+  end
+' <<<"$sources_json") || {
+  echo "The requested default audio input is not available" >&2
+  exit 3
+}
+target_source_object=$(jq -r '.properties."object.id" // "" | tostring' <<<"$target_source_record") || exit 1
+target_source_index=$(jq -r '.index // empty | tostring' <<<"$target_source_record") || exit 1
+[[ $target_source_index =~ ^[0-9]{1,20}$ ]] || {
+  echo "The requested default audio input has an invalid index" >&2
+  exit 3
+}
+if [[ ! $target_source_object =~ ^[0-9]{1,20}$ || $target_source_object != "$node_id" ]]; then
+  echo "The requested audio input changed before it could be selected" >&2
+  exit 3
+fi
+
+if [[ $old_source_name == "$source_name" ]]; then
+  if [[ -n $expected_old_source_object && $target_source_object != "$expected_old_source_object" ]]; then
+    echo "The default audio input was replaced before the request could begin" >&2
+    exit 1
   fi
+  /bin/bash "$script_dir/audio-preferences" set-default input "$source_name" || {
+    echo "The active input preference could not be saved" >&2
+    exit 1
+  }
+  exit 0
 fi
 
-timeout 2 wpctl set-default "$node_id" 2>/dev/null || true
-timeout 2 pactl set-default-source "$source_name" 2>/dev/null || true
-
-actual_source_name=$(timeout 2 pactl get-default-source 2>/dev/null || true)
-if [[ $actual_source_name != "$source_name" ]]; then
-  echo "Could not set the default audio input" >&2
+old_source_index=
+old_source_object=
+if [[ -n $old_source_name && $old_source_name != "$source_name" ]]; then
+  old_source_record=$(jq -r --arg name "$old_source_name" '
+    if type != "array" or length > 512 then error("invalid source list")
+    else [.[] | select(.name == $name)] as $matches
+      | if ($matches | length) == 0 then ""
+        elif ($matches | length) == 1 then
+          ($matches[0] | [(.index // ""), (.properties."object.id" // "")] | @tsv)
+        else error("ambiguous source identity") end
+    end
+  ' <<<"$sources_json") || {
+    echo "Could not inspect audio inputs before changing the default" >&2
+    exit 1
+  }
+  IFS=$'\t' read -r old_source_index old_source_object <<<"$old_source_record"
+fi
+[[ $old_source_index =~ ^[0-9]{1,20}$ ]] || {
+  echo "The current default audio input is no longer available" >&2
+  exit 1
+}
+[[ $old_source_object =~ ^[0-9]{1,20}$ ]] || {
+  echo "The current default audio input has an invalid identity" >&2
+  exit 1
+}
+if [[ -n $expected_old_source_object && $old_source_object != "$expected_old_source_object" ]]; then
+  echo "The default audio input was replaced before the request could begin" >&2
   exit 1
 fi
 
-for output in "${following_outputs[@]}"; do
-  [[ -n $output ]] && timeout 2 pactl move-source-output "$output" "$source_name" 2>/dev/null || true
+following_outputs=()
+following_output_objects=()
+if [[ -n $old_source_index && $old_source_name != "$source_name" ]]; then
+  audio_capture_bounded metadata 4194304 timeout 2 pw-metadata -n default || {
+    echo "Could not inspect persistent application routes before changing the default" >&2
+    exit 1
+  }
+  explicit_rows=$(sed -n "s/^update: id:\([0-9][0-9]*\) key:'target\.\(object\|node\)' value:'\([^']*\)'.*/\1\t\3/p" <<<"$metadata" |
+    awk -F '\t' '
+      $2 != "-1" && length($1) <= 20 && $1 ~ /^[0-9]+$/ && !seen[$1]++ {
+        if (++count > 4096) exit 3
+        print $1 "\t" $2
+      }
+    ') || {
+    echo "Persistent application route metadata is too large" >&2
+    exit 1
+  }
+  declare -A explicitly_targeted=()
+  while IFS=$'\t' read -r object_id target; do
+    [[ -n $object_id ]] && explicitly_targeted["$object_id"]=1
+  done <<<"$explicit_rows"
+
+  audio_capture_bounded source_outputs_json 16777216 \
+    timeout 2 pactl -f json list source-outputs || {
+    echo "Could not inspect recording streams before changing the default" >&2
+    exit 1
+  }
+  output_rows=$(jq -r --arg source "$old_source_index" '
+    if type != "array" or length > 1024 then error("invalid stream list") else . end
+    | [.[] | select((.source | tostring) == $source)] as $streams
+    | if ($streams | length) > 512 or any($streams[]?;
+        ((.index | tostring) | test("^[0-9]{1,20}$") | not)
+        or (((.properties."object.id" // "") | tostring)
+          | test("^[0-9]{1,20}$") | not))
+        or (($streams | map(.index | tostring) | unique | length) != ($streams | length))
+        or (($streams | map(.properties."object.id" | tostring) | unique | length)
+          != ($streams | length)) then
+        error("invalid stream identity")
+      else $streams[]
+        | [.index, .properties."object.id"] | @tsv
+      end
+  ' <<<"$source_outputs_json") || {
+    echo "Could not inspect recording streams before changing the default" >&2
+    exit 1
+  }
+  while IFS=$'\t' read -r output object_id; do
+    [[ -n $output ]] || continue
+    if [[ -z $object_id || -z ${explicitly_targeted[$object_id]:-} ]]; then
+      following_outputs+=("$output")
+      following_output_objects+=("$object_id")
+    fi
+  done <<<"$output_rows"
+fi
+
+rollback_default() {
+  local restored_source_name restored_source_index
+  if [[ -z $old_source_name ]]; then
+    return 1
+  fi
+  restored_source_name=
+  audio_capture_bounded restored_source_name 1024 \
+    timeout 2 pactl get-default-source || true
+  if [[ $restored_source_name == "$old_source_name" ]]; then
+    resolve_source_index "$old_source_name" "$old_source_object" >/dev/null || return 1
+    return 0
+  fi
+  if [[ $old_source_name != "$source_name" ]]; then
+    restored_source_index=$(resolve_source_index \
+      "$old_source_name" "$old_source_object") || return 1
+    timeout 2 wpctl set-default "$old_source_object" 2>/dev/null || true
+    timeout 2 pactl set-default-source "$old_source_name" 2>/dev/null || true
+  fi
+  restored_source_name=
+  audio_capture_bounded restored_source_name 1024 \
+    timeout 2 pactl get-default-source || true
+  [[ $restored_source_name == "$old_source_name" ]] || return 1
+  resolve_source_index "$old_source_name" "$old_source_object" >/dev/null
+}
+
+target_source_index=$(resolve_source_index "$source_name" "$target_source_object") || {
+  echo "The requested audio input changed before it could be selected" >&2
+  exit 3
+}
+timeout 2 wpctl set-default "$node_id" 2>/dev/null || true
+timeout 2 pactl set-default-source "$source_name" 2>/dev/null || true
+
+actual_source_name=
+audio_capture_bounded actual_source_name 1024 timeout 2 pactl get-default-source || true
+if [[ $actual_source_name != "$source_name" ]]; then
+  echo "Could not set the default audio input" >&2
+  rollback_default && exit 1
+  exit 4
+fi
+target_source_index=$(resolve_source_index "$source_name" "$target_source_object") || {
+  echo "The selected audio input was replaced during the default change" >&2
+  rollback_default && exit 1
+  exit 4
+}
+
+moved_outputs=()
+moved_output_objects=()
+move_failed=false
+for (( follower = 0; follower < ${#following_outputs[@]}; follower++ )); do
+  output=${following_outputs[$follower]}
+  object_id=${following_output_objects[$follower]}
+  audio_capture_bounded current_outputs 16777216 \
+    timeout 2 pactl -f json list source-outputs || {
+    move_failed=true
+    break
+  }
+  current_row=$(jq -cer --arg object "$object_id" '
+    if type != "array" or length > 1024 then error("invalid stream list")
+    else [.[] | select(((.properties."object.id" // "") | tostring) == $object)] as $matches
+      | if ($matches | length) == 0 then "__gone__"
+        elif ($matches | length) == 1 then $matches[0]
+        else error("ambiguous stream identity") end
+    end
+  ' <<<"$current_outputs" 2>/dev/null) || { move_failed=true; break; }
+  [[ $current_row != __gone__ ]] || continue
+  current_output=$(jq -r '.index // empty | tostring' <<<"$current_row")
+  current_target=$(jq -r '.source // empty | tostring' <<<"$current_row")
+  [[ $current_output =~ ^[0-9]{1,20}$ && $current_target =~ ^[0-9]{1,20}$ ]] || {
+    move_failed=true
+    break
+  }
+  current_old_index=$(resolve_source_index "$old_source_name" "$old_source_object") || {
+    move_failed=true
+    break
+  }
+  [[ $current_target == "$current_old_index" ]] || continue
+
+  target_source_index=$(resolve_source_index "$source_name" "$target_source_object") || {
+    move_failed=true
+    break
+  }
+
+  move_command_failed=false
+  timeout 2 pactl move-source-output "$current_output" "$source_name" \
+    2>/dev/null || move_command_failed=true
+  audio_capture_bounded remaining_outputs 16777216 \
+    timeout 2 pactl -f json list source-outputs || { move_failed=true; break; }
+  moved_row=$(jq -cer --arg object "$object_id" '
+    if type != "array" or length > 1024 then error("invalid stream list")
+    else [.[] | select(((.properties."object.id" // "") | tostring) == $object)] as $matches
+      | if ($matches | length) == 0 then "__gone__"
+        elif ($matches | length) == 1 then $matches[0]
+        else error("ambiguous stream identity") end
+    end
+  ' <<<"$remaining_outputs" 2>/dev/null) || { move_failed=true; break; }
+  [[ $moved_row != __gone__ ]] || continue
+  moved_output=$(jq -r '.index // empty | tostring' <<<"$moved_row")
+  moved_target=$(jq -r '.source // empty | tostring' <<<"$moved_row")
+  target_source_index=$(resolve_source_index "$source_name" "$target_source_object") || {
+    move_failed=true
+    break
+  }
+  if [[ $moved_output =~ ^[0-9]{1,20}$ && $moved_target == "$target_source_index" ]]; then
+    moved_outputs+=("$moved_output")
+    moved_output_objects+=("$object_id")
+    if [[ $move_command_failed == true ]]; then
+      move_failed=true
+      break
+    fi
+  else
+    move_failed=true
+    break
+  fi
 done
 
-if ! "$script_dir/audio-preferences" set-default input "$source_name"; then
+if [[ $move_failed == false ]]; then
+  final_source_name=
+  audio_capture_bounded final_source_name 1024 \
+    timeout 2 pactl get-default-source || move_failed=true
+  if [[ $move_failed == false && $final_source_name == "$source_name" ]]; then
+    resolve_source_index "$source_name" "$target_source_object" >/dev/null || move_failed=true
+  else
+    move_failed=true
+  fi
+fi
+
+rollback_moved_outputs() {
+  local rollback_outputs row current_output current_target object_id live_target_index live_old_index
+  local -a attempted_objects=()
+  for (( moved = 0; moved < ${#moved_output_objects[@]}; moved++ )); do
+    object_id=${moved_output_objects[$moved]}
+    audio_capture_bounded rollback_outputs 16777216 \
+      timeout 2 pactl -f json list source-outputs || return 1
+    row=$(jq -cer --arg object "$object_id" '
+      if type != "array" or length > 1024 then error("invalid stream list")
+      else [.[] | select(((.properties."object.id" // "") | tostring) == $object)] as $matches
+        | if ($matches | length) == 0 then "__gone__"
+          elif ($matches | length) == 1 then $matches[0]
+          else error("ambiguous stream identity") end
+      end
+    ' <<<"$rollback_outputs" 2>/dev/null) || return 1
+    [[ $row != __gone__ ]] || continue
+    current_output=$(jq -r '.index // empty | tostring' <<<"$row")
+    current_target=$(jq -r '.source // empty | tostring' <<<"$row")
+    [[ $current_output =~ ^[0-9]{1,20}$ && $current_target =~ ^[0-9]{1,20}$ ]] || return 1
+    live_target_index=$(resolve_source_index "$source_name" "$target_source_object") || return 1
+    [[ $current_target == "$live_target_index" ]] || continue
+    timeout 2 pactl move-source-output "$current_output" "$old_source_name" \
+      >/dev/null 2>&1 || true
+    attempted_objects+=("$object_id")
+  done
+  (( ${#attempted_objects[@]} > 0 )) || return 0
+  audio_capture_bounded rollback_outputs 16777216 \
+    timeout 2 pactl -f json list source-outputs || return 1
+  for object_id in "${attempted_objects[@]}"; do
+    row=$(jq -cer --arg object "$object_id" '
+      if type != "array" or length > 1024 then error("invalid stream list")
+      else [.[] | select(((.properties."object.id" // "") | tostring) == $object)] as $matches
+        | if ($matches | length) == 0 then "__gone__"
+          elif ($matches | length) == 1 then $matches[0]
+          else error("ambiguous stream identity") end
+      end
+    ' <<<"$rollback_outputs" 2>/dev/null) || return 1
+    [[ $row != __gone__ ]] || continue
+    current_target=$(jq -r '.source // empty | tostring' <<<"$row")
+    [[ $current_target =~ ^[0-9]{1,20}$ ]] || return 1
+    live_old_index=$(resolve_source_index "$old_source_name" "$old_source_object") || return 1
+    [[ $current_target == "$live_old_index" ]] || return 1
+  done
+}
+
+if [[ $move_failed == true ]]; then
+  rollback_complete=true
+  rollback_moved_outputs || rollback_complete=false
+  rollback_default || rollback_complete=false
+  echo "Could not move applications following the default audio input" >&2
+  [[ $rollback_complete == true ]] && exit 1
+  exit 4
+fi
+
+if ! /bin/bash "$script_dir/audio-preferences" set-default input "$source_name"; then
   echo "The default input changed, but its preference could not be saved" >&2
   exit 2
 fi

--- a/scripts/audio-menu-entry
+++ b/scripts/audio-menu-entry
@@ -5,11 +5,20 @@
 # explicit, reversible integration step rather than a hidden config mutation.
 
 set -euo pipefail
+export LC_ALL=C
 
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+source "$script_dir/.audio-common"
 action=${1:-install}
 menu_file=${AUDIO_CONTROL_MENU_FILE:-$HOME/.config/omarchy/extensions/omarchy-menu.jsonc}
 marker="  // Added by ssupt.audio-control"
 entry='  "setup.audio": {"icon":"","label":"Audio","action":"omarchy-shell shell summon ssupt.audio-control"}'
+maximum_menu_bytes=1048576
+
+command -v jq >/dev/null || {
+  echo "audio-menu-entry requires jq" >&2
+  exit 1
+}
 
 usage() {
   echo "Usage: audio-menu-entry [install|remove]" >&2
@@ -22,51 +31,326 @@ refresh_menu() {
   omarchy-shell shell call omarchy.menu refresh "" >/dev/null 2>&1 || true
 }
 
+# jq is the grammar authority after comments and JSONC trailing commas are
+# removed lexically. Neither pass interprets comment markers or commas inside
+# strings, so validating an existing user file cannot be fooled by values such
+# as URLs or escaped quotes. Slurping also rejects concatenated root documents.
+strip_jsonc_comments() {
+  local source=${1:-$menu_file}
+  awk '
+    {
+      line = $0
+      line_comment = 0
+      for (column = 1; column <= length(line); column++) {
+        character = substr(line, column, 1)
+        next_character = substr(line, column + 1, 1)
+        if (line_comment) break
+        if (block_comment) {
+          if (character == "*" && next_character == "/") {
+            block_comment = 0
+            column++
+          }
+          continue
+        }
+        if (in_string) {
+          printf "%s", character
+          if (escaped) escaped = 0
+          else if (character == "\\") escaped = 1
+          else if (character == "\"") in_string = 0
+          continue
+        }
+        if (character == "\"") {
+          in_string = 1
+          printf "%s", character
+        } else if (character == "/" && next_character == "/") {
+          printf " "
+          line_comment = 1
+          column++
+        } else if (character == "/" && next_character == "*") {
+          printf " "
+          block_comment = 1
+          column++
+        } else {
+          printf "%s", character
+        }
+      }
+      printf "\n"
+      if (in_string) exit 2
+    }
+    END { if (block_comment || in_string) exit 2 }
+  ' "$source"
+}
+
+strip_jsonc_trailing_commas() {
+  awk '
+    function flush_pending(drop_comma) {
+      if (pending == "") return
+      if (drop_comma) printf "%s", substr(pending, 2)
+      else printf "%s", pending
+      pending = ""
+    }
+    {
+      line = $0
+      for (column = 1; column <= length(line); column++) {
+        character = substr(line, column, 1)
+        if (in_string) {
+          printf "%s", character
+          if (escaped) escaped = 0
+          else if (character == "\\") escaped = 1
+          else if (character == "\"") in_string = 0
+          continue
+        }
+        if (pending != "") {
+          if (character ~ /[[:space:]]/) {
+            pending = pending character
+            continue
+          }
+          if (character == "}" || character == "]") flush_pending(1)
+          else flush_pending(0)
+        }
+        if (character == "\"") {
+          in_string = 1
+          printf "%s", character
+        } else if (character == ",") {
+          pending = ","
+        } else {
+          printf "%s", character
+        }
+      }
+      if (pending != "") pending = pending "\n"
+      else printf "\n"
+    }
+    END { flush_pending(0) }
+  '
+}
+
+validate_menu() {
+  local source=${1:-$menu_file}
+  strip_jsonc_comments "$source" | strip_jsonc_trailing_commas |
+    jq -e -s 'length == 1 and (.[0] | type == "object")' >/dev/null 2>&1
+}
+
+menu_has_entry() {
+  local source=${1:-$menu_file}
+  strip_jsonc_comments "$source" | strip_jsonc_trailing_commas |
+    jq -e -s 'length == 1 and (.[0] | type) == "object"
+      and (.[0] | has("setup.audio"))' >/dev/null 2>&1
+}
+
+# Report the root object's closing line/column, whether the generated property
+# already exists, and whether the object has any content. This intentionally
+# lexes JSONC instead of using line-oriented regular expressions: comments,
+# strings containing comment markers, and a closing brace on the same line as
+# the object are all valid menu files.
+inspect_menu() {
+  awk '
+    function invalid() { exit 2 }
+    {
+      line = $0
+      line_comment = 0
+      for (column = 1; column <= length(line); column++) {
+        character = substr(line, column, 1)
+        next_character = substr(line, column + 1, 1)
+
+        if (line_comment) break
+        if (block_comment) {
+          if (character == "*" && next_character == "/") {
+            block_comment = 0
+            column++
+          }
+          continue
+        }
+        if (in_string) {
+          if (escaped) {
+            string_value = string_value character
+            escaped = 0
+          } else if (character == "\\") {
+            string_value = string_value character
+            escaped = 1
+          } else if (character == "\"") {
+            in_string = 0
+            last_significant = "\""
+            if (key_candidate) {
+              pending_key = (string_value == "setup.audio")
+              key_candidate = 0
+            }
+          } else {
+            string_value = string_value character
+          }
+          continue
+        }
+
+        if (character == "/" && next_character == "/") {
+          line_comment = 1
+          column++
+          continue
+        }
+        if (character == "/" && next_character == "*") {
+          block_comment = 1
+          column++
+          continue
+        }
+        if (character ~ /[[:space:]]/) continue
+        if (root_closed) invalid()
+
+        if (pending_key) {
+          if (character == ":") {
+            entry_count++
+            if (entry_count > 1) invalid()
+            has_entry = 1
+            pending_key = 0
+            expect_key = 0
+            continue
+          }
+          pending_key = 0
+        }
+
+        if (!root_started) {
+          if (character != "{") invalid()
+          root_started = 1
+          object_depth = 1
+          expect_key = 1
+          continue
+        }
+
+        if (character == "\"") {
+          in_string = 1
+          escaped = 0
+          string_value = ""
+          key_candidate = (object_depth == 1 && array_depth == 0 && expect_key)
+          if (object_depth == 1 && array_depth == 0) has_content = 1
+          continue
+        }
+        if (character == "{") {
+          if (object_depth == 1 && array_depth == 0) has_content = 1
+          object_depth++
+          continue
+        }
+        if (character == "}") {
+          if (object_depth <= 0) invalid()
+          if (object_depth == 1 && array_depth == 0) {
+            root_trailing_comma = (last_significant == ",")
+            closing_line = NR
+            closing_column = column
+            object_depth = 0
+            root_closed = 1
+          } else {
+            object_depth--
+            last_significant = "}"
+          }
+          continue
+        }
+        if (character == "[") {
+          if (object_depth == 1 && array_depth == 0) has_content = 1
+          array_depth++
+          continue
+        }
+        if (character == "]") {
+          if (array_depth <= 0) invalid()
+          array_depth--
+          last_significant = "]"
+          continue
+        }
+        if (object_depth == 1 && array_depth == 0) {
+          if (character == ",") expect_key = 1
+          else if (character == ":") expect_key = 0
+          has_content = 1
+        }
+        last_significant = character
+      }
+      # JSON strings cannot contain a literal newline.
+      if (in_string) invalid()
+    }
+    END {
+      if (!root_started || !root_closed || object_depth != 0 || array_depth != 0 ||
+          block_comment || in_string) exit 2
+      printf "%d\t%d\t%d\t%d\t%d\n", closing_line, closing_column,
+        has_entry ? 1 : 0, has_content ? 1 : 0, root_trailing_comma ? 1 : 0
+    }
+  ' "$menu_file"
+}
+
 install_entry() {
-  mkdir -p "$(dirname -- "$menu_file")"
   if [[ ! -f $menu_file ]]; then
-    printf '{\n%s\n%s\n}\n' "$marker" "$entry" >"$menu_file"
+    tmp=$(mktemp "${menu_file}.tmp.XXXXXX")
+    trap 'rm -f -- "$tmp"' EXIT
+    printf '{\n%s\n%s\n}\n' "$marker" "$entry" >"$tmp"
+    validate_menu "$tmp" || exit 1
+    chmod 600 -- "$tmp"
+    mv -f -- "$tmp" "$menu_file"
+    trap - EXIT
     refresh_menu
     return
   fi
 
-  grep -Eq '^[[:space:]]*"setup\.audio"[[:space:]]*:' "$menu_file" && return
+  validate_menu || {
+    echo "Audio menu configuration is not valid JSONC" >&2
+    exit 1
+  }
+  # Let the JSON parser decode escaped property names. The positional lexer
+  # below deliberately keeps raw spelling for safe line edits, so on its own
+  # it would miss an existing key such as "setup\u002eaudio" and create a
+  # second semantic property.
+  menu_has_entry && return 0
+  inspection=$(inspect_menu) || {
+    echo "Audio menu configuration is not valid JSONC" >&2
+    exit 1
+  }
+  IFS=$'\t' read -r closing_line closing_column has_entry has_content \
+    has_trailing_comma <<<"$inspection"
+  (( has_entry == 0 )) || return 0
 
   mapfile -t lines <"$menu_file"
-  closing=-1
-  for (( i = ${#lines[@]} - 1; i >= 0; i-- )); do
-    if [[ ${lines[$i]} =~ ^[[:space:]]*\}[[:space:]]*$ ]]; then
-      closing=$i
-      break
-    fi
-  done
-  (( closing >= 0 )) || { echo "Could not find the menu object's closing brace" >&2; exit 1; }
-
-  for (( i = closing - 1; i >= 0; i-- )); do
-    line=${lines[$i]}
-    [[ $line =~ ^[[:space:]]*$ || $line =~ ^[[:space:]]*// ]] && continue
-    if [[ ! $line =~ \{[[:space:]]*$ && ! $line =~ ,[[:space:]]*$ ]]; then
-      lines[$i]="$line,"
-    fi
-    break
-  done
+  closing=$((closing_line - 1))
+  (( closing >= 0 && closing < ${#lines[@]} && closing_column > 0 )) || {
+    echo "Could not locate the menu object's closing brace" >&2
+    exit 1
+  }
 
   tmp=$(mktemp "${menu_file}.tmp.XXXXXX")
+  trap 'rm -f -- "$tmp"' EXIT
   for (( i = 0; i < ${#lines[@]}; i++ )); do
     if (( i == closing )); then
-      printf '%s\n%s\n' "$marker" "$entry"
+      line=${lines[$i]}
+      prefix=${line:0:closing_column-1}
+      if [[ $prefix =~ ^[[:space:]]*$ ]]; then
+        closing_text=$line
+      else
+        indent=${line%%[![:space:]]*}
+        closing_text="${indent}${line:closing_column-1}"
+        printf '%s\n' "$prefix"
+      fi
+      printf '%s\n' "$marker"
+      if (( has_content && ! has_trailing_comma )); then
+        printf '  ,%s\n' "${entry#  }"
+      else
+        printf '%s\n' "$entry"
+      fi
+      printf '%s\n' "$closing_text"
+      continue
     fi
     printf '%s\n' "${lines[$i]}"
   done >"$tmp"
-  mv "$tmp" "$menu_file"
+  validate_menu "$tmp" || {
+    echo "Could not create a valid audio menu configuration" >&2
+    exit 1
+  }
+  chmod 600 -- "$tmp"
+  mv -f -- "$tmp" "$menu_file"
+  trap - EXIT
   refresh_menu
 }
 
 remove_entry() {
   [[ -f $menu_file ]] || return
+  validate_menu && inspect_menu >/dev/null || {
+    echo "Audio menu configuration is not valid JSONC" >&2
+    exit 1
+  }
   mapfile -t lines <"$menu_file"
   tmp=$(mktemp "${menu_file}.tmp.XXXXXX")
-  entry_pattern='^[[:space:]]*"setup\.audio"[[:space:]]*:'
+  trap 'rm -f -- "$tmp"' EXIT
+  entry_pattern='^[[:space:]]*,?[[:space:]]*"setup\.audio"[[:space:]]*:'
   skip_entry=0
   for line in "${lines[@]}"; do
     if [[ $line == "$marker" ]]; then
@@ -80,12 +364,37 @@ remove_entry() {
     skip_entry=0
     printf '%s\n' "$line"
   done >"$tmp"
-  mv "$tmp" "$menu_file"
+  validate_menu "$tmp" || {
+    echo "Could not remove the audio menu entry safely" >&2
+    exit 1
+  }
+  chmod 600 -- "$tmp"
+  mv -f -- "$tmp" "$menu_file"
+  trap - EXIT
   refresh_menu
 }
 
-case "$action" in
-  install) install_entry ;;
-  remove) remove_entry ;;
-  *) usage ;;
-esac
+[[ $action == install || $action == remove ]] || usage
+
+menu_dir=$(dirname -- "$menu_file")
+if [[ $action == remove && ! -d $menu_dir ]]; then
+  exit 0
+fi
+mkdir -p -- "$menu_dir"
+audio_open_lock_path "${menu_file}.lock" 9 \
+  "Audio menu configuration is busy; try again" || exit 1
+if [[ -L $menu_file || (-e $menu_file && ! -f $menu_file) ]]; then
+  echo "Audio menu configuration is not a regular file" >&2
+  exit 1
+fi
+if [[ -e $menu_file ]] &&
+    (( $(stat -c %s -- "$menu_file" 2>/dev/null || printf '%s' "$((maximum_menu_bytes + 1))") > maximum_menu_bytes )); then
+  echo "Audio menu configuration is too large; refusing to rewrite it" >&2
+  exit 1
+fi
+
+if [[ $action == install ]]; then
+  install_entry
+else
+  remove_entry
+fi

--- a/scripts/audio-microphone-test
+++ b/scripts/audio-microphone-test
@@ -6,16 +6,66 @@
 
 set -euo pipefail
 
-runtime_root=${XDG_RUNTIME_DIR:-/run/user/$UID}/omarchy/audio-control
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+source "$script_dir/.audio-common"
+audio_prepare_private_runtime || exit 1
+runtime_root=$AUDIO_CONTROL_PRIVATE_RUNTIME_DIR/omarchy/audio-control
 test_file=${AUDIO_CONTROL_MICROPHONE_TEST_FILE:-$runtime_root/microphone-test.raw}
 record_pid_file=${AUDIO_CONTROL_MICROPHONE_TEST_PID_FILE:-$test_file.pid}
 stop_request_file=${AUDIO_CONTROL_MICROPHONE_TEST_STOP_FILE:-$test_file.stop}
+record_lock_file=${AUDIO_CONTROL_MICROPHONE_TEST_LOCK_FILE:-$test_file.lock}
+test_dir=$(dirname -- "$test_file")
 action=${1:-status}
 sample_rate=48000
 channel_count=1
 sample_bytes=2
 maximum_samples=240000
 maximum_bytes=$((maximum_samples * channel_count * sample_bytes))
+record_timeout_seconds=${AUDIO_CONTROL_MICROPHONE_TEST_RECORD_TIMEOUT:-8}
+
+[[ $record_timeout_seconds =~ ^[1-9][0-9]?$ ]] \
+  && (( record_timeout_seconds <= 30 )) || {
+  echo "Invalid microphone recording timeout" >&2
+  exit 1
+}
+
+[[ $test_file == /* && $(dirname -- "$record_pid_file") == "$test_dir" \
+    && $(dirname -- "$stop_request_file") == "$test_dir" \
+    && $(dirname -- "$record_lock_file") == "$test_dir" \
+    && ${#test_file} -le 4096 && ${#record_pid_file} -le 4096 \
+    && ${#stop_request_file} -le 4096 && ${#record_lock_file} -le 4096 \
+    && $test_file != "$record_pid_file" && $test_file != "$stop_request_file" \
+    && $test_file != "$record_lock_file" && $record_pid_file != "$stop_request_file" \
+    && $record_pid_file != "$record_lock_file" \
+    && $stop_request_file != "$record_lock_file" \
+    && ! $test_file =~ [[:cntrl:]] && ! $record_pid_file =~ [[:cntrl:]] \
+    && ! $stop_request_file =~ [[:cntrl:]] && ! $record_lock_file =~ [[:cntrl:]] ]] || {
+  echo "Microphone test paths must share one absolute runtime directory" >&2
+  exit 1
+}
+
+private_test_dir_ready() {
+  local create=${1:-false} mode permissions
+  if [[ ! -e $test_dir && ! -L $test_dir ]]; then
+    [[ $create == true ]] || return 1
+    mkdir -p -m 700 -- "$test_dir" || return 1
+  fi
+  [[ ! -L $test_dir && -d $test_dir && -O $test_dir ]] || return 1
+  mode=$(stat -Lc '%a' -- "$test_dir" 2>/dev/null) || return 1
+  permissions=${mode: -3}
+  [[ $permissions =~ ^[0-7]{3}$ ]] && (( (8#$permissions & 0022) == 0 ))
+}
+
+safe_control_paths() {
+  local path owner links
+  for path in "$test_file" "$record_pid_file" "$stop_request_file" "$record_lock_file"; do
+    [[ ! -L $path && (! -e $path || (-f $path && -O $path)) ]] || return 1
+    if [[ -e $path ]]; then
+      read -r owner links < <(stat -Lc '%u %h' -- "$path" 2>/dev/null) || return 1
+      [[ $owner == "$UID" && $links == 1 ]] || return 1
+    fi
+  done
+}
 
 usage() {
   echo "Usage: audio-microphone-test [status | record <source-name> | stop | play | clear]" >&2
@@ -31,30 +81,78 @@ recording_size() {
   stat -c '%s' "$path" 2>/dev/null || printf '%s\n' 0
 }
 
+recording_ready() {
+  local size
+  size=$(recording_size "$test_file")
+  (( size >= sample_bytes && size <= maximum_bytes && size % sample_bytes == 0 ))
+}
+
+valid_identifier() {
+  local value=$1
+  jq -ne --arg value "$value" '
+    ($value | length) > 0 and ($value | length) <= 160
+    and ($value | test("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]") | not)
+  ' >/dev/null
+}
+
+process_start_time() {
+  local pid=$1 stat_line stat_fields
+  [[ $pid =~ ^[1-9][0-9]*$ && -r /proc/$pid/stat ]] || return 1
+  stat_line=$(<"/proc/$pid/stat") || return 1
+  # The comm field is parenthesized and may contain spaces. Remove it before
+  # indexing: starttime is field 22, or index 19 in the fields beginning at 3.
+  stat_line=${stat_line##*) }
+  read -r -a stat_fields <<<"$stat_line"
+  [[ ${stat_fields[19]:-} =~ ^[0-9]+$ ]] || return 1
+  printf '%s\n' "${stat_fields[19]}"
+}
+
+read_record_identity() {
+  local current_start extra
+  record_pid=""
+  record_start=""
+  [[ -s $record_pid_file && ! -L $record_pid_file ]] || return 1
+  read -r record_pid record_start extra <"$record_pid_file" || return 1
+  [[ $record_pid =~ ^[1-9][0-9]*$ && $record_start =~ ^[0-9]+$ && -z ${extra:-} ]] || return 1
+  current_start=$(process_start_time "$record_pid") || return 1
+  [[ $current_start == "$record_start" ]]
+}
+
 case "$action" in
   status)
     (( $# == 0 || $# == 1 )) || usage
-    [[ -s $test_file && ! -L $test_file ]] && printf '%s\n' ready || printf '%s\n' empty
+    if [[ ! -e $test_dir && ! -L $test_dir ]]; then
+      printf '%s\n' empty
+      exit 0
+    fi
+    private_test_dir_ready false && safe_control_paths || exit 1
+    recording_ready && printf '%s\n' ready || printf '%s\n' empty
     ;;
   record)
     (( $# == 2 )) || usage
     source_name=$2
-    [[ -n $source_name ]] || usage
-    command -v pw-record >/dev/null
-
-    test_dir=$(dirname -- "$test_file")
+    valid_identifier "$source_name" || usage
+    record_path=$(command -v pw-record)
     umask 077
-    if [[ ! -d $test_dir ]]; then
-      mkdir -p -- "$test_dir"
-      chmod 700 "$test_dir"
-    fi
+    private_test_dir_ready true && safe_control_paths || {
+      echo "Microphone test runtime paths are unsafe" >&2
+      exit 1
+    }
+    audio_open_lock_path "$record_lock_file" 9 \
+      "A microphone test is already recording" 0 || exit 1
     temporary_file=$(mktemp "$test_dir/.microphone-test.XXXXXX.raw")
     record_pid=""
+    record_start=""
+    record_watchdog_pid=""
     rm -f -- "$record_pid_file" "$stop_request_file"
 
     cleanup_recording() {
       local status=$1
       trap - EXIT INT TERM HUP
+      if [[ -n $record_watchdog_pid ]]; then
+        kill -KILL "$record_watchdog_pid" 2>/dev/null || true
+        wait "$record_watchdog_pid" 2>/dev/null || true
+      fi
       if [[ -n $record_pid ]]; then
         kill -KILL "$record_pid" 2>/dev/null || true
         wait "$record_pid" 2>/dev/null || true
@@ -66,7 +164,7 @@ case "$action" in
     trap 'cleanup_recording 130' INT
     trap 'cleanup_recording 143' TERM HUP
 
-    pw-record \
+    "$record_path" \
       --target "$source_name" \
       --media-category Capture \
       --media-role Communication \
@@ -78,16 +176,48 @@ case "$action" in
       --sample-count "$maximum_samples" \
       "$temporary_file" &
     record_pid=$!
-    printf '%s\n' "$record_pid" >"$record_pid_file"
+    for _identity_attempt in {1..20}; do
+      record_start=$(process_start_time "$record_pid" || true)
+      [[ -n $record_start ]] && break
+      kill -0 "$record_pid" 2>/dev/null || break
+      sleep 0.005
+    done
+    if [[ -n $record_start ]]; then
+      printf '%s %s\n' "$record_pid" "$record_start" >"$record_pid_file"
+      # pw-record normally honors --sample-count, but a broken build must not
+      # leave the standalone helper (or a detached child after UI shutdown)
+      # recording forever. Match both PID and start time before killing so PID
+      # reuse can never target an unrelated process. The watchdog must not
+      # inherit the record lock, otherwise a hard-killed parent would make
+      # `clear` wait on the watchdog after it has already reaped the recorder.
+      (
+        exec 9>&-
+        sleep "$record_timeout_seconds"
+        current_start=$(process_start_time "$record_pid" || true)
+        [[ -n $current_start && $current_start == "$record_start" ]] || exit 0
+        kill -KILL "$record_pid" 2>/dev/null || true
+      ) &
+      record_watchdog_pid=$!
+    elif kill -0 "$record_pid" 2>/dev/null; then
+      echo "Could not establish the microphone recorder identity" >&2
+      exit 1
+    fi
     record_status=0
     wait "$record_pid" 2>/dev/null || record_status=$?
     record_pid=""
+    record_start=""
+    if [[ -n $record_watchdog_pid ]]; then
+      kill -KILL "$record_watchdog_pid" 2>/dev/null || true
+      wait "$record_watchdog_pid" 2>/dev/null || true
+      record_watchdog_pid=""
+    fi
     rm -f -- "$record_pid_file"
 
     size=$(recording_size "$temporary_file")
     stopped_early=false
     [[ -f $stop_request_file && ! -L $stop_request_file ]] && stopped_early=true
-    if (( size < sample_bytes )) || { ! $stopped_early && (( size < maximum_bytes )); }; then
+    if (( size < sample_bytes || size > maximum_bytes )) ||
+      { ! $stopped_early && (( size < maximum_bytes )); }; then
       exit "$((record_status == 0 ? 1 : record_status))"
     fi
 
@@ -102,20 +232,18 @@ case "$action" in
     ;;
   stop)
     (( $# == 1 )) || usage
-    test_dir=$(dirname -- "$test_file")
-    [[ -d $test_dir ]] || exit 1
+    private_test_dir_ready false && safe_control_paths || exit 1
     umask 077
-    : >"$stop_request_file"
+    if [[ ! -e $stop_request_file && ! -L $stop_request_file ]]; then
+      (set -o noclobber; : >"$stop_request_file") 2>/dev/null || true
+    fi
+    safe_control_paths || exit 1
 
-    record_pid=""
     for _attempt in {1..20}; do
-      if [[ -s $record_pid_file && ! -L $record_pid_file ]]; then
-        read -r record_pid <"$record_pid_file" || true
-        [[ $record_pid =~ ^[1-9][0-9]*$ ]] && break
-      fi
+      read_record_identity && break
       sleep 0.025
     done
-    if [[ ! $record_pid =~ ^[1-9][0-9]*$ ]] || ! kill -0 "$record_pid" 2>/dev/null; then
+    if [[ ! $record_pid =~ ^[1-9][0-9]*$ ]] || ! read_record_identity; then
       rm -f -- "$stop_request_file"
       exit 1
     fi
@@ -126,12 +254,13 @@ case "$action" in
     ;;
   play)
     (( $# == 1 )) || usage
-    [[ -s $test_file && ! -L $test_file ]] || {
+    private_test_dir_ready false && safe_control_paths || exit 1
+    recording_ready || {
       echo "No microphone test recording is ready" >&2
       exit 1
     }
-    command -v pw-play >/dev/null
-    exec pw-play \
+    play_path=$(command -v pw-play)
+    exec timeout --foreground --kill-after=2 10 "$play_path" \
       --media-role Communication \
       --properties '{"node.name":"omarchy_audio_test_playback","application.id":"ssupt.audio-control","application.name":"Advanced Audio Control","media.name":"Microphone test playback"}' \
       --volume 0.8 \
@@ -143,18 +272,22 @@ case "$action" in
     ;;
   clear)
     (( $# == 1 )) || usage
-    test_dir=$(dirname -- "$test_file")
+    if [[ ! -e $test_dir && ! -L $test_dir ]]; then
+      exit 0
+    fi
+    private_test_dir_ready false && safe_control_paths || exit 1
     if [[ -d $test_dir ]]; then
       # A record helper killed hard skips its cleanup trap, leaving pw-record
       # running and its temporary file behind. Reap both so a cancelled test
       # never keeps the microphone open or stray audio on disk.
-      orphan_pid=""
-      if [[ -s $record_pid_file && ! -L $record_pid_file ]]; then
-        read -r orphan_pid <"$record_pid_file" || true
+      if read_record_identity && kill -0 "$record_pid" 2>/dev/null; then
+        kill -KILL "$record_pid" 2>/dev/null || true
       fi
-      if [[ $orphan_pid =~ ^[1-9][0-9]*$ ]] && kill -0 "$orphan_pid" 2>/dev/null; then
-        kill -KILL "$orphan_pid" 2>/dev/null || true
-      fi
+      # Wait for the recorder (which inherits the record lock) and its parent
+      # to leave before the final deletion. Without this barrier, a clear that
+      # races the recorder's last wait/move can resurrect the clip afterward.
+      audio_open_lock_path "$record_lock_file" 8 \
+        "Microphone recording did not finish while clearing it" 3 || exit 1
       rm -f -- "$test_dir"/.microphone-test.*.raw "$test_file" "$record_pid_file" "$stop_request_file"
     fi
     ;;

--- a/scripts/audio-output-set-default
+++ b/scripts/audio-output-set-default
@@ -1,77 +1,398 @@
 #!/bin/bash
 
 # omarchy:summary=Set the default audio output and move streams following it
-# omarchy:args=<node-id> <sink-name> [current-sink-name]
+# omarchy:args=<node-id> <sink-name> [current-sink-name] [current-sink-id]
 # omarchy:examples=omarchy audio output set default 42 alsa_output.pci-0000_00_1f.3.analog-stereo
+
+set -u -o pipefail
 
 node_id=${1:-}
 sink_name=${2:-}
 old_sink_name=${3:-}
+expected_old_sink_name=$old_sink_name
+expected_old_sink_object=${4:-}
 
-if (( $# < 2 || $# > 3 )) || [[ -z $node_id || -z $sink_name ]]; then
-  echo "Usage: omarchy-audio-output-set-default <node-id> <sink-name> [current-sink-name]" >&2
+if (( $# < 2 || $# > 4 )) || [[ ! $node_id =~ ^[0-9]{1,20}$ || -z $sink_name ]] ||
+    [[ -n $expected_old_sink_object && ! $expected_old_sink_object =~ ^[0-9]{1,20}$ ]]; then
+  echo "Usage: omarchy-audio-output-set-default <node-id> <sink-name> [current-sink-name] [current-sink-id]" >&2
   exit 1
 fi
 
 preferences_file=${OMARCHY_AUDIO_PREFERENCES_FILE:-${XDG_CONFIG_HOME:-${HOME:?}/.config}/omarchy/audio-preferences.json}
 mkdir -p -- "$(dirname -- "$preferences_file")" || exit 1
-exec 8>"${preferences_file}.output.lock" || exit 1
-flock 8 || exit 1
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
-"$script_dir/audio-preferences" show >/dev/null || exit 1
+source "$script_dir/.audio-common"
+audio_acquire_mutation_lock || exit 1
+audio_open_lock_path "${preferences_file}.output.lock" 8 \
+  "Audio output preferences are busy; try again" || exit 1
+/bin/bash "$script_dir/audio-preferences" show >/dev/null || exit 1
+
+valid_identifier() {
+  local value=$1
+  jq -ne --arg value "$value" '
+    ($value | length) > 0 and ($value | length) <= 160
+    and ($value | test("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]") | not)
+  ' >/dev/null
+}
+
+resolve_sink_index() {
+  local identity_name=$1 identity_object=$2 endpoint_json
+  audio_capture_bounded endpoint_json 16777216 \
+    timeout 2 pactl -f json list sinks || return 1
+  jq -er --arg name "$identity_name" --arg object "$identity_object" '
+    if type != "array" or length > 512 then error("invalid sink list") else . end
+    | [ .[] | select(.name == $name) ] as $named
+    | [ .[]
+        | select(((.properties."object.id" // "") | tostring) == $object)
+      ] as $identified
+    | if ($named | length) != 1 or ($identified | length) != 1
+        or (($named[0].properties."object.id" // "") | tostring) != $object
+      then error("ambiguous sink identity")
+      else ($named[0].index | tostring)
+      end
+    | select(test("^[0-9]{1,20}$"))
+  ' <<<"$endpoint_json" 2>/dev/null
+}
+
+valid_identifier "$sink_name" || {
+  echo "Invalid audio output identifier" >&2
+  exit 1
+}
+if [[ -n $old_sink_name ]]; then
+  valid_identifier "$old_sink_name" || {
+    echo "Invalid previous audio output identifier" >&2
+    exit 1
+  }
+fi
 
 # Capture the applications following the old default before changing it.
 # PipeWire records explicit per-application routes in the default metadata, so
 # checking the current sink alone is not enough: an explicitly routed stream may
 # happen to be on the old default and must still remain there.
-live_sink_name=$(timeout 2 pactl get-default-sink 2>/dev/null || true)
-if [[ -n $live_sink_name && $live_sink_name != "$sink_name" ]]; then
-  old_sink_name=$live_sink_name
-elif [[ -z $old_sink_name ]]; then
-  old_sink_name=$live_sink_name
+audio_capture_bounded live_sink_name 1024 timeout 2 pactl get-default-sink || {
+  echo "Could not determine the current default audio output" >&2
+  exit 1
+}
+valid_identifier "$live_sink_name" || {
+  echo "The current default audio output has an invalid identifier" >&2
+  exit 1
+}
+if [[ -n $expected_old_sink_name && $live_sink_name != "$expected_old_sink_name" ]]; then
+  echo "The default audio output changed before the request could begin" >&2
+  exit 1
 fi
-old_sink_index=$(timeout 2 pactl -f json list sinks 2>/dev/null |
-  jq -r --arg name "$old_sink_name" 'map(select(.name == $name))[0].index // empty' || true)
+old_sink_name=$live_sink_name
 
-following_inputs=()
-if [[ -n $old_sink_index && $old_sink_name != "$sink_name" ]]; then
-  if metadata=$(timeout 2 pw-metadata -n default 2>/dev/null); then
-    declare -A explicitly_targeted=()
-    while IFS=$'\t' read -r object_id target; do
-      if [[ $object_id =~ ^[0-9]+$ && $target != "-1" ]]; then
-        explicitly_targeted["$object_id"]=1
-      fi
-    done < <(sed -n "s/^update: id:\([0-9][0-9]*\) key:'target\.\(object\|node\)' value:'\([^']*\)'.*/\1\t\3/p" <<<"$metadata")
+audio_capture_bounded sinks_json 16777216 timeout 2 pactl -f json list sinks || {
+  echo "Could not inspect audio outputs before changing the default" >&2
+  exit 1
+}
+target_sink_record=$(jq -cer --arg name "$sink_name" '
+  if type != "array" or length > 512 then error("invalid sink list")
+  else [.[] | select(.name == $name)] as $matches
+    | if ($matches | length) == 1 then $matches[0]
+      else error("ambiguous sink identity") end
+  end
+' <<<"$sinks_json") || {
+  echo "The requested default audio output is not available" >&2
+  exit 3
+}
+target_sink_object=$(jq -r '.properties."object.id" // "" | tostring' <<<"$target_sink_record") || exit 1
+target_sink_index=$(jq -r '.index // empty | tostring' <<<"$target_sink_record") || exit 1
+[[ $target_sink_index =~ ^[0-9]{1,20}$ ]] || {
+  echo "The requested default audio output has an invalid index" >&2
+  exit 3
+}
+if [[ ! $target_sink_object =~ ^[0-9]{1,20}$ || $target_sink_object != "$node_id" ]]; then
+  echo "The requested audio output changed before it could be selected" >&2
+  exit 3
+fi
 
-    while IFS=$'\t' read -r input object_id; do
-      [[ -n $input ]] || continue
-      if [[ -z $object_id || -z ${explicitly_targeted[$object_id]:-} ]]; then
-        following_inputs+=("$input")
-      fi
-    done < <(timeout 2 pactl -f json list sink-inputs 2>/dev/null |
-      jq -r --arg sink "$old_sink_index" '.[]
-        | select((.sink | tostring) == $sink)
-        | select(.properties."application.name" != null)
-        | select(.properties."application.name" != "EasyEffects")
-        | [.index, (.properties."object.id" // "")]
-        | @tsv' || true)
+if [[ $old_sink_name == "$sink_name" ]]; then
+  if [[ -n $expected_old_sink_object && $target_sink_object != "$expected_old_sink_object" ]]; then
+    echo "The default audio output was replaced before the request could begin" >&2
+    exit 1
   fi
+  /bin/bash "$script_dir/audio-preferences" set-default output "$sink_name" || {
+    echo "The active output preference could not be saved" >&2
+    exit 1
+  }
+  exit 0
 fi
 
-timeout 2 wpctl set-default "$node_id" 2>/dev/null || true
-timeout 2 pactl set-default-sink "$sink_name" 2>/dev/null || true
-
-actual_sink_name=$(timeout 2 pactl get-default-sink 2>/dev/null || true)
-if [[ $actual_sink_name != "$sink_name" ]]; then
-  echo "Could not set the default audio output" >&2
+old_sink_index=
+old_sink_object=
+if [[ -n $old_sink_name && $old_sink_name != "$sink_name" ]]; then
+  old_sink_record=$(jq -r --arg name "$old_sink_name" '
+    if type != "array" or length > 512 then error("invalid sink list")
+    else [.[] | select(.name == $name)] as $matches
+      | if ($matches | length) == 0 then ""
+        elif ($matches | length) == 1 then
+          ($matches[0] | [(.index // ""), (.properties."object.id" // "")] | @tsv)
+        else error("ambiguous sink identity") end
+    end
+  ' <<<"$sinks_json") || {
+    echo "Could not inspect audio outputs before changing the default" >&2
+    exit 1
+  }
+  IFS=$'\t' read -r old_sink_index old_sink_object <<<"$old_sink_record"
+fi
+[[ $old_sink_index =~ ^[0-9]{1,20}$ ]] || {
+  echo "The current default audio output is no longer available" >&2
+  exit 1
+}
+[[ $old_sink_object =~ ^[0-9]{1,20}$ ]] || {
+  echo "The current default audio output has an invalid identity" >&2
+  exit 1
+}
+if [[ -n $expected_old_sink_object && $old_sink_object != "$expected_old_sink_object" ]]; then
+  echo "The default audio output was replaced before the request could begin" >&2
   exit 1
 fi
 
-for input in "${following_inputs[@]}"; do
-  [[ -n $input ]] && timeout 2 pactl move-sink-input "$input" "$sink_name" 2>/dev/null || true
+following_inputs=()
+following_input_objects=()
+if [[ -n $old_sink_index && $old_sink_name != "$sink_name" ]]; then
+  audio_capture_bounded metadata 4194304 timeout 2 pw-metadata -n default || {
+    echo "Could not inspect persistent application routes before changing the default" >&2
+    exit 1
+  }
+  explicit_rows=$(sed -n "s/^update: id:\([0-9][0-9]*\) key:'target\.\(object\|node\)' value:'\([^']*\)'.*/\1\t\3/p" <<<"$metadata" |
+    awk -F '\t' '
+      $2 != "-1" && length($1) <= 20 && $1 ~ /^[0-9]+$/ && !seen[$1]++ {
+        if (++count > 4096) exit 3
+        print $1 "\t" $2
+      }
+    ') || {
+    echo "Persistent application route metadata is too large" >&2
+    exit 1
+  }
+  declare -A explicitly_targeted=()
+  while IFS=$'\t' read -r object_id target; do
+    [[ -n $object_id ]] && explicitly_targeted["$object_id"]=1
+  done <<<"$explicit_rows"
+
+  audio_capture_bounded sink_inputs_json 16777216 \
+    timeout 2 pactl -f json list sink-inputs || {
+    echo "Could not inspect playback streams before changing the default" >&2
+    exit 1
+  }
+  input_rows=$(jq -r --arg sink "$old_sink_index" '
+    if type != "array" or length > 1024 then error("invalid stream list") else . end
+    | [.[]
+      | select((.sink | tostring) == $sink)
+      | select((.properties."application.name" // "") != "EasyEffects")
+    ] as $streams
+    | if ($streams | length) > 512 or any($streams[]?;
+        ((.index | tostring) | test("^[0-9]{1,20}$") | not)
+        or (((.properties."object.id" // "") | tostring)
+          | test("^[0-9]{1,20}$") | not))
+        or (($streams | map(.index | tostring) | unique | length) != ($streams | length))
+        or (($streams | map(.properties."object.id" | tostring) | unique | length)
+          != ($streams | length)) then
+        error("invalid stream identity")
+      else $streams[]
+        | [.index, .properties."object.id"] | @tsv
+      end
+  ' <<<"$sink_inputs_json") || {
+    echo "Could not inspect playback streams before changing the default" >&2
+    exit 1
+  }
+  while IFS=$'\t' read -r input object_id; do
+    [[ -n $input ]] || continue
+    if [[ -z $object_id || -z ${explicitly_targeted[$object_id]:-} ]]; then
+      following_inputs+=("$input")
+      following_input_objects+=("$object_id")
+    fi
+  done <<<"$input_rows"
+fi
+
+rollback_default() {
+  local restored_sink_name restored_sink_index
+  if [[ -z $old_sink_name ]]; then
+    return 1
+  fi
+  restored_sink_name=
+  audio_capture_bounded restored_sink_name 1024 \
+    timeout 2 pactl get-default-sink || true
+  if [[ $restored_sink_name == "$old_sink_name" ]]; then
+    resolve_sink_index "$old_sink_name" "$old_sink_object" >/dev/null || return 1
+    return 0
+  fi
+  if [[ $old_sink_name != "$sink_name" ]]; then
+    restored_sink_index=$(resolve_sink_index \
+      "$old_sink_name" "$old_sink_object") || return 1
+    timeout 2 wpctl set-default "$old_sink_object" 2>/dev/null || true
+    timeout 2 pactl set-default-sink "$old_sink_name" 2>/dev/null || true
+  fi
+  restored_sink_name=
+  audio_capture_bounded restored_sink_name 1024 \
+    timeout 2 pactl get-default-sink || true
+  [[ $restored_sink_name == "$old_sink_name" ]] || return 1
+  resolve_sink_index "$old_sink_name" "$old_sink_object" >/dev/null
+}
+
+target_sink_index=$(resolve_sink_index "$sink_name" "$target_sink_object") || {
+  echo "The requested audio output changed before it could be selected" >&2
+  exit 3
+}
+timeout 2 wpctl set-default "$node_id" 2>/dev/null || true
+timeout 2 pactl set-default-sink "$sink_name" 2>/dev/null || true
+
+actual_sink_name=
+audio_capture_bounded actual_sink_name 1024 timeout 2 pactl get-default-sink || true
+if [[ $actual_sink_name != "$sink_name" ]]; then
+  echo "Could not set the default audio output" >&2
+  rollback_default && exit 1
+  exit 4
+fi
+target_sink_index=$(resolve_sink_index "$sink_name" "$target_sink_object") || {
+  echo "The selected audio output was replaced during the default change" >&2
+  rollback_default && exit 1
+  exit 4
+}
+
+moved_inputs=()
+moved_input_objects=()
+move_failed=false
+for (( follower = 0; follower < ${#following_inputs[@]}; follower++ )); do
+  input=${following_inputs[$follower]}
+  object_id=${following_input_objects[$follower]}
+  audio_capture_bounded current_inputs 16777216 \
+    timeout 2 pactl -f json list sink-inputs || {
+    move_failed=true
+    break
+  }
+  current_row=$(jq -cer --arg object "$object_id" '
+    if type != "array" or length > 1024 then error("invalid stream list")
+    else [.[] | select(((.properties."object.id" // "") | tostring) == $object)] as $matches
+      | if ($matches | length) == 0 then "__gone__"
+        elif ($matches | length) == 1 then $matches[0]
+        else error("ambiguous stream identity") end
+    end
+  ' <<<"$current_inputs" 2>/dev/null) || { move_failed=true; break; }
+  [[ $current_row != __gone__ ]] || continue
+  current_input=$(jq -r '.index // empty | tostring' <<<"$current_row")
+  current_target=$(jq -r '.sink // empty | tostring' <<<"$current_row")
+  [[ $current_input =~ ^[0-9]{1,20}$ && $current_target =~ ^[0-9]{1,20}$ ]] || {
+    move_failed=true
+    break
+  }
+  current_old_index=$(resolve_sink_index "$old_sink_name" "$old_sink_object") || {
+    move_failed=true
+    break
+  }
+  # A concurrent explicit reroute owns the stream once it has left the old
+  # default; do not drag it back into default-following behavior.
+  [[ $current_target == "$current_old_index" ]] || continue
+
+  target_sink_index=$(resolve_sink_index "$sink_name" "$target_sink_object") || {
+    move_failed=true
+    break
+  }
+
+  move_command_failed=false
+  timeout 2 pactl move-sink-input "$current_input" "$sink_name" \
+    2>/dev/null || move_command_failed=true
+  audio_capture_bounded remaining_inputs 16777216 \
+    timeout 2 pactl -f json list sink-inputs || { move_failed=true; break; }
+  moved_row=$(jq -cer --arg object "$object_id" '
+    if type != "array" or length > 1024 then error("invalid stream list")
+    else [.[] | select(((.properties."object.id" // "") | tostring) == $object)] as $matches
+      | if ($matches | length) == 0 then "__gone__"
+        elif ($matches | length) == 1 then $matches[0]
+        else error("ambiguous stream identity") end
+    end
+  ' <<<"$remaining_inputs" 2>/dev/null) || { move_failed=true; break; }
+  [[ $moved_row != __gone__ ]] || continue
+  moved_input=$(jq -r '.index // empty | tostring' <<<"$moved_row")
+  moved_target=$(jq -r '.sink // empty | tostring' <<<"$moved_row")
+  target_sink_index=$(resolve_sink_index "$sink_name" "$target_sink_object") || {
+    move_failed=true
+    break
+  }
+  if [[ $moved_input =~ ^[0-9]{1,20}$ && $moved_target == "$target_sink_index" ]]; then
+    moved_inputs+=("$moved_input")
+    moved_input_objects+=("$object_id")
+    if [[ $move_command_failed == true ]]; then
+      move_failed=true
+      break
+    fi
+  else
+    move_failed=true
+    break
+  fi
 done
 
-if ! "$script_dir/audio-preferences" set-default output "$sink_name"; then
+# Recheck both the logical default and its captured object after moving the
+# followers. A same-name replacement or an external default change must not be
+# persisted as though this transaction completed.
+if [[ $move_failed == false ]]; then
+  final_sink_name=
+  audio_capture_bounded final_sink_name 1024 \
+    timeout 2 pactl get-default-sink || move_failed=true
+  if [[ $move_failed == false && $final_sink_name == "$sink_name" ]]; then
+    resolve_sink_index "$sink_name" "$target_sink_object" >/dev/null || move_failed=true
+  else
+    move_failed=true
+  fi
+fi
+
+rollback_moved_inputs() {
+  local rollback_inputs row current_input current_target object_id live_target_index live_old_index
+  local -a attempted_objects=()
+  for (( moved = 0; moved < ${#moved_input_objects[@]}; moved++ )); do
+    object_id=${moved_input_objects[$moved]}
+    audio_capture_bounded rollback_inputs 16777216 \
+      timeout 2 pactl -f json list sink-inputs || return 1
+    row=$(jq -cer --arg object "$object_id" '
+      if type != "array" or length > 1024 then error("invalid stream list")
+      else [.[] | select(((.properties."object.id" // "") | tostring) == $object)] as $matches
+        | if ($matches | length) == 0 then "__gone__"
+          elif ($matches | length) == 1 then $matches[0]
+          else error("ambiguous stream identity") end
+      end
+    ' <<<"$rollback_inputs" 2>/dev/null) || return 1
+    [[ $row != __gone__ ]] || continue
+    current_input=$(jq -r '.index // empty | tostring' <<<"$row")
+    current_target=$(jq -r '.sink // empty | tostring' <<<"$row")
+    [[ $current_input =~ ^[0-9]{1,20}$ && $current_target =~ ^[0-9]{1,20}$ ]] || return 1
+    live_target_index=$(resolve_sink_index "$sink_name" "$target_sink_object") || return 1
+    [[ $current_target == "$live_target_index" ]] || continue
+    timeout 2 pactl move-sink-input "$current_input" "$old_sink_name" \
+      >/dev/null 2>&1 || true
+    attempted_objects+=("$object_id")
+  done
+  (( ${#attempted_objects[@]} > 0 )) || return 0
+  audio_capture_bounded rollback_inputs 16777216 \
+    timeout 2 pactl -f json list sink-inputs || return 1
+  for object_id in "${attempted_objects[@]}"; do
+    row=$(jq -cer --arg object "$object_id" '
+      if type != "array" or length > 1024 then error("invalid stream list")
+      else [.[] | select(((.properties."object.id" // "") | tostring) == $object)] as $matches
+        | if ($matches | length) == 0 then "__gone__"
+          elif ($matches | length) == 1 then $matches[0]
+          else error("ambiguous stream identity") end
+      end
+    ' <<<"$rollback_inputs" 2>/dev/null) || return 1
+    [[ $row != __gone__ ]] || continue
+    current_target=$(jq -r '.sink // empty | tostring' <<<"$row")
+    [[ $current_target =~ ^[0-9]{1,20}$ ]] || return 1
+    live_old_index=$(resolve_sink_index "$old_sink_name" "$old_sink_object") || return 1
+    [[ $current_target == "$live_old_index" ]] || return 1
+  done
+}
+
+if [[ $move_failed == true ]]; then
+  rollback_complete=true
+  rollback_moved_inputs || rollback_complete=false
+  rollback_default || rollback_complete=false
+  echo "Could not move applications following the default audio output" >&2
+  [[ $rollback_complete == true ]] && exit 1
+  exit 4
+fi
+
+if ! /bin/bash "$script_dir/audio-preferences" set-default output "$sink_name"; then
   echo "The default output changed, but its preference could not be saved" >&2
   exit 2
 fi

--- a/scripts/audio-policy-settings
+++ b/scripts/audio-policy-settings
@@ -6,6 +6,9 @@
 
 set -euo pipefail
 
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+source "$script_dir/.audio-common"
+
 readonly boolean_settings=(
   node.features.audio.mono
   linking.pause-playback
@@ -40,24 +43,38 @@ setting_kind() {
 
 read_raw_setting() {
   local setting=$1 output
-  output=$(wpctl settings "$setting" 2>/dev/null) || return 1
+  audio_capture_bounded output 65536 timeout 3 wpctl settings "$setting" || return 1
   awk '
-    $1 == "Value:" { print $2; found=1; exit }
-    END { if (!found) exit 1 }
+    $1 == "Value:" { count++; value=$2 }
+    END {
+      if (count != 1) exit 1
+      print value
+    }
   ' <<<"$output"
 }
 
+values_equal() {
+  local kind=$1 actual=$2 expected=$3
+  if [[ $kind == boolean ]]; then
+    [[ $actual == "$expected" ]]
+  else
+    jq -ne --arg actual "$actual" --arg expected "$expected" '
+      (($actual | tonumber) - ($expected | tonumber) | fabs) < 0.000001
+    ' >/dev/null 2>&1
+  fi
+}
+
 snapshot() {
-  local result='{}' setting kind raw display
+  local result='{}' setting kind raw display successful_reads=0
 
   for setting in "${boolean_settings[@]}" "${volume_settings[@]}"; do
     kind=$(setting_kind "$setting")
     raw=$(read_raw_setting "$setting") || continue
-
     if [[ $kind == boolean ]]; then
       [[ $raw == true || $raw == false ]] || continue
       result=$(jq -c --arg key "$setting" --argjson value "$raw" \
         '. + {($key): $value}' <<<"$result")
+      successful_reads=$((successful_reads + 1))
       continue
     fi
 
@@ -68,15 +85,26 @@ snapshot() {
     ') || continue
     result=$(jq -c --arg key "$setting" --argjson value "$display" \
       '. + {($key): $value}' <<<"$result")
+    successful_reads=$((successful_reads + 1))
   done
 
+  if (( successful_reads == 0 )); then
+    echo "Could not read any supported audio policy" >&2
+    return 1
+  fi
   printf '%s\n' "$result"
 }
 
 action=${1:-show}
+command -v wpctl >/dev/null 2>&1 || {
+  echo "wpctl is required to manage audio policies" >&2
+  exit 1
+}
+audio_prepare_private_runtime || exit 1
 case "$action" in
   show)
     (( $# <= 1 )) || usage
+    audio_acquire_settings_lock || exit 1
     snapshot
     ;;
   set)
@@ -85,17 +113,29 @@ case "$action" in
     value=$3
     kind=$(setting_kind "$setting") || usage
 
+    audio_acquire_settings_lock || exit 1
+
     # Query first so unsupported settings remain hidden and cannot be created
     # accidentally on WirePlumber versions that do not provide them.
-    read_raw_setting "$setting" >/dev/null || {
+    old_value=$(read_raw_setting "$setting") || {
       echo "Unsupported audio policy: $setting" >&2
       exit 1
     }
 
     if [[ $kind == boolean ]]; then
+      [[ $old_value == true || $old_value == false ]] || {
+        echo "Audio policy returned an invalid current value" >&2
+        exit 1
+      }
       [[ $value == true || $value == false ]] || usage
       wireplumber_value=$value
     else
+      jq -ne --arg value "$old_value" '
+        ($value | tonumber) as $number | $number >= 0 and $number <= 1
+      ' >/dev/null 2>&1 || {
+        echo "Audio policy returned an invalid current value" >&2
+        exit 1
+      }
       wireplumber_value=$(jq -ner --arg value "$value" '
         ($value | tonumber) as $linear
         | select($linear >= 0 and $linear <= 1)
@@ -103,7 +143,26 @@ case "$action" in
       ') || usage
     fi
 
-    wpctl settings --save "$setting" "$wireplumber_value" >/dev/null
+    if values_equal "$kind" "$old_value" "$wireplumber_value"; then
+      snapshot
+      exit 0
+    fi
+
+    timeout 3 wpctl settings --save "$setting" "$wireplumber_value" >/dev/null || true
+    confirmed_value=$(read_raw_setting "$setting") || confirmed_value=
+    if ! values_equal "$kind" "$confirmed_value" "$wireplumber_value"; then
+      if values_equal "$kind" "$confirmed_value" "$old_value"; then
+        echo "Audio policy change was not applied" >&2
+        exit 1
+      fi
+      rollback_complete=false
+      timeout 3 wpctl settings --save "$setting" "$old_value" >/dev/null 2>&1 || true
+      restored_value=$(read_raw_setting "$setting") || restored_value=
+      values_equal "$kind" "$restored_value" "$old_value" && rollback_complete=true
+      echo "Audio policy change could not be verified" >&2
+      [[ $rollback_complete == true ]] || exit 4
+      exit 1
+    fi
     snapshot
     ;;
   *) usage ;;

--- a/scripts/audio-port-set
+++ b/scripts/audio-port-set
@@ -8,11 +8,29 @@ direction=${1:-}
 endpoint=${2:-}
 port=${3:-}
 
+set -u -o pipefail
+
 if (( $# != 3 )) || [[ $direction != "output" && $direction != "input" ]] ||
   [[ -z $endpoint || -z $port ]]; then
   echo "Usage: audio-port-set <output|input> <endpoint> <port>" >&2
   exit 1
 fi
+
+valid_identifier() {
+  local value=$1
+  jq -ne --arg value "$value" '
+    ($value | length) > 0 and ($value | length) <= 160
+    and ($value | test("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]") | not)
+  ' >/dev/null
+}
+valid_identifier "$endpoint" && valid_identifier "$port" || {
+  echo "Invalid audio endpoint or port identifier" >&2
+  exit 1
+}
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+source "$script_dir/.audio-common"
+audio_acquire_mutation_lock "Another audio port change is still finishing" || exit 1
 
 if [[ $direction == "output" ]]; then
   list=sinks
@@ -22,19 +40,163 @@ else
   command=set-source-port
 fi
 
-if ! timeout 2 pactl -f json list "$list" 2>/dev/null | jq -e \
+audio_capture_bounded endpoints 16777216 timeout 2 pactl -f json list "$list" || {
+  echo "Could not inspect audio ports" >&2
+  exit 1
+}
+endpoint_record=$(jq -cer --arg direction "$direction" \
   --arg endpoint "$endpoint" --arg port "$port" '
-    any(.[];
-      .name == $endpoint
-      and (. as $audio_endpoint
-        | any(.ports[]?;
-            .name == $port
-            and (.availability != "not available" or $port == $audio_endpoint.active_port))))
-  ' >/dev/null; then
+    def numeric_id:
+      (tostring | test("^[0-9]{1,20}$"));
+    def active_port_name:
+      .active_port as $active
+      | if ($active | type) == "object" then ($active.name // "")
+        elif ($active | type) == "string" then $active
+        else ""
+        end;
+    if type != "array" or length > 512 then error("invalid endpoint list")
+    else [.[]
+      | select(.name == $endpoint)
+      | select($direction == "output" or (
+          ((.name // "") | endswith(".monitor") | not)
+          and (((.properties // {})["device.class"] // "")
+            | tostring | ascii_downcase) != "monitor"))] as $matches
+      | if ($matches | length) == 0 then empty
+        elif ($matches | length) != 1 then error("ambiguous endpoint identity")
+        else $matches[0] as $audio_endpoint
+          | if (($audio_endpoint.index // "") | numeric_id)
+              and (((($audio_endpoint.properties // {})."object.id" // "") | numeric_id))
+            then . else error("invalid endpoint identity") end
+          | (if ($audio_endpoint.ports | type) == "array"
+              and ($audio_endpoint.ports | length) <= 256
+            then $audio_endpoint.ports else error("invalid port list") end) as $ports
+          | [$ports[] | select(.name == $port)] as $port_matches
+          | if ($port_matches | length) == 0 then empty
+            elif ($port_matches | length) != 1 then error("ambiguous port identity")
+            elif $port_matches[0].availability == "not available"
+                and $port != ($audio_endpoint | active_port_name) then empty
+            else $audio_endpoint end
+        end
+    end
+  ' <<<"$endpoints" 2>/dev/null)
+query_status=$?
+if (( query_status != 0 )); then
+  if (( query_status != 4 )); then
+    echo "Could not inspect audio ports" >&2
+    exit 1
+  fi
   # Exit 3 tells callers the target is absent rather than broken, so scenes
   # can report it as a skipped device instead of a failed step.
   echo "Audio port is not available" >&2
   exit 3
 fi
 
-timeout 2 pactl "$command" "$endpoint" "$port"
+original_port=$(jq -r '
+  def active_port_name:
+    .active_port as $active
+    | if ($active | type) == "object" then ($active.name // "")
+      elif ($active | type) == "string" then $active
+      else ""
+      end;
+  active_port_name
+' <<<"$endpoint_record") || exit 1
+[[ -n $original_port ]] && valid_identifier "$original_port" || {
+  echo "Could not determine the current audio port" >&2
+  exit 1
+}
+endpoint_object_id=$(jq -r '.properties."object.id" // empty | tostring' \
+  <<<"$endpoint_record") || exit 1
+endpoint_index=$(jq -r '.index // empty | tostring' <<<"$endpoint_record") || exit 1
+[[ $endpoint_object_id =~ ^[0-9]{1,20}$ && $endpoint_index =~ ^[0-9]{1,20}$ ]] || exit 1
+[[ $original_port == "$port" ]] && exit 0
+
+endpoint_state() {
+  local expected_port=$1 state
+  audio_capture_bounded state 16777216 \
+    timeout 2 pactl -f json list "$list" || return 1
+  jq -er --arg endpoint "$endpoint" --arg object "$endpoint_object_id" \
+    --arg expected "$expected_port" '
+    def identifier:
+      type == "string" and length > 0 and length <= 160
+      and (test("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]") | not);
+    def active_port_name:
+      .active_port as $active
+      | if ($active | type) == "object" then ($active.name // "")
+        elif ($active | type) == "string" then $active
+        else ""
+        end;
+    if type != "array" or length > 512 then error("invalid endpoint list")
+    else . as $all
+      | [.[] | select((((.properties // {})."object.id" // "") | tostring) == $object)]
+        as $matches
+      | if ($matches | length) == 0 then "__gone__"
+        elif ($matches | length) != 1 then error("ambiguous endpoint identity")
+        else $matches[0] as $audio_endpoint
+          | (($audio_endpoint.index // "") | tostring) as $index
+          | ($audio_endpoint | active_port_name) as $active
+          | if $audio_endpoint.name != $endpoint
+              or ($index | test("^[0-9]{1,20}$") | not)
+              or ($active | identifier | not)
+              or ([ $all[] | select(((.index // "") | tostring) == $index) ] | length) != 1
+              or ($audio_endpoint.ports | type) != "array"
+              or ($audio_endpoint.ports | length) > 256
+            then error("invalid live endpoint")
+            else [$audio_endpoint.ports[] | select(.name == $expected)] as $ports
+              | if $expected != "" and (($ports | length) != 1
+                  or ($ports[0].availability == "not available" and $active != $expected))
+                then error("requested port is unavailable")
+                else [$index, $active] | @tsv end
+            end
+        end
+    end
+  ' <<<"$state"
+}
+
+active_port_is() {
+  local expected=$1 location current_index current_port
+  location=$(endpoint_state "") || return 1
+  [[ $location != "__gone__" ]] || return 1
+  IFS=$'\t' read -r current_index current_port <<<"$location"
+  [[ $current_index =~ ^[0-9]{1,20}$ && $current_port == "$expected" ]]
+}
+
+rollback_port() {
+  local location current_index current_port
+  # A failed command may still have reached the server, so verify the state
+  # independently instead of treating its exit status as authoritative.
+  location=$(endpoint_state "$original_port") || return 1
+  [[ $location != "__gone__" ]] || return 1
+  IFS=$'\t' read -r current_index current_port <<<"$location"
+  [[ $current_index =~ ^[0-9]{1,20}$ ]] || return 1
+  timeout 2 pactl "$command" "$current_index" "$original_port" >/dev/null 2>&1 || true
+  active_port_is "$original_port"
+}
+
+target_location=$(endpoint_state "$port") || {
+  echo "Could not safely resolve the audio endpoint" >&2
+  exit 1
+}
+[[ $target_location != "__gone__" ]] || {
+  echo "Audio endpoint disappeared before the port change" >&2
+  exit 3
+}
+IFS=$'\t' read -r live_endpoint_index live_active_port <<<"$target_location"
+[[ $live_endpoint_index =~ ^[0-9]{1,20}$ ]] || exit 1
+
+if ! timeout 2 pactl "$command" "$live_endpoint_index" "$port"; then
+  if active_port_is "$original_port"; then
+    exit 1
+  fi
+  rollback_port && exit 1
+  echo "Audio port changed after a failed request and could not be restored" >&2
+  exit 4
+fi
+if ! active_port_is "$port"; then
+  if rollback_port; then
+    echo "Audio port change was not applied" >&2
+    exit 1
+  fi
+  echo "Audio port changed, but the requested port was not reported active" >&2
+  exit 4
+fi
+exit 0

--- a/scripts/audio-ports
+++ b/scripts/audio-ports
@@ -8,31 +8,89 @@ if (( $# != 0 )); then
   exit 1
 fi
 
-set -o pipefail
+set -u -o pipefail
+LC_ALL=C
 
-timeout 2 pactl -f json list 2>/dev/null | jq -c '
+maximum_pactl_bytes=16777216
+endpoints_json=$(timeout 2 pactl -f json list 2>/dev/null |
+  head -c "$((maximum_pactl_bytes + 1))") || exit 1
+(( ${#endpoints_json} <= maximum_pactl_bytes )) || {
+  echo "Audio endpoint information is too large" >&2
+  exit 1
+}
+
+if jq -c '
+  def identifier:
+    if type == "string" and length > 0 and length <= 160
+        and (test("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]") | not)
+      then . else "" end;
+  def clean_label($fallback):
+    (if type == "string" then . else "" end
+      | gsub("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]"; " ")
+      | gsub(" +"; " ") | sub("^ +"; "") | sub(" +$"; "") | .[:160])
+    | if length > 0 then . else $fallback end;
+  def active_port_name($endpoint):
+    $endpoint.active_port as $active
+    | (if ($active | type) == "object" then ($active.name // "")
+       elif ($active | type) == "string" then $active
+       else "" end) | identifier;
+
   def usable_ports($endpoint):
-    [
-      $endpoint.ports[]?
-      | select(.availability != "not available" or .name == $endpoint.active_port)
-      | { value: .name, label: (.description // .name) }
-    ];
+    ([
+      (if ($endpoint.ports | type) == "array" then $endpoint.ports[:256] else [] end)[]?
+      | select(type == "object")
+      | (.name | identifier) as $name
+      | select($name != "")
+      | select(.availability != "not available" or $name == active_port_name($endpoint))
+      | { value: $name, label: ((.description // $name) | clean_label($name)) }
+    ]) as $ports
+    | if (($ports | map(.value) | unique | length) != ($ports | length))
+        then error("ambiguous port identity")
+      else $ports[:64] end;
 
   def endpoints($direction; $values):
-    [
-      $values[]?
-      | select($direction == "output" or (.name | endswith(".monitor") | not))
+    ([
+      $values[:512][]?
       | . as $endpoint
-      | usable_ports($endpoint) as $ports
-      | select($ports | length > 1)
-      | {
-          direction: $direction,
-          endpoint: $endpoint.name,
-          label: ($endpoint.description // $endpoint.name),
-          activePort: ($endpoint.active_port // ""),
-          ports: $ports
-        }
-    ];
+      | select(type == "object")
+      | (.name | identifier) as $name
+      | select($name != "")
+      | select($direction == "output" or (
+          ($name | endswith(".monitor") | not)
+          and (((.properties // {})["device.class"] // "")
+            | tostring | ascii_downcase) != "monitor"))
+      | {name: $name, raw: $endpoint}
+    ]) as $candidates
+    | if any($candidates[]?;
+          (((.raw.index // "") | tostring) | test("^[0-9]{1,20}$") | not)
+          or ((((.raw.properties // {})."object.id" // "") | tostring)
+            | test("^[0-9]{1,20}$") | not))
+        or (($candidates | map(.name) | unique | length) != ($candidates | length))
+        or (($candidates | map(.raw.index | tostring) | unique | length)
+          != ($candidates | length))
+        or (($candidates | map((.raw.properties."object.id") | tostring) | unique | length)
+          != ($candidates | length))
+      then error("ambiguous endpoint identity")
+      else [
+        $candidates[]
+        | . as $candidate
+        | usable_ports($candidate.raw) as $ports
+        | select($ports | length > 1)
+        | {
+            direction: $direction,
+            endpoint: $candidate.name,
+            label: (($candidate.raw.description // $candidate.name)
+              | clean_label($candidate.name)),
+            activePort: active_port_name($candidate.raw),
+            ports: $ports
+          }
+      ][:64] end;
 
-  endpoints("output"; (.sinks // [])) + endpoints("input"; (.sources // []))
-' || exit 1
+  if type != "object" then error("expected an endpoint object") else . end
+  | endpoints("output"; (if (.sinks | type) == "array" then .sinks else [] end))
+    + endpoints("input"; (if (.sources | type) == "array" then .sources else [] end))
+' <<<"$endpoints_json"; then
+  :
+else
+  exit 1
+fi

--- a/scripts/audio-preferences
+++ b/scripts/audio-preferences
@@ -6,8 +6,11 @@
 
 set -euo pipefail
 
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+source "$script_dir/.audio-common"
 preferences_file=${OMARCHY_AUDIO_PREFERENCES_FILE:-${XDG_CONFIG_HOME:-${HOME:?}/.config}/omarchy/audio-preferences.json}
 action=${1:-show}
+maximum_store_bytes=1048576
 
 usage() {
   echo "Usage: audio-preferences [show | set-default <output|input> <node-name> | set-profile <bluetooth-address> <profile>]" >&2
@@ -19,20 +22,65 @@ default_preferences() {
 }
 
 read_preferences() {
-  if [[ ! -s $preferences_file ]]; then
+  if [[ -L $preferences_file || (-e $preferences_file && ! -f $preferences_file) ]]; then
+    echo "Audio preferences are not stored in a regular file" >&2
+    return 1
+  elif [[ ! -s $preferences_file ]]; then
     default_preferences
-  elif jq -e 'type == "object"' "$preferences_file" >/dev/null 2>&1; then
-    jq -c '
-      .version = 1
-      | .defaults = (if (.defaults | type) == "object" then .defaults else {} end)
-      | .defaults.output = (if (.defaults.output | type) == "string" then .defaults.output else "" end)
-      | .defaults.input = (if (.defaults.input | type) == "string" then .defaults.input else "" end)
-      | .bluetoothProfiles = (if (.bluetoothProfiles | type) == "object" then .bluetoothProfiles else {} end)
+  elif (( $(stat -c %s -- "$preferences_file" 2>/dev/null || printf '%s' "$((maximum_store_bytes + 1))") > maximum_store_bytes )); then
+    echo "Audio preferences are too large; refusing to overwrite them" >&2
+    return 1
+  elif jq -se 'length == 1 and (.[0] | type) == "object"
+      and ((.[0] | has("version") | not) or .[0].version == 1)' \
+      "$preferences_file" >/dev/null 2>&1; then
+    jq -cs '
+      def clean($maximum):
+        tostring
+        | gsub("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]"; " ")
+        | gsub(" +"; " ")
+        | sub("^ +"; "") | sub(" +$"; "")
+        | .[0:$maximum];
+      def identifier($maximum):
+        if type == "string" and length > 0 and length <= $maximum
+            and (test("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]") | not)
+          then . else "" end;
+      .[0]
+      | (if (.defaults | type) == "object" then .defaults else {} end) as $defaults
+      | (if (.bluetoothProfiles | type) == "object" then .bluetoothProfiles else {} end) as $profiles
+      | {
+          version: 1,
+          defaults: {
+            output: (($defaults.output // "") | identifier(160)),
+            input: (($defaults.input // "") | identifier(160))
+          },
+          bluetoothProfiles: (
+            reduce ([$profiles | to_entries[:512][]?
+              | (.key | ascii_downcase | gsub("[^0-9a-f]"; "")) as $address
+              | (.value | identifier(160)) as $profile
+              | select(($address | test("^[0-9a-f]{12}$")) and $profile != "")
+              | {key: $address, value: $profile}][]) as $entry
+              ({}; if length >= 128 or has($entry.key) then .
+                else .[$entry.key] = $entry.value end)
+          )
+        }
     ' "$preferences_file"
+  elif jq -se 'length == 1 and (.[0] | type) == "object"' \
+      "$preferences_file" >/dev/null 2>&1; then
+    echo "Audio preferences use an unsupported schema version; refusing to overwrite them" >&2
+    return 1
   else
     echo "Audio preferences contain invalid JSON; refusing to overwrite them" >&2
     return 1
   fi
+}
+
+validate_identifier() {
+  local value=$1 maximum=$2
+  jq -ner --arg value "$value" --argjson maximum "$maximum" '
+    $value
+    | select(length > 0 and length <= $maximum)
+    | select(test("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]") | not)
+  '
 }
 
 write_preferences() {
@@ -43,8 +91,8 @@ write_preferences() {
   preferences_dir=$(dirname -- "$preferences_file")
   mkdir -p -- "$preferences_dir"
   lock_file="${preferences_file}.lock"
-  exec 9>"$lock_file"
-  flock 9
+  audio_open_lock_path "$lock_file" 9 \
+    "Audio preferences are busy; try again" || return 1
 
   temporary_file=$(mktemp "$preferences_dir/.audio-preferences.XXXXXX")
   trap 'rm -f -- "$temporary_file"' EXIT
@@ -66,7 +114,7 @@ case "$action" in
   set-default)
     (( $# == 3 )) || usage
     direction=$2
-    node_name=$3
+    node_name=$(validate_identifier "$3" 160) || usage
     [[ $direction == output || $direction == input ]] || usage
     [[ -n $node_name ]] || usage
     write_preferences \
@@ -77,7 +125,7 @@ case "$action" in
     (( $# == 3 )) || usage
     address=${2,,}
     address=${address//[^0-9a-f]/}
-    profile=$3
+    profile=$(validate_identifier "$3" 160) || usage
     [[ $address =~ ^[0-9a-f]{12}$ && -n $profile ]] || usage
     write_preferences \
       '.version = 1 | .bluetoothProfiles[$address] = $profile' \

--- a/scripts/audio-profile-set
+++ b/scripts/audio-profile-set
@@ -13,13 +13,37 @@ if (( $# != 2 )) || [[ -z $card || -z $profile ]]; then
   exit 1
 fi
 
-set -o pipefail
+set -u -o pipefail
 
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
-profiles=$("$script_dir/audio-profiles") || exit 1
-profile_state=$(jq -c --arg card "$card" --arg profile "$profile" '
-  [.[] | select(.name == $card) | .profiles[] | select(.value == $profile)][0] // empty
+valid_identifier() {
+  local value=$1
+  jq -ne --arg value "$value" '
+    ($value | length) > 0 and ($value | length) <= 160
+    and ($value | test("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]") | not)
+  ' >/dev/null
+}
+valid_identifier "$card" && valid_identifier "$profile" || {
+  echo "Invalid card or profile identifier" >&2
+  exit 1
+}
+
+source "$script_dir/.audio-common"
+audio_acquire_mutation_lock "Another audio profile change is still finishing" || exit 1
+
+profiles=$(/bin/bash "$script_dir/audio-profiles") || exit 1
+card_state=$(jq -c --arg card "$card" '
+  [.[] | select(.name == $card)] as $matches
+  | if ($matches | length) == 1 then $matches[0]
+    elif ($matches | length) == 0 then empty
+    else error("ambiguous card identity") end
 ' <<<"$profiles") || exit 1
+profile_state=$(jq -c --arg profile "$profile" '
+  [.profiles[] | select(.value == $profile)] as $matches
+  | if ($matches | length) == 1 then $matches[0]
+    elif ($matches | length) == 0 then empty
+    else error("ambiguous profile identity") end
+' <<<"$card_state") || exit 1
 if [[ -z $profile_state ]]; then
   echo "Profile is not available for this device" >&2
   exit 3
@@ -29,107 +53,422 @@ expected_sources=$(jq -r '.sources // 0' <<<"$profile_state")
 [[ $expected_sinks =~ ^[0-9]+$ ]] || expected_sinks=0
 [[ $expected_sources =~ ^[0-9]+$ ]] || expected_sources=0
 
-# Exit codes: 0 changed (or was already active), 2 saved but preference lost,
-# 3 target card or profile absent, 1 everything else.
-card_info=$(timeout 2 pactl -f json list cards 2>/dev/null |
-  jq -c --arg card "$card" 'map(select(.name == $card))[0] // empty') || exit 1
+bluetooth=$(jq -r '.bluetooth == true' <<<"$card_state")
+bluetooth_address=$(jq -r '.address // ""' <<<"$card_state")
+normalized_address=${bluetooth_address,,}
+normalized_address=${normalized_address//[^0-9a-f]/}
+
+save_profile_preference() {
+  [[ $bluetooth == true ]] || return 0
+  [[ $normalized_address =~ ^[0-9a-f]{12}$ ]] || return 1
+  /bin/bash "$script_dir/audio-preferences" set-profile "$normalized_address" "$profile"
+}
+
+# A Bluetooth profile choice is also the shared preference used after a
+# temporary headset-mode switch. Validate that store before touching hardware,
+# matching the default-device helpers' no-partial-change guarantee.
+if [[ $bluetooth == true ]]; then
+  [[ $normalized_address =~ ^[0-9a-f]{12}$ ]] || {
+    echo "Bluetooth device address is not available" >&2
+    exit 1
+  }
+  /bin/bash "$script_dir/audio-preferences" show >/dev/null || exit 1
+fi
+
+# Exit codes: 0 changed (or was already active), 2 changed but preference lost,
+# 3 target card or profile absent, 4 changed/unknown with incomplete recovery,
+# and 1 for a verified unchanged failure.
+audio_capture_bounded live_cards 16777216 timeout 2 pactl -f json list cards || exit 1
+card_info=$(jq -c --arg card "$card" '
+  if type != "array" or length > 512 then error("invalid card list")
+  else [.[] | select(.name == $card)] as $matches
+    | if ($matches | length) == 1 then $matches[0] as $candidate
+      | (($candidate.index // "") | tostring) as $index
+      | (((($candidate.properties // {})."object.id" // "") | tostring)) as $object
+      | if ($index | test("^[0-9]{1,20}$"))
+          and ([.[] | select(((.index // "") | tostring) == $index)] | length) == 1
+          and ($object == "" or (($object | test("^[0-9]{1,20}$"))
+            and ([.[]
+              | select((((.properties // {})."object.id" // "") | tostring) == $object)]
+              | length) == 1))
+        then $candidate else error("ambiguous card identity") end
+      elif ($matches | length) == 0 then empty
+      else error("ambiguous card identity") end
+  end
+' <<<"$live_cards") || exit 1
 [[ -n $card_info ]] || {
   echo "Audio card is not available" >&2
   exit 3
 }
 card_index=$(jq -r '.index // empty' <<<"$card_info") || exit 1
-[[ $card_index =~ ^[0-9]+$ ]] || exit 1
+[[ $card_index =~ ^[0-9]{1,20}$ ]] || exit 1
+card_object_id=$(jq -r '.properties."object.id" // empty | tostring' <<<"$card_info") || exit 1
+[[ -z $card_object_id || $card_object_id =~ ^[0-9]{1,20}$ ]] || exit 1
 
 # Re-applying the active profile would run the whole mute-restore dance for
 # nothing, which briefly silences playback and can leave endpoints muted if
 # endpoints never come back. Treat it as done.
 active_profile=$(jq -r '.active_profile // empty' <<<"$card_info")
+valid_identifier "$active_profile" || {
+  echo "The current audio profile identity is invalid" >&2
+  exit 1
+}
 if [[ -n $active_profile && $active_profile == "$profile" ]]; then
+  if ! save_profile_preference; then
+    echo "The audio profile is active, but its preference could not be saved" >&2
+    exit 2
+  fi
   exit 0
 fi
 
 read_endpoint_states() {
   local endpoint_type=$1
-  timeout 2 pactl -f json list "$endpoint_type" 2>/dev/null |
-    jq -c --argjson card "$card_index" '
-      map(
-        select(.card == $card)
-        | {
-            index: .index,
-            name: (.name // ""),
-            mute: (.mute // false),
-            volumes: [
-              .volume // {}
-              | to_entries[]?
-              | if .value.value != null then (.value.value | tostring)
-                else (.value.value_percent // empty)
-                end
-            ]
-          }
-      )
-    '
+  local endpoint_json
+  audio_capture_bounded endpoint_json 16777216 \
+    timeout 2 pactl -f json list "$endpoint_type" || return 1
+  jq -c --argjson card "$card_index" '
+    def valid_identifier:
+      type == "string" and length > 0 and length <= 160
+      and (test("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]") | not);
+    def endpoint_volumes:
+      (.volume // {})
+      | if type != "object" or length > 64 then error("invalid endpoint volume")
+        else [to_entries[]?
+          | if (.value.value | type) == "number"
+              and .value.value >= 0 and .value.value <= 1000000000 then
+              (.value.value | floor | tostring)
+            elif (.value.value_percent | type) == "string"
+              and (.value.value_percent | test("^[0-9]{1,4}%$")) then
+              .value.value_percent
+            else error("invalid endpoint volume") end]
+        end;
+    if type != "array" or length > 512 then error("invalid endpoint list") else . end
+    | map(select(.card == $card)) as $endpoints
+    | if ($endpoints | length) > 64
+        or (($endpoints | map(.name) | unique | length) != ($endpoints | length))
+        or (($endpoints | map(.index | tostring) | unique | length) != ($endpoints | length))
+        or (($endpoints | map(.properties."object.id" | tostring) | unique | length)
+          != ($endpoints | length))
+        or any($endpoints[]?;
+          ((.index | tostring) | test("^[0-9]{1,20}$") | not)
+          or (((.properties."object.id" // "") | tostring)
+            | test("^[0-9]{1,20}$") | not)
+          or ((.name | valid_identifier) | not)
+          or ((.mute | type) != "boolean")) then
+        error("invalid endpoint state")
+      else $endpoints | map({
+          index: .index,
+          object: (.properties."object.id" | tostring),
+          name: .name,
+          mute: .mute,
+          volumes: endpoint_volumes
+        })
+      end
+  ' <<<"$endpoint_json"
 }
 
-sink_states=$(read_endpoint_states sinks) || sink_states='[]'
-source_states=$(read_endpoint_states sources) || source_states='[]'
-jq -e 'type == "array"' <<<"$sink_states" >/dev/null 2>&1 || sink_states='[]'
-jq -e 'type == "array"' <<<"$source_states" >/dev/null 2>&1 || source_states='[]'
+read_card_active_profile() {
+  local cards_json value
+  audio_capture_bounded cards_json 16777216 \
+    timeout 2 pactl -f json list cards || return 1
+  value=$(jq -er --arg card "$card" --arg index "$card_index" \
+    --arg object "$card_object_id" '
+    if type != "array" or length > 512 then error("invalid card list")
+    else . as $all
+      | [.[]
+      | select(.name == $card and ((.index // "") | tostring) == $index)
+      | select($object == ""
+          or (((.properties."object.id" // "") | tostring) == $object))] as $matches
+      | if ($matches | length) == 1 then $matches[0] as $candidate
+        | if (($candidate.active_profile // null) | type) == "string"
+            and ([ $all[] | select(((.index // "") | tostring) == $index) ] | length) == 1
+            and ($object == "" or ([ $all[]
+              | select((((.properties // {})."object.id" // "") | tostring) == $object) ]
+              | length) == 1)
+          then $candidate.active_profile
+          else error("ambiguous card identity") end
+        else error("ambiguous card identity") end
+    end
+  ' <<<"$cards_json") || return 1
+  valid_identifier "$value" || return 1
+  printf '%s\n' "$value"
+}
+
+read_card_active_profile_with_retry() {
+  local attempt value
+  for (( attempt = 0; attempt < 6; attempt++ )); do
+    value=$(read_card_active_profile 2>/dev/null || true)
+    if [[ -n $value ]]; then
+      printf '%s\n' "$value"
+      return 0
+    fi
+    (( attempt == 5 )) || sleep 0.05
+  done
+  return 1
+}
+
+resolve_endpoint_object() {
+  local endpoint_kind=$1 endpoint_object=$2 current_states matches
+  [[ $endpoint_kind == sink || $endpoint_kind == source ]] || return 1
+  [[ $endpoint_object =~ ^[0-9]{1,20}$ ]] || return 1
+  current_states=$(read_endpoint_states "${endpoint_kind}s") || return 1
+  matches=$(jq -c --arg object "$endpoint_object" \
+    '[.[] | select(.object == $object)]' <<<"$current_states") || return 1
+  [[ $(jq 'length' <<<"$matches") == 1 ]] || return 1
+  jq -c '.[0]' <<<"$matches"
+}
+
+set_endpoint_mute_for_object() {
+  local endpoint_kind=$1 endpoint_object=$2 desired=$3 live_state endpoint_name
+  [[ $desired == true || $desired == false ]] || return 1
+  live_state=$(resolve_endpoint_object "$endpoint_kind" "$endpoint_object") || return 1
+  endpoint_name=$(jq -r '.name // empty' <<<"$live_state")
+  [[ -n $endpoint_name ]] || return 1
+  timeout 2 pactl "set-${endpoint_kind}-mute" "$endpoint_name" "$desired" \
+    >/dev/null 2>&1 || true
+  live_state=$(resolve_endpoint_object "$endpoint_kind" "$endpoint_object") || return 1
+  jq -e --argjson desired "$desired" '.mute == $desired' \
+    <<<"$live_state" >/dev/null
+}
+
+verify_endpoint_object_mutes() {
+  local endpoint_kind=$1 states=$2 desired=$3 current_states
+  current_states=$(read_endpoint_states "${endpoint_kind}s") || return 1
+  jq -e --argjson saved "$states" --argjson desired "$desired" '
+    . as $current
+    | all($saved[];
+        . as $saved_endpoint
+        | [ $current[] | select(.object == $saved_endpoint.object) ] as $matches
+        | ($matches | length) == 1 and $matches[0].mute == $desired)
+  ' <<<"$current_states" >/dev/null
+}
+
+sink_states=$(read_endpoint_states sinks) || {
+  echo "Could not inspect audio outputs before changing the profile" >&2
+  exit 1
+}
+source_states=$(read_endpoint_states sources) || {
+  echo "Could not inspect audio inputs before changing the profile" >&2
+  exit 1
+}
+jq -e 'type == "array"' <<<"$sink_states" >/dev/null 2>&1 || exit 1
+jq -e 'type == "array"' <<<"$source_states" >/dev/null 2>&1 || exit 1
+original_sink_count=$(jq 'length' <<<"$sink_states")
+original_source_count=$(jq 'length' <<<"$source_states")
+
+# The endpoint snapshots are only meaningful while the card still has the
+# captured identity and profile. Refuse before muting anything if policy has
+# already replaced or changed it.
+snapshot_active_profile=$(read_card_active_profile_with_retry 2>/dev/null || true)
+[[ $snapshot_active_profile == "$active_profile" ]] || {
+  echo "The audio card changed while its endpoint state was inspected" >&2
+  exit 1
+}
 
 # Profile changes recreate endpoints, and a newly exposed sink can carry a
 # previously stored 100% volume. Mute the old endpoint, create the new one,
 # restore its level first, and only then restore the original mute state.
-mapfile -t old_sinks < <(jq -r '.[].index | select(type == "number")' <<<"$sink_states")
-mapfile -t old_sources < <(jq -r '.[].index | select(type == "number")' <<<"$source_states")
-for sink_index in "${old_sinks[@]}"; do
-  [[ $sink_index =~ ^[0-9]+$ ]] || continue
-  timeout 2 pactl set-sink-mute "$sink_index" true >/dev/null 2>&1 || true
+mapfile -t old_sinks < <(jq -r '.[].name' <<<"$sink_states")
+mapfile -t old_sources < <(jq -r '.[].name' <<<"$source_states")
+mapfile -t old_sink_objects < <(jq -r '.[].object' <<<"$sink_states")
+mapfile -t old_source_objects < <(jq -r '.[].object' <<<"$source_states")
+prepare_failed=false
+for sink_object in "${old_sink_objects[@]}"; do
+  set_endpoint_mute_for_object sink "$sink_object" true || prepare_failed=true
 done
-for source_index in "${old_sources[@]}"; do
-  [[ $source_index =~ ^[0-9]+$ ]] || continue
-  timeout 2 pactl set-source-mute "$source_index" true >/dev/null 2>&1 || true
+for source_object in "${old_source_objects[@]}"; do
+  set_endpoint_mute_for_object source "$source_object" true || prepare_failed=true
 done
 
+# Command status is not authoritative: Pulse can fail after applying a mute,
+# or report success without changing a concurrently replaced endpoint.
+verify_endpoint_object_mutes sink "$sink_states" true || prepare_failed=true
+verify_endpoint_object_mutes source "$source_states" true || prepare_failed=true
+
 old_sink_inputs=()
+old_sink_input_objects=()
 old_sink_input_mutes=()
 if (( ${#old_sinks[@]} > 0 )); then
   old_sinks_json=$(jq -c '[.[].index | select(type == "number")]' <<<"$sink_states")
-  while IFS=$'\t' read -r input_index input_muted; do
-    [[ $input_index =~ ^[0-9]+$ ]] || continue
-    old_sink_inputs+=("$input_index")
-    old_sink_input_mutes+=("$input_muted")
-    timeout 2 pactl set-sink-input-mute "$input_index" true >/dev/null 2>&1 || true
-  done < <(timeout 2 pactl -f json list sink-inputs 2>/dev/null |
-    jq -r --argjson sinks "$old_sinks_json" '
-      .[] | select(.sink as $sink | $sinks | index($sink)) | [.index, (.mute // false)] | @tsv
-    ' || true)
+  audio_capture_bounded sink_inputs_json 16777216 \
+    timeout 2 pactl -f json list sink-inputs || prepare_failed=true
+  if [[ $prepare_failed == false ]]; then
+    input_rows=$(jq -r --argjson sinks "$old_sinks_json" '
+      if type != "array" or length > 1024 then error("invalid stream list") else . end
+      | [.[] | select(.sink as $sink | $sinks | index($sink))] as $streams
+      | if ($streams | length) > 512
+          or (($streams | map(.index | tostring) | unique | length)
+            != ($streams | length))
+          or (($streams | map(.properties."object.id" | tostring) | unique | length)
+            != ($streams | length))
+          or any($streams[]?;
+          ((.index | tostring) | test("^[0-9]{1,20}$") | not)
+          or (((.properties."object.id" // "") | tostring)
+            | test("^[0-9]{1,20}$") | not)
+          or ((.mute | type) != "boolean")) then
+          error("invalid stream state")
+        else $streams[]
+          | [.index, .properties."object.id", .mute] | @tsv
+        end
+    ' <<<"$sink_inputs_json") || prepare_failed=true
+  fi
+  if [[ $prepare_failed == false ]]; then
+    while IFS=$'\t' read -r input_index input_object input_muted; do
+      [[ $input_index =~ ^[0-9]{1,20}$ && $input_object =~ ^[0-9]{1,20}$ ]] || continue
+      old_sink_inputs+=("$input_index")
+      old_sink_input_objects+=("$input_object")
+      old_sink_input_mutes+=("$input_muted")
+      timeout 2 pactl set-sink-input-mute "$input_index" true >/dev/null 2>&1 || true
+    done <<<"$input_rows"
+  fi
 fi
 
+verify_prepared_sink_inputs() {
+  local current_inputs objects_json
+  (( ${#old_sink_inputs[@]} > 0 )) || return 0
+  audio_capture_bounded current_inputs 16777216 \
+    timeout 2 pactl -f json list sink-inputs || return 1
+  objects_json=$(printf '%s\n' "${old_sink_input_objects[@]}" |
+    jq -Rsc 'split("\n")[:-1]') || return 1
+  # Vanished streams are already safe. If the same stream still exists, its
+  # actual mute flag must confirm preparation regardless of command status.
+  jq -e --argjson objects "$objects_json" '
+    . as $streams
+    | type == "array" and length <= 1024
+      and all($objects[];
+        . as $object
+        | [$streams[]?
+            | select(((.properties."object.id" // "") | tostring) == $object)] as $matches
+        | ($matches | length) == 0
+          or (($matches | length) == 1 and $matches[0].mute == true))
+  ' <<<"$current_inputs" >/dev/null
+}
+verify_prepared_sink_inputs || prepare_failed=true
+
+restore_failed=false
 restore_sink_inputs() {
+  local current_inputs final_inputs input_index input_object input_muted matches
+  local -a restore_objects=() restore_mutes=()
+  (( ${#old_sink_inputs[@]} > 0 )) || return
+  audio_capture_bounded current_inputs 16777216 \
+    timeout 2 pactl -f json list sink-inputs || {
+    restore_failed=true
+    return
+  }
   for (( input = 0; input < ${#old_sink_inputs[@]}; input++ )); do
-    timeout 2 pactl set-sink-input-mute \
-      "${old_sink_inputs[$input]}" "${old_sink_input_mutes[$input]}" >/dev/null 2>&1 || true
+    input_index=${old_sink_inputs[$input]}
+    input_object=${old_sink_input_objects[$input]}
+    input_muted=${old_sink_input_mutes[$input]}
+    # A vanished stream needs no restoration, and a reused Pulse index must
+    # never transfer the previous application's mute state to a new process.
+    matches=$(jq -c --arg object "$input_object" '
+      if type != "array" or length > 1024 then error("invalid stream list")
+      else [.[]? | select(((.properties."object.id" // "") | tostring) == $object)] end
+    ' <<<"$current_inputs" 2>/dev/null) || {
+      restore_failed=true
+      continue
+    }
+    case $(jq 'length' <<<"$matches") in
+      0) continue ;;
+      1) ;;
+      *) restore_failed=true; continue ;;
+    esac
+    input_index=$(jq -r '.[0].index // empty' <<<"$matches")
+    [[ $input_index =~ ^[0-9]{1,20}$ ]] || {
+      restore_failed=true
+      continue
+    }
+    timeout 2 pactl set-sink-input-mute "$input_index" "$input_muted" \
+      >/dev/null 2>&1 || true
+    restore_objects+=("$input_object")
+    restore_mutes+=("$input_muted")
+  done
+  (( ${#restore_objects[@]} > 0 )) || return
+  audio_capture_bounded final_inputs 16777216 \
+    timeout 2 pactl -f json list sink-inputs || {
+    restore_failed=true
+    return
+  }
+  for (( input = 0; input < ${#restore_objects[@]}; input++ )); do
+    input_object=${restore_objects[$input]}
+    input_muted=${restore_mutes[$input]}
+    matches=$(jq -c --arg object "$input_object" '
+      if type != "array" or length > 1024 then error("invalid stream list")
+      else [.[]? | select(((.properties."object.id" // "") | tostring) == $object)] end
+    ' <<<"$final_inputs" 2>/dev/null) || {
+      restore_failed=true
+      continue
+    }
+    case $(jq 'length' <<<"$matches") in
+      0) continue ;;
+      1)
+        jq -e --argjson muted "$input_muted" '.[0].mute == $muted' \
+          <<<"$matches" >/dev/null 2>&1 || restore_failed=true
+        ;;
+      *) restore_failed=true ;;
+    esac
   done
 }
 
 restore_endpoint_mutes() {
   local endpoint_kind=$1
   local states=$2
-  local count index endpoint_index endpoint_muted
+  local count index endpoint_name endpoint_object endpoint_muted current_states matches
   count=$(jq 'length' <<<"$states")
   for (( index = 0; index < count; index++ )); do
-    endpoint_index=$(jq -r --argjson index "$index" '.[$index].index // empty' <<<"$states")
+    endpoint_object=$(jq -r --argjson index "$index" '.[$index].object // empty' <<<"$states")
     endpoint_muted=$(jq -r --argjson index "$index" '.[$index].mute // false' <<<"$states")
-    [[ $endpoint_index =~ ^[0-9]+$ ]] || continue
-    timeout 2 pactl "set-${endpoint_kind}-mute" "$endpoint_index" "$endpoint_muted" >/dev/null 2>&1 || true
+    [[ $endpoint_object =~ ^[0-9]{1,20}$ ]] || {
+      restore_failed=true
+      continue
+    }
+    current_states=$(read_endpoint_states "${endpoint_kind}s") || {
+      restore_failed=true
+      continue
+    }
+    matches=$(jq -c --arg object "$endpoint_object" \
+      '[.[] | select(.object == $object)]' <<<"$current_states") || {
+      restore_failed=true
+      continue
+    }
+    case $(jq 'length' <<<"$matches") in
+      0) continue ;;
+      1) endpoint_name=$(jq -r '.[0].name // empty' <<<"$matches") ;;
+      *) restore_failed=true; continue ;;
+    esac
+    [[ -n $endpoint_name ]] || {
+      restore_failed=true
+      continue
+    }
+    timeout 2 pactl "set-${endpoint_kind}-mute" "$endpoint_name" "$endpoint_muted" >/dev/null 2>&1 || true
   done
+  current_states=$(read_endpoint_states "${endpoint_kind}s") || {
+    restore_failed=true
+    return
+  }
+  jq -e --argjson saved "$states" '
+    . as $current
+    | all($saved[];
+        . as $saved_endpoint
+        | [ $current[] | select(.object == $saved_endpoint.object) ] as $matches
+        | ($matches | length) == 0
+          or (($matches | length) == 1 and $matches[0].mute == $saved_endpoint.mute))
+  ' <<<"$current_states" >/dev/null || restore_failed=true
 }
 
-if ! timeout 2 pactl set-card-profile "$card" "$profile"; then
+if [[ $prepare_failed == true ]]; then
   restore_endpoint_mutes sink "$sink_states"
   restore_endpoint_mutes source "$source_states"
   restore_sink_inputs
+  echo "Could not safely mute current audio before changing the profile" >&2
+  [[ $restore_failed == false ]] || exit 4
   exit 1
 fi
+
+# Do not trust the command status alone. Pulse can report a transport error
+# after the profile has already changed; the live card state below is the
+# authority and the same endpoint restoration must run in either case.
+timeout 2 pactl set-card-profile "$card" "$profile" || true
 
 new_sink_states='[]'
 new_source_states='[]'
@@ -142,7 +481,19 @@ for (( attempt = 0; attempt < 40; attempt++ )); do
   new_source_states=$(read_endpoint_states sources) || new_source_states='[]'
   new_sink_count=$(jq 'length' <<<"$new_sink_states")
   new_source_count=$(jq 'length' <<<"$new_source_states")
-  (( new_sink_count >= expected_sinks && new_source_count >= expected_sources )) && break
+  sink_count_ready=false
+  source_count_ready=false
+  if (( expected_sinks == 0 )); then
+    (( new_sink_count == 0 )) && sink_count_ready=true
+  else
+    (( new_sink_count >= expected_sinks )) && sink_count_ready=true
+  fi
+  if (( expected_sources == 0 )); then
+    (( new_source_count == 0 )) && source_count_ready=true
+  else
+    (( new_source_count >= expected_sources )) && source_count_ready=true
+  fi
+  $sink_count_ready && $source_count_ready && break
   (( $(date +%s%3N) >= wait_deadline )) && break
   sleep 0.05
 done
@@ -151,81 +502,269 @@ restore_new_endpoint_states() {
   local endpoint_kind=$1
   local old_states=$2
   local new_states=$3
-  local count index endpoint_index endpoint_name new_state saved_state restore_state
+  local expected_profile=${4:-}
+  local count index endpoint_index endpoint_name endpoint_object new_state live_state
+  local saved_state restore_state current_states live_profile
   local saved_count new_channel_count endpoint_muted
   local -a saved_volumes volume_arguments
+  local expected_states='[]' expected_volumes
 
-  count=$(jq 'length' <<<"$new_states")
+  count=$(jq -er 'if type == "array" and length <= 64 then length
+    else error("invalid endpoint snapshot") end' <<<"$new_states") || {
+    restore_failed=true
+    return
+  }
+  if [[ -n $expected_profile ]]; then
+    live_profile=$(read_card_active_profile 2>/dev/null || true)
+    if [[ $live_profile != "$expected_profile" ]]; then
+      restore_failed=true
+      return
+    fi
+  fi
 
   # Mute every newly exposed endpoint before restoring any of them. This keeps
   # later endpoints from becoming audible while an earlier one is configured.
+  # Resolve every command from the captured PipeWire object immediately before
+  # use, so a same-name replacement cannot inherit its predecessor's state.
   for (( index = 0; index < count; index++ )); do
-    endpoint_index=$(jq -r --argjson index "$index" '.[$index].index // empty' <<<"$new_states")
-    [[ $endpoint_index =~ ^[0-9]+$ ]] || continue
-    timeout 2 pactl "set-${endpoint_kind}-mute" "$endpoint_index" true >/dev/null 2>&1 || true
+    endpoint_object=$(jq -r --argjson index "$index" '.[$index].object // empty' \
+      <<<"$new_states")
+    set_endpoint_mute_for_object "$endpoint_kind" "$endpoint_object" true ||
+      restore_failed=true
   done
+  verify_endpoint_object_mutes "$endpoint_kind" "$new_states" true || restore_failed=true
 
   for (( index = 0; index < count; index++ )); do
     new_state=$(jq -c --argjson index "$index" '.[$index]' <<<"$new_states")
     endpoint_index=$(jq -r '.index // empty' <<<"$new_state")
     endpoint_name=$(jq -r '.name // ""' <<<"$new_state")
-    [[ $endpoint_index =~ ^[0-9]+$ ]] || continue
+    endpoint_object=$(jq -r '.object // empty' <<<"$new_state")
+    if [[ ! $endpoint_index =~ ^[0-9]{1,20}$ || -z $endpoint_name
+        || ! $endpoint_object =~ ^[0-9]{1,20}$ ]]; then
+      restore_failed=true
+      continue
+    fi
+    live_state=$(resolve_endpoint_object "$endpoint_kind" "$endpoint_object") || {
+      restore_failed=true
+      continue
+    }
 
     # Names remain stable for many profile changes. When a profile changes the
     # endpoint name too, preserve state by endpoint order instead of copying the
     # first endpoint's state to every new endpoint.
-    saved_state=$(jq -c --arg name "$endpoint_name" --argjson index "$index" '
-      ([.[] | select(.name == $name)][0] // .[$index] // empty)
+    saved_state=$(jq -c --arg name "$endpoint_name" --argjson index "$index" \
+      --argjson live_index "$endpoint_index" '
+      ([.[] | select(.name == $name)][0]
+        // (.[$index] | select(.index != $live_index))
+        // empty)
     ' <<<"$old_states")
     restore_state=${saved_state:-$new_state}
+    expected_volumes='null'
 
     if [[ -n $saved_state ]]; then
       mapfile -t saved_volumes < <(jq -r '.volumes[]?' <<<"$saved_state")
       saved_count=${#saved_volumes[@]}
-      new_channel_count=$(jq '.volumes | length' <<<"$new_state")
+      new_channel_count=$(jq '.volumes | length' <<<"$live_state")
       if (( saved_count > 0 )); then
         if (( saved_count == new_channel_count )); then
           volume_arguments=("${saved_volumes[@]}")
         else
           volume_arguments=("${saved_volumes[0]}")
         fi
-        timeout 2 pactl "set-${endpoint_kind}-volume" "$endpoint_index" \
+        endpoint_name=$(jq -r '.name // empty' <<<"$live_state")
+        [[ -n $endpoint_name ]] || {
+          restore_failed=true
+          continue
+        }
+        timeout 2 pactl "set-${endpoint_kind}-volume" "$endpoint_name" \
           "${volume_arguments[@]}" >/dev/null 2>&1 || true
+        if (( saved_count == new_channel_count )); then
+          expected_volumes=$(printf '%s\n' "${saved_volumes[@]}" | jq -Rsc 'split("\n")[:-1]')
+        else
+          expected_volumes=$(jq -cn --arg value "${saved_volumes[0]}" \
+            --argjson count "$new_channel_count" '[range(0; $count) | $value]')
+        fi
       fi
     fi
 
     endpoint_muted=$(jq -r '.mute // false' <<<"$restore_state")
-    timeout 2 pactl "set-${endpoint_kind}-mute" "$endpoint_index" "$endpoint_muted" >/dev/null 2>&1 || true
+    set_endpoint_mute_for_object "$endpoint_kind" "$endpoint_object" \
+      "$endpoint_muted" || restore_failed=true
+    expected_states=$(jq -c --arg object "$endpoint_object" \
+      --argjson muted "$endpoint_muted" --argjson volumes "$expected_volumes" '
+        . + [{object: $object, mute: $muted, volumes: $volumes}]
+      ' <<<"$expected_states") || {
+      restore_failed=true
+      continue
+    }
   done
-}
 
-restore_new_endpoint_states sink "$sink_states" "$new_sink_states"
-restore_new_endpoint_states source "$source_states" "$new_source_states"
+  current_states=$(read_endpoint_states "${endpoint_kind}s") || {
+    restore_failed=true
+    return
+  }
+  jq -e --argjson expected "$expected_states" '
+    . as $current
+    | all($expected[];
+        . as $wanted
+        | [ $current[] | select(.object == $wanted.object) ] as $matches
+        | ($matches | length) == 1
+          and $matches[0].mute == $wanted.mute
+          and ($wanted.volumes == null or $matches[0].volumes == $wanted.volumes))
+  ' <<<"$current_states" >/dev/null || restore_failed=true
+}
 
 restore_surviving_endpoint_mutes() {
-  local endpoint_kind=$1 old_states=$2 new_states=$3
-  local count index endpoint_index endpoint_muted
-  count=$(jq 'length' <<<"$old_states")
-  for (( index = 0; index < count; index++ )); do
-    endpoint_index=$(jq -r --argjson index "$index" '.[$index].index // empty' <<<"$old_states")
-    [[ $endpoint_index =~ ^[0-9]+$ ]] || continue
-    # Only endpoints that never got recreated still carry the transitional
-    # mute; vanished ones need nothing and recreated ones were just restored.
-    jq -e --argjson idx "$endpoint_index" 'any(.[].index; . == $idx)' \
-      <<<"$new_states" >/dev/null 2>&1 || continue
-    endpoint_muted=$(jq -r --argjson index "$index" '.[$index].mute // false' <<<"$old_states")
-    timeout 2 pactl "set-${endpoint_kind}-mute" "$endpoint_index" "$endpoint_muted" >/dev/null 2>&1 || true
-  done
+  local endpoint_kind=$1 old_states=$2
+  # Names identify the logical endpoint. Restoring by a Pulse index could mute
+  # or unmute an unrelated node if the old endpoint vanished and its index was
+  # reused while the profile was settling.
+  restore_endpoint_mutes "$endpoint_kind" "$old_states"
 }
 
-if (( new_sink_count < expected_sinks || new_source_count < expected_sources )); then
+rollback_to_original_profile() {
+  local observed_profile=${1:-}
+  local rollback_failed=false rollback_before_sinks='[]' rollback_before_sources='[]'
+  local rollback_sink_states='[]' rollback_source_states='[]'
+  local rollback_counts_ready=false rollback_deadline rollback_live_profile
+  local rollback_sink_count=0 rollback_source_count=0 endpoint_object attempt
+
+  echo "The requested profile was not reported active after the change" >&2
+  if [[ -z $observed_profile ]]; then
+    # Card identity is unknown, so name- or index-based graph operations would
+    # risk touching a replacement. Only restore captured objects that still
+    # exist and the identity-tracked streams, then report incomplete recovery.
+    restore_failed=false
+    restore_endpoint_mutes sink "$sink_states"
+    restore_endpoint_mutes source "$source_states"
+    restore_sink_inputs
+    echo "The audio card identity could not be verified for rollback" >&2
+    exit 4
+  fi
+
+  # A setter can land on a third profile after a transport or policy race.
+  # Mute that unintended graph, return to the captured original profile, then
+  # restore state only while the original card identity is verified.
+  rollback_before_sinks=$(read_endpoint_states sinks) || {
+    rollback_before_sinks='[]'
+    rollback_failed=true
+  }
+  rollback_before_sources=$(read_endpoint_states sources) || {
+    rollback_before_sources='[]'
+    rollback_failed=true
+  }
+  while IFS= read -r endpoint_object; do
+    set_endpoint_mute_for_object sink "$endpoint_object" true || rollback_failed=true
+  done < <(jq -r '.[].object' <<<"$rollback_before_sinks")
+  while IFS= read -r endpoint_object; do
+    set_endpoint_mute_for_object source "$endpoint_object" true || rollback_failed=true
+  done < <(jq -r '.[].object' <<<"$rollback_before_sources")
+  verify_endpoint_object_mutes sink "$rollback_before_sinks" true || rollback_failed=true
+  verify_endpoint_object_mutes source "$rollback_before_sources" true || rollback_failed=true
+
+  if [[ $observed_profile != "$active_profile" ]]; then
+    # Re-resolve immediately before using the card name; a duplicate or
+    # replacement that appeared since observation makes rollback unsafe.
+    rollback_live_profile=$(read_card_active_profile 2>/dev/null || true)
+    if [[ -n $rollback_live_profile ]]; then
+      timeout 2 pactl set-card-profile "$card" "$active_profile" >/dev/null 2>&1 || true
+    else
+      rollback_failed=true
+    fi
+  fi
+
+  rollback_deadline=$(( $(date +%s%3N) + 2500 ))
+  for (( attempt = 0; attempt < 40; attempt++ )); do
+    rollback_live_profile=$(read_card_active_profile 2>/dev/null || true)
+    if [[ $rollback_live_profile == "$active_profile" ]]; then
+      rollback_sink_states=$(read_endpoint_states sinks) || rollback_sink_states='[]'
+      rollback_source_states=$(read_endpoint_states sources) || rollback_source_states='[]'
+      rollback_sink_count=$(jq 'length' <<<"$rollback_sink_states")
+      rollback_source_count=$(jq 'length' <<<"$rollback_source_states")
+      if (( rollback_sink_count == original_sink_count
+          && rollback_source_count == original_source_count )); then
+        rollback_counts_ready=true
+        break
+      fi
+    fi
+    (( $(date +%s%3N) >= rollback_deadline )) && break
+    sleep 0.05
+  done
+
+  rollback_live_profile=$(read_card_active_profile_with_retry 2>/dev/null || true)
+  [[ $rollback_live_profile == "$active_profile" ]] || rollback_failed=true
+  [[ $rollback_counts_ready == true ]] || rollback_failed=true
+
+  # Failures while configuring the unintended target graph no longer matter
+  # once rollback begins; only verified recovery determines exit 1 versus 4.
+  restore_failed=$rollback_failed
+  restore_new_endpoint_states sink "$sink_states" "$rollback_sink_states" "$active_profile"
+  restore_new_endpoint_states source "$source_states" "$rollback_source_states" "$active_profile"
+  restore_sink_inputs
+  rollback_live_profile=$(read_card_active_profile_with_retry 2>/dev/null || true)
+  [[ $rollback_live_profile == "$active_profile" ]] || restore_failed=true
+  if [[ $restore_failed == false ]]; then
+    echo "The original audio profile and endpoint state were restored" >&2
+    exit 1
+  fi
+  echo "The requested profile failed and the original state could not be fully restored" >&2
+  exit 4
+}
+
+final_active_profile=$(read_card_active_profile_with_retry 2>/dev/null || true)
+[[ $final_active_profile == "$profile" ]] ||
+  rollback_to_original_profile "$final_active_profile"
+
+# Do not apply saved volumes or unmute any newly exposed endpoint until the
+# card itself confirms the requested profile under the captured index/object
+# identity. A wrong-profile race goes through rollback above while its graph
+# remains muted.
+new_sink_states=$(read_endpoint_states sinks) || {
+  new_sink_states='[]'
+  restore_failed=true
+}
+new_source_states=$(read_endpoint_states sources) || {
+  new_source_states='[]'
+  restore_failed=true
+}
+new_sink_count=$(jq 'length' <<<"$new_sink_states")
+new_source_count=$(jq 'length' <<<"$new_source_states")
+post_snapshot_profile=$(read_card_active_profile_with_retry 2>/dev/null || true)
+[[ $post_snapshot_profile == "$profile" ]] ||
+  rollback_to_original_profile "$post_snapshot_profile"
+restore_new_endpoint_states sink "$sink_states" "$new_sink_states" "$profile"
+restore_new_endpoint_states source "$source_states" "$new_source_states" "$profile"
+post_restore_profile=$(read_card_active_profile_with_retry 2>/dev/null || true)
+[[ $post_restore_profile == "$profile" ]] ||
+  rollback_to_original_profile "$post_restore_profile"
+
+transition_complete=true
+if { (( expected_sinks == 0 && new_sink_count != 0 )) ||
+     (( expected_sinks > 0 && new_sink_count < expected_sinks )) ||
+     (( expected_sources == 0 && new_source_count != 0 )) ||
+     (( expected_sources > 0 && new_source_count < expected_sources )); }; then
   # Endpoints that were expected after the profile change never appeared.
   # Undo the transitional muting on every endpoint that survived it, so a
   # slow or refused transition cannot leave playback silently muted.
-  echo "Audio endpoints did not reappear after the profile change" >&2
-  restore_surviving_endpoint_mutes sink "$sink_states" "$new_sink_states"
-  restore_surviving_endpoint_mutes source "$source_states" "$new_source_states"
+  echo "Audio endpoints did not settle after the profile change" >&2
+  restore_surviving_endpoint_mutes sink "$sink_states"
+  restore_surviving_endpoint_mutes source "$source_states"
+  transition_complete=false
 fi
 
 restore_sink_inputs
+preference_saved=true
+save_profile_preference || preference_saved=false
+
+if [[ $transition_complete == false || $restore_failed == true ]]; then
+  [[ $preference_saved == true ]] ||
+    echo "The changed profile preference also could not be saved" >&2
+  echo "The audio profile changed, but endpoint state was only partially restored" >&2
+  exit 4
+fi
+
+if [[ $preference_saved == false ]]; then
+  echo "The audio profile changed, but its preference could not be saved" >&2
+  exit 2
+fi
 exit 0

--- a/scripts/audio-profiles
+++ b/scripts/audio-profiles
@@ -3,49 +3,120 @@
 # omarchy:summary=List available audio card profiles as JSON
 # omarchy:group=audio
 
-set -o pipefail
+set -u -o pipefail
+LC_ALL=C
 
-timeout 2 pactl -f json list cards 2>/dev/null | jq -c '
+(( $# == 0 )) || {
+  echo "Usage: audio-profiles" >&2
+  exit 1
+}
+
+maximum_pactl_bytes=16777216
+cards=$(timeout 2 pactl -f json list cards 2>/dev/null |
+  head -c "$((maximum_pactl_bytes + 1))") || exit 1
+(( ${#cards} <= maximum_pactl_bytes )) || {
+  echo "Audio card information is too large" >&2
+  exit 1
+}
+
+if jq -c '
+  def identifier($maximum):
+    if type == "string" and length > 0 and length <= $maximum
+        and (test("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]") | not)
+      then . else "" end;
+  def clean_label($fallback):
+    (if type == "string" then . else "" end
+      | gsub("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]"; " ")
+      | gsub(" +"; " ") | sub("^ +"; "") | sub(" +$"; "") | .[:160])
+    | if length > 0 then . else $fallback end;
+  def bounded_count:
+    if type == "number" and . >= 0 and . <= 64 then floor else 0 end;
+  def bounded_priority:
+    if type == "number" and . >= 0 and . <= 1000000000 then . else 0 end;
   # Cards that ship a UCM profile name their ports "[Out] Speaker" instead of
   # following the classic ACP scheme ("analog-output"), so match both.
   def port_supports($card; $profile; $direction):
     any(
-      (($card.ports // {}) | to_entries)[]?;
-      ((.value.priority // 0) > 0)
-      and ((.value.profiles // []) | index($profile) != null)
-      and (.key | test($direction))
+      (($card.ports // {})
+        | if type == "object" then to_entries[:256] else [] end)[]?;
+      (.value | type) == "object"
+      and ((.value.priority // 0) | bounded_priority) > 0
+      and ((.value.profiles // [])
+        | if type == "array" then .[:256] else [] end | index($profile) != null)
+      and ((.key | type) == "string" and (.key | test($direction)))
     );
 
-  map(. as $card | {
-    name: $card.name,
-    label: ($card.properties["device.description"] // $card.properties["device.alias"] // $card.name),
-    bluetooth: (($card.properties["device.api"] // "") == "bluez5"),
-    address: ($card.properties["api.bluez5.address"] // $card.properties["device.string"] // ""),
-    activeProfile: ($card.active_profile // "off"),
-    profiles: (
-      $card.profiles
-      | to_entries
-      | map(
-          select((.value.available != false and .value.available != "no") or .key == $card.active_profile)
-          | select(
-              .key == $card.active_profile
-              or .key == "off"
-              or (($card.properties["device.api"] // "") == "bluez5")
-              or (
-                ((.value.sinks // 0) == 0 or port_supports($card; .key; "^\\[Out\\] |output"))
-                and ((.value.sources // 0) == 0 or port_supports($card; .key; "^\\[In\\] |input"))
+  if type != "array" then error("expected a card array") else .[:128] end
+  | . as $raw_cards
+  | [ $raw_cards[] | select(type == "object") ] as $objects
+  | [ $objects[] | ((.index // "") | tostring) ] as $indexes
+  | [ $objects[]
+      | (((.properties // {})."object.id" // "") | tostring)
+      | select(. != "") ] as $object_ids
+  | if any($indexes[]; test("^[0-9]{1,20}$") | not)
+      or (($indexes | unique | length) != ($indexes | length))
+      or any($object_ids[]; test("^[0-9]{1,20}$") | not)
+      or (($object_ids | unique | length) != ($object_ids | length))
+    then error("ambiguous card identity") else $raw_cards end
+  | map(
+      select(type == "object")
+      | . as $card
+      | ($card.name | identifier(160)) as $name
+      | select($name != "")
+      | ($card.properties
+          | if type == "object" then . else {} end) as $properties
+      | (($card.active_profile // "off") | identifier(160)) as $rawActive
+      | (if $rawActive == "" then "off" else $rawActive end) as $active
+      | {
+          name: $name,
+          label: (($properties["device.description"]
+            // $properties["device.alias"] // $name) | clean_label($name)),
+          bluetooth: (($properties["device.api"] // "") == "bluez5"),
+          address: (($properties["api.bluez5.address"]
+            // $properties["device.string"] // "") | identifier(80)),
+          activeProfile: $active,
+          profiles: (
+            ($card.profiles // {})
+            | if type == "object" then to_entries[:256] else [] end
+            | map(
+                select((.value | type) == "object")
+                | (.key | identifier(160)) as $profile
+                | select($profile != "")
+                | select((.value.available != false and .value.available != "no")
+                    or $profile == $active)
+                | select(
+                    $profile == $active
+                    or $profile == "off"
+                    or (($properties["device.api"] // "") == "bluez5")
+                    or (
+                      (((.value.sinks // 0) | bounded_count) == 0
+                        or port_supports($card; $profile; "^\\[Out\\] |output"))
+                      and (((.value.sources // 0) | bounded_count) == 0
+                        or port_supports($card; $profile; "^\\[In\\] |input"))
+                    )
+                  )
+                | {
+                    value: $profile,
+                    label: ((.value.description // $profile) | clean_label($profile)),
+                    sinks: ((.value.sinks // 0) | bounded_count),
+                    sources: ((.value.sources // 0) | bounded_count),
+                    priority: ((.value.priority // 0) | bounded_priority)
+                  }
               )
-            )
-          | {
-              value: .key,
-              label: (.value.description // .key),
-              sinks: (.value.sinks // 0),
-              sources: (.value.sources // 0),
-              priority: (.value.priority // 0)
-            }
-        )
-      | sort_by(-.priority, .label)
-      | map(del(.priority))
+            | unique_by(.value)
+            | sort_by(-.priority, (.label | ascii_downcase))
+            | .[:64]
+            | map(del(.priority))
+          )
+        }
+      | select((.profiles | length) > 0)
     )
-  })
-' || exit 1
+  | . as $cards
+  | if (($cards | map(.name) | unique | length) != ($cards | length))
+      then error("ambiguous card identity")
+    else $cards[:64] end
+' <<<"$cards"; then
+  :
+else
+  exit 1
+fi

--- a/scripts/audio-recovery
+++ b/scripts/audio-recovery
@@ -5,16 +5,31 @@
 
 set -euo pipefail
 
-(( $# == 0 )) || {
+if (( $# == 0 )); then
+  :
+elif (( $# == 1 )) && [[ $1 == --run ]]; then
+  :
+else
   echo "Usage: audio-recovery" >&2
   exit 1
-}
+fi
 
 recovery_command=${AUDIO_CONTROL_RECOVERY_COMMAND:-omarchy-restart-audio}
 recovery_launcher=${AUDIO_CONTROL_RECOVERY_LAUNCHER:-omarchy-launch-floating-terminal-with-presentation}
 recovery_path=$(command -v "$recovery_command")
+script_path=$(readlink -f -- "${BASH_SOURCE[0]}")
+script_dir=$(dirname -- "$script_path")
+source "$script_dir/.audio-common"
+
+if [[ ${1:-} == --run ]]; then
+  audio_acquire_mutation_lock \
+    "Another audio change is still finishing; recovery was not started" || exit 1
+  exec "$recovery_path"
+fi
+
 launcher_path=$(command -v "$recovery_launcher")
+printf -v launch_command '%q --run' "$script_path"
 
 # The official recovery may need to explain a stuck USB device or request
 # authorization for usbreset. Never hide that interaction inside the shell.
-"$launcher_path" "$recovery_path" >/dev/null 2>&1 &
+exec "$launcher_path" "$launch_command"

--- a/scripts/audio-resolve-output-sink
+++ b/scripts/audio-resolve-output-sink
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+# omarchy:summary=Resolve the bounded physical endpoint behind the default output
+# omarchy:group=audio
+
+set -u -o pipefail
+LC_ALL=C
+
+(( $# == 0 )) || {
+  echo "Usage: audio-resolve-output-sink" >&2
+  exit 1
+}
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=.audio-common
+source "$script_dir/.audio-common"
+
+audio_prepare_private_runtime || exit 1
+command -v omarchy-audio-output-sink >/dev/null || exit 1
+command -v jq >/dev/null || exit 1
+
+audio_capture_bounded resolved 1024 \
+  timeout 4 omarchy-audio-output-sink || exit 1
+
+# The resolver is an identity oracle. Accept exactly one short, printable
+# identifier so diagnostics or repeated output can never be mistaken for a
+# PipeWire node name by the QML caller.
+jq -ne --arg value "$resolved" '
+  ($value | length) > 0 and ($value | length) <= 160
+  and ($value
+    | test("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]")
+    | not)
+' >/dev/null || exit 1
+
+printf '%s\n' "$resolved"

--- a/scripts/audio-scenes
+++ b/scripts/audio-scenes
@@ -5,10 +5,95 @@
 # omarchy:args=[save <name> [scene-json] | delete <name>]
 
 set -euo pipefail
+LC_ALL=C
 
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+source "$script_dir/.audio-common"
 scenes_file=${OMARCHY_AUDIO_SCENES_FILE:-${XDG_CONFIG_HOME:-${HOME:?}/.config}/omarchy/audio-scenes.json}
 action=${1:-}
 maximum_scenes=24
+maximum_store_bytes=2097152
+
+scene_jq_defs='
+  def clean($maximum):
+    tostring
+    | gsub("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]"; " ")
+    | gsub(" +"; " ")
+    | sub("^ +"; "") | sub(" +$"; "")
+    | .[0:$maximum];
+  def identifier($maximum):
+    if type == "string" and length > 0 and length <= $maximum
+        and (test("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]") | not)
+      then . else "" end;
+  def bounded_number($fallback; $minimum; $maximum):
+    (if type == "number" then . else (tonumber? // $fallback) end) as $value
+    | if $value < $minimum then $minimum
+      elif $value > $maximum then $maximum
+      elif ($value >= $minimum and $value <= $maximum) then $value
+      else $fallback end;
+  def normalized_scene:
+    select(type == "object")
+    | {
+        name: ((.name // "") | clean(48)),
+        savedAt: ((.savedAt // "") | clean(32)),
+        defaults: (
+          if (.defaults | type) == "object" then .defaults else {} end
+          | {
+              output: ((.output // "") | identifier(160)),
+              input: ((.input // "") | identifier(160))
+            }
+        ),
+        devices: (
+          reduce ([(if (.devices | type) == "array" then .devices else [] end)[:256][]?
+            | select(type == "object")
+            | ((.name // "") | identifier(160)) as $device
+            | select($device != "" and (.direction == "output" or .direction == "input"))
+            | {
+                key: (.direction + ":" + $device),
+                value: {
+                  name: $device,
+                  direction: .direction,
+                  volume: ((.volume // 1) | bounded_number(1; 0; 1.5)),
+                  muted: (.direction == "input" and .muted == true),
+                  balance: ((.balance // 0) | bounded_number(0; -1; 1))
+                }
+              }][]) as $entry
+            ({seen: {}, values: []};
+              if (.seen | has($entry.key)) or (.values | length) >= 64 then .
+              else .seen[$entry.key] = true | .values += [$entry.value] end)
+          | .values
+        ),
+        ports: (
+          reduce ([(if (.ports | type) == "array" then .ports else [] end)[:256][]?
+            | select(type == "object")
+            | ((.endpoint // "") | identifier(160)) as $endpoint
+            | ((.value // "") | identifier(160)) as $value
+            | select($endpoint != "" and $value != ""
+                and (.direction == "output" or .direction == "input"))
+            | {
+                key: (.direction + ":" + $endpoint),
+                value: {direction: .direction, endpoint: $endpoint, value: $value}
+              }][]) as $entry
+            ({seen: {}, values: []};
+              if (.seen | has($entry.key)) or (.values | length) >= 64 then .
+              else .seen[$entry.key] = true | .values += [$entry.value] end)
+          | .values
+        ),
+        profiles: (
+          reduce ([(if (.profiles | type) == "array" then .profiles else [] end)[:256][]?
+            | select(type == "object")
+            | ((.card // "") | identifier(160)) as $card
+            | ((.profile // "") | identifier(160)) as $profile
+            | select($card != "" and $profile != "" and $profile != "off")
+            | {key: $card, value: {card: $card, profile: $profile}}][]) as $entry
+            ({seen: {}, values: []};
+              if (.seen | has($entry.key)) or (.values | length) >= 64 then .
+              else .seen[$entry.key] = true | .values += [$entry.value] end)
+          | .values
+        )
+      }
+    | select(.name != "");
+'
 
 usage() {
   echo "Usage: audio-scenes save <name> [scene-json] | audio-scenes delete <name>" >&2
@@ -17,17 +102,47 @@ usage() {
 }
 
 read_scenes() {
-  if [[ ! -s $scenes_file ]]; then
+  if [[ -L $scenes_file || (-e $scenes_file && ! -f $scenes_file) ]]; then
+    echo "Audio scenes are not stored in a regular file" >&2
+    return 1
+  elif [[ ! -s $scenes_file ]]; then
     printf '%s\n' '{"version":1,"scenes":[]}'
-  elif jq -e 'type == "object"' "$scenes_file" >/dev/null 2>&1; then
-    jq -c '
-      .version = 1
-      | .scenes = (if (.scenes | type) == "array" then .scenes else [] end)
+  elif (( $(stat -c %s -- "$scenes_file" 2>/dev/null || printf '%s' "$((maximum_store_bytes + 1))") > maximum_store_bytes )); then
+    echo "Audio scenes are too large; refusing to overwrite them" >&2
+    return 1
+  elif jq -se 'length == 1 and (.[0] | type) == "object"
+      and ((.[0] | has("version") | not) or .[0].version == 1)' \
+      "$scenes_file" >/dev/null 2>&1; then
+    jq -cs "$scene_jq_defs"'
+      .[0]
+      | reduce ([
+        (if (.scenes | type) == "array" then .scenes else [] end)[:96][]?
+        | normalized_scene
+      ][]) as $scene
+        ({seen: {}, values: []};
+          if (.seen | has($scene.name)) or (.values | length) >= 24 then .
+          else .seen[$scene.name] = true | .values += [$scene] end)
+      | {version: 1, scenes: .values}
     ' "$scenes_file"
+  elif jq -se 'length == 1 and (.[0] | type) == "object"' \
+      "$scenes_file" >/dev/null 2>&1; then
+    echo "Audio scenes use an unsupported schema version; refusing to overwrite them" >&2
+    return 1
   else
     echo "Audio scenes contain invalid JSON; refusing to overwrite them" >&2
     return 1
   fi
+}
+
+normalize_string() {
+  local value=$1 maximum=$2
+  jq -nr --arg value "$value" --argjson maximum "$maximum" '
+    $value
+    | gsub("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]"; " ")
+    | gsub(" +"; " ")
+    | sub("^ +"; "") | sub(" +$"; "")
+    | .[0:$maximum]
+  '
 }
 
 write_scenes() {
@@ -37,8 +152,8 @@ write_scenes() {
   local scenes_dir temporary_file
   scenes_dir=$(dirname -- "$scenes_file")
   mkdir -p -- "$scenes_dir"
-  exec 9>"${scenes_file}.lock"
-  flock 9
+  audio_open_lock_path "${scenes_file}.lock" 9 \
+    "Audio scenes are busy; try again" || return 1
 
   temporary_file=$(mktemp "$scenes_dir/.audio-scenes.XXXXXX")
   trap 'rm -f -- "$temporary_file"' EXIT
@@ -55,11 +170,16 @@ write_scenes() {
 case "$action" in
   save)
     (( $# == 2 || $# == 3 )) || usage
-    name=$2
+    name=$(normalize_string "$2" 48)
     [[ -n $name ]] || usage
     if (( $# == 3 )); then
+      (( ${#3} <= maximum_store_bytes )) || {
+        echo "Scene is too large" >&2
+        exit 1
+      }
       scene_json=$(printf '%s' "$3" |
-        jq -c 'if type == "object" then . else empty end' 2>/dev/null) || {
+        jq -cse 'if length == 1 and (.[0] | type) == "object"
+          then .[0] else error("expected one object") end' 2>/dev/null) || {
         echo "Scene must be a JSON object" >&2
         exit 1
       }
@@ -68,32 +188,29 @@ case "$action" in
         exit 1
       }
     else
-      scene_json=$(jq -c .) || {
-        echo "Scene is not valid JSON" >&2
+      scene_input_with_marker=$(head -c "$((maximum_store_bytes + 1))"; printf x)
+      scene_input=${scene_input_with_marker%x}
+      (( ${#scene_input} <= maximum_store_bytes )) || {
+        echo "Scene is too large" >&2
         exit 1
       }
-      [[ $scene_json == "{"* ]] || {
-        echo "Scene must be a JSON object" >&2
+      scene_json=$(jq -cse 'if length == 1 and (.[0] | type) == "object"
+          then .[0] else error("expected one object") end' <<<"$scene_input") || {
+        echo "Scene is not valid JSON" >&2
         exit 1
       }
     fi
     # The command argument is authoritative, and safety invariants belong in
     # the store as well as in the QML parser. This keeps hand-written/imported
-    # scenes from persisting output mutes or card power-off profiles.
-    scene_json=$(jq -c --arg name "$name" '
-      .name = $name
-      | .devices = (
-          if (.devices | type) == "array" then
-            [.devices[] | if type == "object" and .direction == "output"
-              then .muted = false else . end]
-          else [] end
-        )
-      | .profiles = (
-          if (.profiles | type) == "array" then
-            [.profiles[] | select(type != "object" or (.profile? // "") != "off")]
-          else [] end
-        )
+    # scenes from persisting output mutes, invalid directions, or card
+    # power-off profiles.
+    scene_json=$(jq -c --arg name "$name" "$scene_jq_defs"'
+      .name = $name | normalized_scene
     ' <<<"$scene_json") || exit 1
+    [[ -n $scene_json ]] || {
+      echo "Scene has no valid name" >&2
+      exit 1
+    }
     write_scenes '
       .version = 1
       | .scenes = (
@@ -105,7 +222,7 @@ case "$action" in
     ;;
   delete)
     (( $# == 2 )) || usage
-    name=$2
+    name=$(normalize_string "$2" 48)
     [[ -n $name ]] || usage
     write_scenes '.version = 1 | .scenes |= map(select(.name != $name))' --arg name "$name"
     ;;

--- a/scripts/audio-sink-availability
+++ b/scripts/audio-sink-availability
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# omarchy:summary=Read bounded output availability from Omarchy
+# omarchy:group=audio
+
+set -u -o pipefail
+LC_ALL=C
+
+(( $# == 0 )) || {
+  echo "Usage: audio-sink-availability" >&2
+  exit 1
+}
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=.audio-common
+source "$script_dir/.audio-common"
+
+audio_prepare_private_runtime || exit 1
+command -v omarchy-audio-sink-availability >/dev/null || exit 1
+
+# The upstream helper emits one <node-name><TAB><0|1> record per output. Its
+# result is parsed defensively in Model.js; this wrapper supplies the missing
+# process-time and byte ceilings before a StdioCollector holds it in memory.
+audio_capture_bounded availability 1048576 \
+  timeout 4 omarchy-audio-sink-availability || exit 1
+
+printf '%s\n' "$availability"

--- a/scripts/audio-speaker-test
+++ b/scripts/audio-speaker-test
@@ -13,13 +13,35 @@ set -euo pipefail
 
 sink_name=$1
 speaker_command=${AUDIO_CONTROL_SPEAKER_TEST_COMMAND:-speaker-test}
-[[ -n $sink_name && $sink_name != *.monitor ]] || exit 1
 command -v jq >/dev/null
 speaker_path=$(command -v "$speaker_command")
+LC_ALL=C
 
-sink=$(pactl -f json list sinks | jq -cer --arg sink "$sink_name" '
-  first(.[] | select(.name == $sink))
-') || {
+jq -ne --arg sink "$sink_name" '
+  ($sink | length) > 0 and ($sink | length) <= 160
+  and ($sink | endswith(".monitor") | not)
+  and ($sink | test("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]") | not)
+' >/dev/null || {
+  echo "Invalid output identifier" >&2
+  exit 1
+}
+
+maximum_pactl_bytes=16777216
+sinks_json=$(timeout 4s pactl -f json list sinks |
+  head -c "$((maximum_pactl_bytes + 1))") || exit 1
+(( ${#sinks_json} <= maximum_pactl_bytes )) || {
+  echo "Audio output information is too large" >&2
+  exit 1
+}
+
+sink=$(jq -cer --arg sink "$sink_name" '
+  if type != "array" or length > 512 then error("invalid sink list")
+  else [.[] | select(.name == $sink)] as $matches
+    | if ($matches | length) == 1 then $matches[0]
+      elif ($matches | length) == 0 then empty
+      else error("ambiguous sink identity") end
+  end
+' <<<"$sinks_json") || {
   echo "The selected output is no longer available" >&2
   exit 2
 }
@@ -39,4 +61,5 @@ channels=$(jq -er '
 
 export PULSE_SINK=$sink_name
 export PULSE_PROP="application.id=ssupt.audio-control application.name='Advanced Audio Control' media.name='Speaker channel test'"
-exec "$speaker_path" -D pulse -c "$channels" -t wav -l 1 -S 35
+exec timeout --foreground --kill-after=2 30 \
+  "$speaker_path" -D pulse -c "$channels" -t wav -l 1 -S 35

--- a/scripts/audio-stream-route-set
+++ b/scripts/audio-stream-route-set
@@ -9,44 +9,253 @@ stream=${2:-}
 target=${3:-}
 mode=${4:-override}
 
+set -u -o pipefail
+
 if (( $# < 3 || $# > 4 )) || [[ $direction != "playback" && $direction != "recording" ]] ||
-  [[ ! $stream =~ ^[0-9]+$ || ! $target =~ ^[0-9]+$ ]] ||
+  [[ ! $stream =~ ^[0-9]{1,20}$ || ! $target =~ ^[0-9]{1,20}$ ]] ||
   [[ $mode != "override" && $mode != "default" ]]; then
   echo "Usage: omarchy-audio-stream-route-set <playback|recording> <stream-serial> <target-serial> [override|default]" >&2
   exit 1
 fi
 
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+source "$script_dir/.audio-common"
+audio_acquire_mutation_lock || exit 1
+
 if [[ $direction == "playback" ]]; then
   move_command=move-sink-input
   streams_key=sink_inputs
   targets_key=sinks
+  endpoint_key=sink
 else
   move_command=move-source-output
   streams_key=source_outputs
   targets_key=sources
+  endpoint_key=source
 fi
-
-timeout 2 pactl "$move_command" "$stream" "$target" || exit 1
 
 # WirePlumber stores explicit stream targets by application identity and restores
 # them when that application creates a new stream. Moving through Pulse normally
 # writes such a target, except when the stream is already on that sink. Write both
 # target forms ourselves so choosing the current default is still persistent,
 # and clear both when the user returns to default-following mode.
-state=$(timeout 2 pactl -f json list 2>/dev/null) || exit 1
-stream_object_id=$(jq -r --arg key "$streams_key" --arg stream "$stream" '
-  .[$key] | map(select((.index | tostring) == $stream))[0].properties."object.id" // empty
+audio_capture_bounded state 16777216 timeout 2 pactl -f json list || exit 1
+stream_record=$(jq -cer --arg key "$streams_key" --arg stream "$stream" '
+  if type != "object" or (.[$key] | type) != "array" or (.[$key] | length) > 1024
+    then error("invalid stream list")
+  else [.[$key][] | select((.index | tostring) == $stream)] as $matches
+    | if ($matches | length) == 1 then $matches[0]
+      else error("ambiguous stream identity") end
+  end
 ' <<<"$state") || exit 1
+stream_object_id=$(jq -r '.properties."object.id" // empty | tostring' <<<"$stream_record") || exit 1
 [[ $stream_object_id =~ ^[0-9]+$ ]] || exit 1
+original_target=$(jq -r --arg endpoint "$endpoint_key" '
+  if $endpoint == "sink" then (.sink // empty) else (.source // empty) end
+  | tostring
+' <<<"$stream_record") || exit 1
+[[ $stream_object_id =~ ^[0-9]{1,20}$ && $original_target =~ ^[0-9]{1,20}$ ]] || exit 1
+
+target_record=$(jq -cer --arg key "$targets_key" --arg target "$target" '
+  if type != "object" or (.[$key] | type) != "array" or (.[$key] | length) > 512
+    then error("invalid target list")
+  else [.[$key][] | select((.index | tostring) == $target)] as $matches
+    | if ($matches | length) == 1 then $matches[0]
+      else error("ambiguous target identity") end
+  end
+' <<<"$state") || exit 1
+target_object_id=$(jq -r '.properties."object.id" // empty | tostring' <<<"$target_record") || exit 1
+[[ $target_object_id =~ ^[0-9]{1,20}$ ]] || exit 1
+
+original_target_record=$(jq -cer --arg key "$targets_key" --arg target "$original_target" '
+  if type != "object" or (.[$key] | type) != "array" or (.[$key] | length) > 512
+    then error("invalid target list")
+  else [.[$key][] | select((.index | tostring) == $target)] as $matches
+    | if ($matches | length) == 1 then $matches[0]
+      else error("ambiguous original target identity") end
+  end
+' <<<"$state") || exit 1
+original_target_object_id=$(jq -r \
+  '.properties."object.id" // empty | tostring' <<<"$original_target_record") || exit 1
+[[ $original_target_object_id =~ ^[0-9]{1,20}$ ]] || exit 1
+
+# Refuse to make an audible change unless the metadata needed to make it
+# persistent is readable first. Keep the previous values for rollback if one
+# of the two metadata writes fails after the stream has moved.
+audio_capture_bounded metadata 4194304 timeout 2 pw-metadata -n default || exit 1
+metadata_value() {
+  local key=$1 escaped_key value
+  escaped_key=${key//./\\.}
+  value=$(sed -n "s/^update: id:${stream_object_id} key:'${escaped_key}' value:'\\([^']*\\)'.*/\\1/p" \
+    <<<"$metadata")
+  if [[ -z $value ]]; then
+    grep -Fq "id:${stream_object_id} key:'${key}' value:'" <<<"$metadata" && return 1
+    printf '%s\n' -1
+  elif [[ $value == -1 || $value =~ ^[0-9]{1,20}$ ]]; then
+    printf '%s\n' "$value"
+  else
+    return 1
+  fi
+}
+previous_object=$(metadata_value target.object) || exit 1
+previous_node=$(metadata_value target.node) || exit 1
+
+stream_location() {
+  local live_state
+  audio_capture_bounded live_state 16777216 \
+    timeout 2 pactl -f json list || return 1
+  jq -er --arg key "$streams_key" --arg stream "$stream" \
+    --arg object "$stream_object_id" --arg endpoint "$endpoint_key" '
+    if type != "object" or (.[$key] | type) != "array" or (.[$key] | length) > 1024
+      then error("invalid stream list")
+    else [.[$key][]
+        | select(((.properties."object.id" // "") | tostring) == $object)] as $matches
+      | if ($matches | length) == 0 then "__gone__"
+        elif ($matches | length) != 1 then error("ambiguous stream identity")
+        else $matches[0] as $entry
+          | (($entry.index // "") | tostring) as $index
+          | (if $endpoint == "sink" then ($entry.sink // "")
+              else ($entry.source // "") end | tostring) as $target
+          | if ($index | test("^[0-9]{1,20}$"))
+              and ($target | test("^[0-9]{1,20}$"))
+            then [$index, $target] | @tsv
+            else error("invalid live stream identity") end
+        end
+    end
+  ' <<<"$live_state"
+}
+
+endpoint_index() {
+  local object_id=$1 live_state
+  audio_capture_bounded live_state 16777216 \
+    timeout 2 pactl -f json list || return 1
+  jq -er --arg key "$targets_key" --arg object "$object_id" '
+    if type != "object" or (.[$key] | type) != "array" or (.[$key] | length) > 512
+      then error("invalid target list")
+    else [.[$key][]
+        | select(((.properties."object.id" // "") | tostring) == $object)] as $matches
+      | if ($matches | length) == 0 then "__gone__"
+        elif ($matches | length) != 1 then error("ambiguous target identity")
+        else (($matches[0].index // "") | tostring) as $index
+          | if ($index | test("^[0-9]{1,20}$")) then $index
+            else error("invalid target index") end
+        end
+    end
+  ' <<<"$live_state"
+}
+
+stream_endpoint() {
+  local location current_index current_endpoint
+  location=$(stream_location) || return 1
+  if [[ $location == "__gone__" ]]; then
+    printf '%s\n' "__gone__"
+    return 0
+  fi
+  IFS=$'\t' read -r current_index current_endpoint <<<"$location"
+  [[ $current_index =~ ^[0-9]{1,20}$ && $current_endpoint =~ ^[0-9]{1,20}$ ]] || return 1
+  printf '%s\n' "$current_endpoint"
+}
+
+read_metadata_value() {
+  local key=$1 live_metadata escaped_key value
+  audio_capture_bounded live_metadata 4194304 \
+    timeout 2 pw-metadata -n default || return 1
+  escaped_key=${key//./\\.}
+  value=$(sed -n "s/^update: id:${stream_object_id} key:'${escaped_key}' value:'\\([^']*\\)'.*/\\1/p" \
+    <<<"$live_metadata")
+  if [[ -z $value ]]; then
+    grep -Fq "id:${stream_object_id} key:'${key}' value:'" <<<"$live_metadata" && return 1
+    printf '%s\n' -1
+  elif [[ $value == -1 || $value =~ ^[0-9]{1,20}$ ]]; then
+    printf '%s\n' "$value"
+  else
+    return 1
+  fi
+}
+
+route_committed() {
+  local expected_object=$1 expected_node=$2
+  local actual_endpoint actual_object actual_node live_target
+  actual_endpoint=$(stream_endpoint) || return 1
+  live_target=$(endpoint_index "$target_object_id") || return 1
+  [[ $live_target != "__gone__" && $actual_endpoint == "$live_target" ]] || return 1
+  [[ $expected_object == -1 || $expected_object == "$live_target" ]] || return 1
+  actual_object=$(read_metadata_value target.object) || return 1
+  actual_node=$(read_metadata_value target.node) || return 1
+  [[ $actual_object == "$expected_object" && $actual_node == "$expected_node" ]]
+}
+
+restore_route() {
+  local location current_index actual_endpoint original_live_target
+  local actual_object actual_node
+  location=$(stream_location) || return 1
+  [[ $location != "__gone__" ]] || return 0
+  IFS=$'\t' read -r current_index actual_endpoint <<<"$location"
+  [[ $current_index =~ ^[0-9]{1,20}$ && $actual_endpoint =~ ^[0-9]{1,20}$ ]] || return 1
+  original_live_target=$(endpoint_index "$original_target_object_id") || return 1
+  [[ $original_live_target != "__gone__" ]] || return 1
+  if [[ $actual_endpoint != "$original_live_target" ]]; then
+    timeout 2 pactl "$move_command" "$current_index" "$original_live_target" \
+      >/dev/null 2>&1 || true
+  fi
+  timeout 2 pw-metadata -n default -- "$stream_object_id" \
+    target.object "$previous_object" Spa:Id >/dev/null 2>&1 || true
+  timeout 2 pw-metadata -n default -- "$stream_object_id" \
+    target.node "$previous_node" Spa:Id >/dev/null 2>&1 || true
+
+  actual_endpoint=$(stream_endpoint) || return 1
+  if [[ $actual_endpoint != "__gone__" ]]; then
+    original_live_target=$(endpoint_index "$original_target_object_id") || return 1
+    [[ $original_live_target != "__gone__"
+        && $actual_endpoint == "$original_live_target" ]] || return 1
+  fi
+  # Metadata for a vanished stream disappears naturally and has no remaining
+  # route to restore. Otherwise require both prior values byte-for-byte.
+  [[ $actual_endpoint == "__gone__" ]] && return 0
+  actual_object=$(read_metadata_value target.object) || return 1
+  actual_node=$(read_metadata_value target.node) || return 1
+  [[ $actual_object == "$previous_object" && $actual_node == "$previous_node" ]]
+}
+
+fail_after_move() {
+  if restore_route; then
+    exit 1
+  fi
+  echo "The application route changed and could not be fully restored" >&2
+  exit 4
+}
+
+current_location=$(stream_location) || exit 1
+[[ $current_location != "__gone__" ]] || exit 1
+IFS=$'\t' read -r current_stream current_endpoint <<<"$current_location"
+[[ $current_stream =~ ^[0-9]{1,20}$ && $current_endpoint =~ ^[0-9]{1,20}$ ]] || exit 1
+live_target=$(endpoint_index "$target_object_id") || exit 1
+[[ $live_target != "__gone__" ]] || exit 1
+original_live_target=$(endpoint_index "$original_target_object_id") || exit 1
+[[ $original_live_target != "__gone__" && $original_live_target == "$current_endpoint" ]] || exit 1
+
+timeout 2 pactl "$move_command" "$current_stream" "$live_target" || true
+actual_target=$(stream_endpoint) || fail_after_move
+verified_target=$(endpoint_index "$target_object_id") || fail_after_move
+if [[ $verified_target == "__gone__" || $actual_target != "$verified_target" ]]; then
+  # An unchanged or vanished stream has no partial move. A third endpoint is
+  # an unexpected partial result and still goes through the same verifier.
+  if [[ $actual_target == "$current_endpoint" || $actual_target == "__gone__" ]]; then
+    exit 1
+  fi
+  fail_after_move
+fi
 
 if [[ $mode == "override" ]]; then
-  target_object_id=$(jq -r --arg key "$targets_key" --arg target "$target" '
-    .[$key] | map(select((.index | tostring) == $target))[0].properties."object.id" // empty
-  ' <<<"$state") || exit 1
-  [[ $target_object_id =~ ^[0-9]+$ ]] || exit 1
-  timeout 2 pw-metadata -n default -- "$stream_object_id" target.object "$target" Spa:Id >/dev/null 2>&1 || exit 1
-  timeout 2 pw-metadata -n default -- "$stream_object_id" target.node "$target_object_id" Spa:Id >/dev/null 2>&1 || exit 1
+  timeout 2 pw-metadata -n default -- "$stream_object_id" \
+    target.object "$verified_target" Spa:Id >/dev/null 2>&1 || true
+  timeout 2 pw-metadata -n default -- "$stream_object_id" \
+    target.node "$target_object_id" Spa:Id >/dev/null 2>&1 || true
+  route_committed "$verified_target" "$target_object_id" || fail_after_move
 else
-  timeout 2 pw-metadata -n default -- "$stream_object_id" target.object -1 Spa:Id >/dev/null 2>&1 || exit 1
-  timeout 2 pw-metadata -n default -- "$stream_object_id" target.node -1 Spa:Id >/dev/null 2>&1 || exit 1
+  timeout 2 pw-metadata -n default -- "$stream_object_id" \
+    target.object -1 Spa:Id >/dev/null 2>&1 || true
+  timeout 2 pw-metadata -n default -- "$stream_object_id" \
+    target.node -1 Spa:Id >/dev/null 2>&1 || true
+  route_committed -1 -1 || fail_after_move
 fi

--- a/scripts/audio-stream-routes
+++ b/scripts/audio-stream-routes
@@ -8,35 +8,80 @@ if (( $# != 0 )); then
   exit 1
 fi
 
-set -o pipefail
+set -u -o pipefail
+LC_ALL=C
 
 # PipeWire's Pulse server exposes stream and endpoint object.serial values as
 # sink-input/source-output and sink/source indices. Quickshell exposes those
 # same serials on its nodes, giving the panel an exact, label-independent map.
 # Explicit targets live in PipeWire metadata; retain that distinction so an app
 # pinned to the current default is not presented as following the default.
-metadata=$(timeout 2 pw-metadata -n default 2>/dev/null) || exit 1
+maximum_metadata_bytes=4194304
+maximum_pactl_bytes=16777216
+metadata=$(timeout 2 pw-metadata -n default 2>/dev/null |
+  head -c "$((maximum_metadata_bytes + 1))") || exit 1
+(( ${#metadata} <= maximum_metadata_bytes )) || {
+  echo "PipeWire metadata is too large" >&2
+  exit 1
+}
 explicit_targets=$(sed -n "s/^update: id:\([0-9][0-9]*\) key:'target\.\(object\|node\)' value:'\([^']*\)'.*/\1\t\3/p" <<<"$metadata" |
-  awk -F '\t' '$2 != "-1" { print $1 }' |
+  awk -F '\t' '
+    length($1) > 20 || $1 !~ /^[0-9]+$/ { exit 3 }
+    $2 == "-1" { next }
+    length($2) > 20 || $2 !~ /^[0-9]+$/ { exit 3 }
+    !seen[$1]++ {
+      if (++count > 4096) exit 3
+      print $1
+    }
+  ' |
   jq -Rsc 'split("\n") | map(select(length > 0)) | map({key: ., value: true}) | from_entries') || exit 1
 
-timeout 2 pactl -f json list 2>/dev/null | jq -c --argjson explicit "$explicit_targets" '
-  def routes($streams; $endpoint):
-    $streams
-    | map(
-        select(.index != null and .[$endpoint] != null)
-        | {
-            key: (.index | tostring),
-            value: {
-              target: (.[$endpoint] | tostring),
-              mode: (if ($explicit[(.properties."object.id" | tostring)] // false) then "override" else "default" end)
-            }
-          }
-      )
-    | from_entries;
+routes_json=$(timeout 2 pactl -f json list 2>/dev/null |
+  head -c "$((maximum_pactl_bytes + 1))") || exit 1
+(( ${#routes_json} <= maximum_pactl_bytes )) || {
+  echo "Audio route information is too large" >&2
+  exit 1
+}
 
-  {
-    playback: routes((.sink_inputs // []); "sink"),
-    recording: routes((.source_outputs // []); "source")
-  }
-' || exit 1
+if jq -c --argjson explicit "$explicit_targets" '
+  def serial:
+    tostring | select(test("^[0-9]{1,20}$"));
+  def bounded_array($name; $maximum):
+    .[$name]
+    | if type == "array" and length <= $maximum then .
+      else error("invalid " + $name) end;
+  def routes($streams; $endpoint):
+    [ $streams[]
+      | if type == "object" and (.properties | type) == "object" then .
+        else error("invalid stream record") end
+      | (.index | serial) as $index
+      | (.[$endpoint] | serial) as $target
+      | (.properties."object.id" | serial) as $object
+      | {
+          key: $index,
+          object: $object,
+          value: {
+            target: $target,
+            mode: (if ($explicit[$object] // false)
+              then "override" else "default" end)
+          }
+        }
+    ] as $entries
+    | if ($entries | length) != ($streams | length)
+        or (($entries | map(.key) | unique | length) != ($entries | length))
+        or (($entries | map(.object) | unique | length) != ($entries | length))
+      then error("ambiguous stream identity")
+      else ($entries[:512] | map(del(.object)) | from_entries) end;
+
+  if type != "object" then error("expected a route object") else . end
+  | (bounded_array("sink_inputs"; 2048)) as $sinkInputs
+  | (bounded_array("source_outputs"; 2048)) as $sourceOutputs
+  | {
+      playback: routes($sinkInputs; "sink"),
+      recording: routes($sourceOutputs; "source")
+    }
+' <<<"$routes_json"; then
+  :
+else
+  exit 1
+fi

--- a/scripts/place-advanced-window
+++ b/scripts/place-advanced-window
@@ -1,17 +1,33 @@
 #!/bin/bash
 
-set -o pipefail
+set -euo pipefail
+
+(( $# == 0 )) || {
+  echo "Usage: place-advanced-window" >&2
+  exit 1
+}
 
 # Capture the caller's workspace before focusing or moving the existing
 # settings window. A second summon from another workspace should bring the
 # one settings surface to the user instead of activating it out of sight.
-target_workspace=$(hyprctl activeworkspace -j 2>/dev/null | jq -r '.id // empty') || exit 1
+maximum_hyprland_bytes=4194304
+workspace_json=$(timeout 2 hyprctl activeworkspace -j 2>/dev/null |
+  head -c "$((maximum_hyprland_bytes + 1))") || exit 1
+(( ${#workspace_json} <= maximum_hyprland_bytes )) || exit 1
+target_workspace=$(jq -r 'if type == "object" then (.id // empty) else empty end' \
+  <<<"$workspace_json") || exit 1
 [[ $target_workspace =~ ^[1-9][0-9]*$ ]] || exit 1
 
 for (( attempt = 0; attempt < 40; attempt++ )); do
-  client=$(hyprctl clients -j 2>/dev/null | jq -c '
-    [.[] | select(.class == "org.quickshell" and .title == "Advanced Audio Control")][-1] // empty
-  ') || exit 1
+  clients_json=$(timeout 2 hyprctl clients -j 2>/dev/null |
+    head -c "$((maximum_hyprland_bytes + 1))") || exit 1
+  (( ${#clients_json} <= maximum_hyprland_bytes )) || exit 1
+  client=$(jq -c '
+    if type == "array" then
+      [.[-4096:][]
+        | select(.class == "org.quickshell" and .title == "Advanced Audio Control")][-1] // empty
+    else empty end
+  ' <<<"$clients_json") || exit 1
 
   address=$(jq -r '.address // empty' <<<"$client")
   floating=$(jq -r '.floating // false' <<<"$client")
@@ -19,14 +35,14 @@ for (( attempt = 0; attempt < 40; attempt++ )); do
   if [[ $address =~ ^0x[0-9a-fA-F]+$ ]]; then
     window="address:$address"
     if [[ $current_workspace != "$target_workspace" ]]; then
-      hyprctl dispatch "hl.dsp.window.move({ workspace = \"$target_workspace\", follow = false, window = \"$window\" })" >/dev/null || exit 1
+      timeout 2 hyprctl dispatch "hl.dsp.window.move({ workspace = \"$target_workspace\", follow = false, window = \"$window\" })" >/dev/null || exit 1
     fi
     if [[ $floating != "true" ]]; then
-      hyprctl dispatch "hl.dsp.window.float({ window = \"$window\", action = \"toggle\" })" >/dev/null || exit 1
+      timeout 2 hyprctl dispatch "hl.dsp.window.float({ window = \"$window\", action = \"toggle\" })" >/dev/null || exit 1
     fi
-    hyprctl dispatch "hl.dsp.window.resize({ window = \"$window\", x = 680, y = 560 })" >/dev/null || exit 1
-    hyprctl dispatch "hl.dsp.window.center({ window = \"$window\" })" >/dev/null || exit 1
-    hyprctl dispatch "hl.dsp.focus({ window = \"$window\" })" >/dev/null || exit 1
+    timeout 2 hyprctl dispatch "hl.dsp.window.resize({ window = \"$window\", x = 680, y = 560 })" >/dev/null || exit 1
+    timeout 2 hyprctl dispatch "hl.dsp.window.center({ window = \"$window\" })" >/dev/null || exit 1
+    timeout 2 hyprctl dispatch "hl.dsp.focus({ window = \"$window\" })" >/dev/null || exit 1
     exit 0
   fi
 

--- a/scripts/prepare-advanced-window
+++ b/scripts/prepare-advanced-window
@@ -3,7 +3,14 @@
 # Register the static rule before the Wayland toplevel is mapped. Applying
 # float after mapping leaves one tiled frame visible and can disturb the
 # workspace layout; a pre-map rule makes its first rendered frame final.
-hyprctl eval '
+set -euo pipefail
+
+(( $# == 0 )) || {
+  echo "Usage: prepare-advanced-window" >&2
+  exit 1
+}
+
+timeout 2 hyprctl eval '
   hl.window_rule({
     name = "ssupt-audio-control",
     match = {

--- a/test/all
+++ b/test/all
@@ -13,7 +13,121 @@ fail() {
 for script in "$ROOT"/scripts/*; do
   bash -n "$script" || fail "bash syntax: ${script##*/}"
 done
+bash -n "$ROOT/scripts/.audio-common" || fail "bash syntax: .audio-common"
 echo "PASS: helper syntax"
+
+runtime_safety_dir=$(mktemp -d)
+runtime_private="$runtime_safety_dir/private"
+mkdir -m 700 -- "$runtime_private"
+AUDIO_CONTROL_PRIVATE_RUNTIME_DIR="$runtime_private" \
+  bash -c 'source "$1"; audio_acquire_mutation_lock' _ \
+    "$ROOT/scripts/.audio-common" || fail "private runtime lock"
+[[ $(stat -c '%a' "$runtime_private/omarchy-audio-mutation.lock") == 600 ]] ||
+  fail "private runtime lock permissions"
+
+chmod 777 -- "$runtime_private"
+if AUDIO_CONTROL_PRIVATE_RUNTIME_DIR="$runtime_private" \
+  bash -c 'source "$1"; audio_acquire_mutation_lock' _ \
+    "$ROOT/scripts/.audio-common" >/dev/null 2>&1; then
+  fail "world-writable private runtime accepted"
+fi
+chmod 700 -- "$runtime_private"
+
+runtime_lock="$runtime_private/omarchy-audio-mutation.lock"
+rm -f -- "$runtime_lock"
+ln -s -- "$runtime_safety_dir/target" "$runtime_lock"
+if timeout 2 env AUDIO_CONTROL_PRIVATE_RUNTIME_DIR="$runtime_private" \
+  bash -c 'source "$1"; audio_acquire_mutation_lock' _ \
+    "$ROOT/scripts/.audio-common" >/dev/null 2>&1; then
+  fail "symlink runtime lock accepted"
+else
+  [[ $? != 124 ]] || fail "symlink runtime lock blocked"
+fi
+rm -f -- "$runtime_lock"
+mkfifo -- "$runtime_lock"
+if timeout 2 env AUDIO_CONTROL_PRIVATE_RUNTIME_DIR="$runtime_private" \
+  bash -c 'source "$1"; audio_acquire_mutation_lock' _ \
+    "$ROOT/scripts/.audio-common" >/dev/null 2>&1; then
+  fail "FIFO runtime lock accepted"
+else
+  [[ $? != 124 ]] || fail "FIFO runtime lock blocked"
+fi
+rm -f -- "$runtime_lock"
+touch "$runtime_safety_dir/hardlink-target"
+ln -- "$runtime_safety_dir/hardlink-target" "$runtime_lock"
+if timeout 2 env AUDIO_CONTROL_PRIVATE_RUNTIME_DIR="$runtime_private" \
+  bash -c 'source "$1"; audio_acquire_mutation_lock' _ \
+    "$ROOT/scripts/.audio-common" >/dev/null 2>&1; then
+  fail "hard-linked runtime lock accepted"
+else
+  [[ $? != 124 ]] || fail "hard-linked runtime lock blocked"
+fi
+
+# Bounded capture must validate its producer even when the sourcing shell did
+# not enable pipefail itself.
+if AUDIO_CONTROL_PRIVATE_RUNTIME_DIR="$runtime_private" \
+  bash -c 'source "$1"; audio_prepare_private_runtime; audio_capture_bounded output 16 /bin/false' \
+    _ "$ROOT/scripts/.audio-common" >/dev/null 2>&1; then
+  fail "bounded capture ignored a failed producer without pipefail"
+fi
+AUDIO_CONTROL_PRIVATE_RUNTIME_DIR="$runtime_private" \
+  bash -c 'source "$1"; audio_prepare_private_runtime; audio_capture_bounded output 16 /usr/bin/printf abc && [[ $output == abc ]]' \
+    _ "$ROOT/scripts/.audio-common" || fail "bounded capture rejected valid output"
+if AUDIO_CONTROL_PRIVATE_RUNTIME_DIR="$runtime_private" \
+  bash -c 'source "$1"; audio_prepare_private_runtime; audio_capture_bounded output 16 /usr/bin/printf "a\0b"' \
+    _ "$ROOT/scripts/.audio-common" >/dev/null 2>&1; then
+  fail "bounded capture silently removed a NUL byte"
+fi
+
+resolved_sink=$(AUDIO_CONTROL_PRIVATE_RUNTIME_DIR="$runtime_private" \
+  AUDIO_CONTROL_OUTPUT_SINK_RESPONSE=physical-speakers PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-resolve-output-sink")
+[[ $resolved_sink == physical-speakers ]] || fail "bounded physical output resolver"
+if AUDIO_CONTROL_PRIVATE_RUNTIME_DIR="$runtime_private" \
+  AUDIO_CONTROL_OUTPUT_SINK_RESPONSE=$'physical-speakers\nunexpected-output' \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-resolve-output-sink" \
+    >/dev/null 2>&1; then
+  fail "physical output resolver accepted multiple lines"
+fi
+if AUDIO_CONTROL_PRIVATE_RUNTIME_DIR="$runtime_private" \
+  AUDIO_CONTROL_OUTPUT_SINK_OVERSIZED=1 PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-resolve-output-sink" >/dev/null 2>&1; then
+  fail "physical output resolver accepted oversized output"
+fi
+availability=$(AUDIO_CONTROL_PRIVATE_RUNTIME_DIR="$runtime_private" \
+  AUDIO_CONTROL_SINK_AVAILABILITY_RESPONSE=$'physical-speakers\t1\nheadphones\t0' \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-sink-availability")
+[[ $availability == $'physical-speakers\t1\nheadphones\t0' ]] ||
+  fail "bounded sink availability"
+if AUDIO_CONTROL_PRIVATE_RUNTIME_DIR="$runtime_private" \
+  AUDIO_CONTROL_SINK_AVAILABILITY_OVERSIZED=1 PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-sink-availability" >/dev/null 2>&1; then
+  fail "sink availability accepted oversized output"
+fi
+rm -rf -- "$runtime_safety_dir"
+
+for helper_call in \
+  'audio-profiles extra' \
+  'audio-ports extra' \
+  'audio-resolve-output-sink extra' \
+  'audio-sink-availability extra' \
+  'audio-stream-routes extra' \
+  'audio-speaker-test output extra' \
+  'audio-recovery extra' \
+  'prepare-advanced-window extra' \
+  'place-advanced-window extra'; do
+  read -r -a helper_arguments <<<"$helper_call"
+  if "$ROOT/scripts/${helper_arguments[0]}" "${helper_arguments[@]:1}" \
+      >/dev/null 2>&1; then
+    fail "extra helper argument accepted by ${helper_arguments[0]}"
+  fi
+done
+echo "PASS: private runtime and strict helper interfaces"
+
+if command -v qmllint >/dev/null 2>&1; then
+  qmllint "$ROOT"/*.qml || fail "QML lint"
+  echo "PASS: QML lint"
+fi
 
 node - "$ROOT/Model.js" <<'JS'
 const assert = require('node:assert/strict')
@@ -41,6 +155,20 @@ assert.deepEqual(model.parseAudioControlSettings('not json'), {
   captureNotifications: true
 })
 assert.equal(model.parseAudioControlSettings('{"captureNotifications":false}').captureNotifications, false)
+assert.equal(model.sanitizeIdentifier(' exact identifier ', 160), ' exact identifier ')
+assert.equal(model.sanitizeIdentifier('invalid\nidentifier', 160), '')
+assert.equal(model.sanitizeIdentifier('x'.repeat(161), 160), '')
+assert.equal(model.isAudioControlSettingsDocument('{}'), true)
+assert.equal(model.isAudioControlSettingsDocument('{"outputOverdrive":"true"}'), false)
+assert.equal(model.isAudioControlSettingsDocument(''), false)
+assert.equal(model.isAudioPreferencesDocument('{"defaults":{}}'), true)
+assert.equal(model.isAudioPreferencesDocument('{"defaults":[]}'), false)
+assert.equal(model.isAudioScenesDocument('{"version":1,"scenes":[]}'), true)
+assert.equal(model.isAudioScenesDocument('{"version":2,"scenes":[]}'), false)
+assert.equal(model.isAudioScenesDocument('{"scenes":{}}'), false)
+assert.equal(model.isAudioRulesDocument('{"appRules":[],"devices":{}}'), true)
+assert.equal(model.isAudioRulesDocument('{"appRules":{}}'), false)
+assert.equal(model.isAudioRulesDocument('x'.repeat(1048577)), false)
 assert.deepEqual(
   model.parseAudioScenes(JSON.stringify({
     version: 1,
@@ -71,6 +199,41 @@ assert.deepEqual(
     // "off" is never stored: scenes never power cards down.
     profiles: [{ card: 'bluez_card.test', profile: 'a2dp-aac' }]
   })
+const prototypeScenes = model.parseAudioScenes(JSON.stringify({
+  scenes: [
+    { name: '__proto__' },
+    { name: 'constructor' },
+    { name: '__proto__' }
+  ]
+}))
+assert.deepEqual(prototypeScenes.scenes.map(scene => scene.name), ['__proto__', 'constructor'])
+const sanitizedScene = model.sanitizeSceneEntry({
+  name: '  Desk\nScene  ',
+  defaults: { output: 'speakers', input: ' mic\n' },
+  devices: [
+    { name: 'bad', direction: 'sideways' },
+    { name: ' speakers\n', direction: 'output', volume: 0.5, muted: true },
+    { name: 'speakers', direction: 'output', volume: Infinity, muted: true },
+    { name: 'speakers', direction: 'output', volume: 0.25, muted: false }
+  ],
+  ports: [
+    { endpoint: 'speakers', direction: 'sideways', value: 'ignored' },
+    { endpoint: 'speakers', direction: 'output', value: 'headphones' },
+    { endpoint: 'speakers', direction: 'output', value: ' ignored\t' }
+  ],
+  profiles: [{ card: 'card.one', profile: 'stereo' }]
+})
+assert.equal(sanitizedScene.name, 'Desk Scene')
+assert.deepEqual(sanitizedScene.defaults, { output: 'speakers', input: '' })
+assert.deepEqual(sanitizedScene.devices, [
+  { name: 'speakers', direction: 'output', volume: 1, muted: false, balance: 0 }
+])
+assert.deepEqual(sanitizedScene.ports, [
+  { endpoint: 'speakers', direction: 'output', value: 'headphones' }
+])
+assert.deepEqual(model.audioScenePlan(sanitizedScene).map(step => step.kind), [
+  'profile', 'settle', 'port', 'device', 'default'
+])
 assert.deepEqual(model.parseAudioPolicySettings(JSON.stringify({
   'node.features.audio.mono': true,
   'linking.pause-playback': 'true',
@@ -94,6 +257,18 @@ assert.deepEqual(audioPreferences, {
   defaults: { output: 'headphones', input: 'headset-microphone' },
   bluetoothProfiles: { '001122334455': 'a2dp-aac' }
 })
+assert.deepEqual(model.parseAudioPreferences(JSON.stringify({
+  defaults: { output: 'bad\noutput', input: ' input ' },
+  bluetoothProfiles: {
+    '00:11:22:33:44:55': 'first-profile',
+    '001122334455': 'second-profile',
+    'not-an-address': 'ignored'
+  }
+})), {
+  version: 1,
+  defaults: { output: '', input: ' input ' },
+  bluetoothProfiles: { '001122334455': 'first-profile' }
+})
 assert.equal(model.preferredAudioProfile(
   audioPreferences, '00-11-22-33-44-55', cards[0].profiles, cards[0].activeProfile
 ), 'a2dp-aac')
@@ -106,19 +281,49 @@ assert.equal(model.preferredAudioNodeName(
 assert.equal(model.preferredAudioNodeName(
   audioPreferences, 'output', { name: 'speakers' }, [{ name: 'speakers' }]
 ), 'speakers')
+assert.equal(model.preferredAudioNodeName(
+  audioPreferences, 'output', { name: 'speakers' }, [
+    { name: 'headphones' }, { name: 'headphones' }, { name: 'speakers' }
+  ]
+), 'speakers')
+assert.equal(model.preferredAudioNodeName(
+  { defaults: { output: '' } }, 'output', { name: 'speakers' }, [
+    { name: 'headphones' }, { name: 'speakers' }, { name: 'speakers' }
+  ]
+), '')
+const oversizedProfileOptions = Array.from({ length: 300 }, (_, index) => ({
+  value: index === 256 ? 'a2dp-aac' : 'profile-' + index
+}))
+assert.equal(model.preferredAudioProfile(
+  audioPreferences, '00:11:22:33:44:55', oversizedProfileOptions, 'fallback'
+), 'fallback')
+const oversizedNodes = Array.from({ length: 4200 }, (_, index) => ({
+  name: index === 4096 ? 'headphones' : 'node-' + index
+}))
+assert.equal(model.preferredAudioNodeName(
+  audioPreferences, 'output', { name: 'speakers' }, oversizedNodes
+), 'speakers')
 assert.equal(model.balanceValue(1, 1), 0)
 assert.equal(model.balanceValue(1, 0.25), -0.75)
 assert.equal(model.balanceValue(0.5, 1), 0.5)
+assert.equal(model.balanceValue(NaN, Infinity), 0)
 assert.deepEqual(model.applyBalance([0.8, 0.8], 0, 1, 0.25), [0.6000000000000001, 0.8])
 assert.deepEqual(model.applyBalance([0.8, 0.8], 0, 1, -1), [0.8, 0])
+assert.deepEqual(model.applyBalance([NaN, Infinity], 0, 1, NaN), [0, 0])
+const oversizedChannels = new Array(65).fill(1)
+assert.equal(model.applyBalance(oversizedChannels, 0, 1, 0.5), oversizedChannels)
 assert.deepEqual([0.2, 0.6, 1].map(volume =>
   model.audioMeterLevel([], [], 1, volume, false)), [0.2, 0.6, 1])
 assert.ok(Math.abs(model.audioMeterLevel([0.8, 0.4], [0.25, 0.75], 0, 0, false) - 0.3) < 1e-9)
 assert.equal(model.audioMeterLevel([1], [1.5], 0, 0, false), 1)
 assert.equal(model.audioMeterLevel([1], [1], 1, 1, true), 0)
+assert.equal(model.audioMeterLevel(
+  new Array(65).fill(1), new Array(65).fill(1), 0.25, 0.5, false), 0.125)
 assert.equal(model.outputVolumeName(1, false), 'Concert hall')
 assert.equal(model.outputVolumeName(1.25, false), 'Concert hall')
 assert.equal(model.outputVolumeName(1.26, false), 'Overdrive')
+assert.equal(model.outputVolumeName(NaN, false), 'Silenced')
+assert.equal(model.outputVolumeName(Infinity, false), 'Silenced')
 assert.deepEqual(model.parseAudioPorts(JSON.stringify([{
   direction: 'output', endpoint: 'speakers', label: 'Built-in Audio', activePort: 'speaker',
   ports: [{ value: 'speaker', label: 'Speakers' }, { value: 'headphones', label: 'Headphones' }]
@@ -134,6 +339,11 @@ assert.deepEqual(model.audioProfileOptions(cards[0]), [
   { value: 'a2dp-aac', label: 'High fidelity (AAC, no microphone)' },
   { value: 'headset-msbc', label: 'Headset (mSBC, microphone)' }
 ])
+assert.equal(model.audioProfileOptions({
+  profiles: Array.from({ length: 300 }, (_, index) => ({ value: String(index), label: String(index) }))
+}).length, 64)
+assert.equal(model.audioCardsByBluetooth(
+  Array.from({ length: 300 }, () => ({ bluetooth: true })), true).length, 64)
 
 const defaultOutput = {
   name: 'default-output',
@@ -159,6 +369,20 @@ const headsetInput = {
   ready: true,
   properties: { 'object.serial': 21 }
 }
+assert.equal(model.nodeObjectId({ id: 42 }), '42')
+assert.equal(model.nodeObjectId({ ready: true, properties: { 'object.id': '43' } }), '43')
+assert.equal(model.nodeObjectId({
+  id: 42, ready: true, properties: { 'object.id': '43' }
+}), '')
+assert.equal(model.nodeObjectId({ id: 'not-an-id' }), '')
+assert.equal(model.nodeName({ name: 'alsa_output.pci' }), 'alsa_output.pci')
+assert.equal(model.nodeName({ name: 'bad\nname' }), '')
+assert.equal(model.nodeName({ name: 42 }), '')
+assert.equal(model.uniqueNodeSerial([defaultOutput, headphones], defaultOutput), '10')
+assert.equal(model.uniqueNodeSerial([
+  defaultOutput,
+  { ready: true, properties: { 'object.serial': 10 } }
+], defaultOutput), '')
 assert.deepEqual(model.streamOutputOptions([defaultOutput, headphones], defaultOutput), [
   { value: 'default:10', label: 'Follow default output' },
   { value: 'override:10', label: 'Always use Desk Speakers' },
@@ -175,6 +399,28 @@ assert.deepEqual(model.streamOutputOptions([headphones], defaultOutput), [
   { value: 'default:10', label: 'Follow default output' },
   { value: 'override:11', label: 'Always use Headphones' }
 ])
+assert.deepEqual(model.streamOutputOptions([
+  defaultOutput,
+  { name: 'duplicate-default', ready: true, properties: { 'object.serial': 10 } },
+  headphones
+], defaultOutput), [
+  { value: 'override:11', label: 'Always use Headphones' }
+])
+assert.deepEqual(model.streamOutputOptions([
+  defaultOutput,
+  headphones,
+  { name: 'duplicate-headphones', ready: true, properties: { 'object.serial': 11 } }
+], defaultOutput), [
+  { value: 'default:10', label: 'Follow default output' },
+  { value: 'override:10', label: 'Always use Desk Speakers' }
+])
+const oversizedRouteDevices = Array.from({ length: 600 }, (_, index) => ({
+  name: 'route-' + index,
+  ready: true,
+  properties: { 'object.serial': index + 1 }
+}))
+assert.equal(model.streamOutputOptions(
+  oversizedRouteDevices, oversizedRouteDevices[0]).length, 513)
 
 const playbackStream = {
   name: 'firefox', isStream: true, isSink: true, ready: true, audio: {},
@@ -195,6 +441,7 @@ const obsStream = {
 const classified = model.classifyAudioNodes([
   { name: 'speakers', isStream: false, isSink: true },
   { name: 'microphone', isStream: false, isSink: false, ready: true, audio: {} },
+  { name: 'audio-filter', isStream: false, ready: true, audio: {}, type: 'Audio/Filter' },
   { name: 'speakers.monitor', isStream: false, isSink: false, ready: true, audio: {} },
   playbackStream,
   recordingStream,
@@ -209,6 +456,24 @@ assert.deepEqual(classified.sinks.map(node => node.name), ['speakers'])
 assert.deepEqual(classified.sources.map(node => node.name), ['microphone'])
 assert.deepEqual(classified.playbackStreams.map(node => node.name), ['firefox'])
 assert.deepEqual(classified.recordingStreams.map(node => node.name), ['firefox-capture'])
+assert.equal(model.isPlaybackStream({
+  isStream: true, isSink: false, type: 'Stream/Output/Audio'
+}), false)
+assert.equal(model.isRecordingStream({
+  isStream: true, isSink: true, type: 'Stream/Input/Audio'
+}), false)
+assert.deepEqual(model.listSnapshot({ 0: 'first', 1: 'second', length: 2 }), [
+  'first', 'second'
+])
+const vanishedNode = {}
+Object.defineProperty(vanishedNode, 'ready', { get() { throw new Error('vanished') } })
+Object.defineProperty(vanishedNode, 'name', { get() { throw new Error('vanished') } })
+assert.equal(model.nodeName(vanishedNode), '')
+assert.equal(model.nodeObjectId(vanishedNode), '')
+assert.deepEqual(model.classifyAudioNodes([vanishedNode]), {
+  sinks: [], sources: [], playbackStreams: [], recordingStreams: []
+})
+assert.deepEqual(model.availableRuleApplicationLabels([vanishedNode], [], []), [])
 
 assert.deepEqual(model.availableRuleApplicationLabels(
   [playbackStream, vlcStream], [recordingStream, obsStream], [
@@ -216,9 +481,28 @@ assert.deepEqual(model.availableRuleApplicationLabels(
     { app: 'obs', direction: 'recording', target: 'microphone' }
   ]
 ), ['Firefox', 'VLC'])
+const oversizedRuleStreams = Array.from({ length: 600 }, (_, index) => ({
+  ready: true,
+  audio: {},
+  properties: { 'application.name': 'Application ' + index }
+}))
+assert.equal(model.availableRuleApplicationLabels(oversizedRuleStreams, [], []).length, 512)
+assert.equal(model.findAppRule(Array.from({ length: 300 }, (_, index) => ({
+  app: index === 256 ? 'late-app' : 'app-' + index,
+  direction: 'playback',
+  target: 'speakers'
+})), 'playback', 'late-app'), null)
 assert.deepEqual(model.parseAudioRules(JSON.stringify({
   devices: { favorites: ['speakers', 'speakers'], hidden: ['mic', 'mic'] }
 })).devices, { aliases: {}, favorites: ['speakers'], hidden: ['mic'] })
+const prototypeRules = model.parseAudioRules(
+  '{"appRules":[{"app":"__proto__","direction":"playback","target":"speakers"},' +
+  '{"app":"constructor","direction":"recording","target":"mic"}],' +
+  '"devices":{"aliases":{"__proto__":"Prototype alias","constructor":"Safe alias"}}}'
+)
+assert.deepEqual(prototypeRules.appRules.map(rule => rule.app), ['__proto__', 'constructor'])
+assert.deepEqual(prototypeRules.devices.aliases,
+  JSON.parse('{"__proto__":"Prototype alias","constructor":"Safe alias"}'))
 assert.deepEqual(['other', 'hasOwnProperty'].sort(
   model.deviceSortComparator(['hasOwnProperty'])), ['hasOwnProperty', 'other'])
 assert.deepEqual([{ name: 'speakers' }, { name: 'headphones' }].sort(
@@ -232,10 +516,46 @@ assert.deepEqual(model.uniqueRecordingStreamLabels([
 ]), ['Firefox', 'Discord'])
 assert.deepEqual(model.addedRecordingStreamLabels(
   ['Firefox', 'OBS'], ['firefox', 'Discord', 'OBS Studio']), ['Discord', 'OBS Studio'])
+assert.equal(model.uniqueRecordingStreamLabels(Array.from({ length: 600 }, (_, index) => ({
+  ready: true,
+  properties: { 'application.name': 'Recorder ' + index }
+}))).length, 512)
+assert.deepEqual(model.addedRecordingStreamLabels([], ['Recorder', 'recorder']), ['Recorder'])
+const lateMprisPlayers = Array.from({ length: 257 }, () => null)
+lateMprisPlayers[256] = { identity: 'Late Player', isPlaying: true, canPlay: true }
+assert.equal(model.mprisLabelsFor(lateMprisPlayers, () => true), '')
+assert.equal(model.mprisLabelsFor({
+  0: { identity: 'Sequence Player', isPlaying: true, canPlay: true },
+  length: 1
+}, () => true), 'Sequence Player')
 assert.equal(model.streamIconName({ ready: true, properties: { 'application.icon_name': 'firefox' } }, [], []), 'firefox')
 assert.equal(model.streamIconName({ ready: true, properties: { 'application.icon_name': 'chromium-browser' } }, [], []), 'chromium')
 assert.equal(model.streamIconName({ ready: true, properties: { 'application.id': 'org.example.App.desktop' } }, [], []), 'org.example.App')
 assert.equal(model.streamIconName({ description: 'Spotify' }, [], []), 'spotify')
+assert.equal(model.streamIconName({ ready: true, properties: {
+  'application.icon_name': '../../private/icon'
+} }, [], []), '')
+assert.equal(model.friendlyStreamLabel('constructor'), 'constructor')
+const prototypeAvailability = model.parseSinkAvailability('__proto__\t0\nconstructor\t0\n')
+assert.equal(model.mapValue(prototypeAvailability, '__proto__', true), false)
+assert.equal(model.mapValue(prototypeAvailability, 'constructor', true), false)
+assert.equal(model.parseSinkAvailability('duplicate\t1\nduplicate\t0\n').duplicate, false)
+assert.deepEqual(model.parseAudioStreamRoutes(JSON.stringify({
+  playback: { 300: { target: 101, mode: 'override' }, bad: { target: 9, mode: 'override' } },
+  recording: { 400: { target: '201', mode: 'default' }, 401: { target: 'x', mode: 'default' } }
+})), {
+  valid: true,
+  playback: { 300: { target: '101', mode: 'override' } },
+  recording: { 400: { target: '201', mode: 'default' } }
+})
+assert.deepEqual(model.parseAudioStreamRoutes('not json'), {
+  valid: false, playback: {}, recording: {}
+})
+assert.deepEqual(model.parseStreamOutputOption('override:' + '1'.repeat(21)), { mode: '', sink: '' })
+assert.deepEqual(model.parseAudioStreamRoutes(JSON.stringify({
+  playback: { ['1'.repeat(21)]: { target: 1, mode: 'override' } },
+  recording: { 1: { target: '2'.repeat(21), mode: 'default' } }
+})), { valid: true, playback: {}, recording: {} })
 const diagnostics = model.parseAudioDiagnostics(JSON.stringify({
   version: 1,
   healthy: true,
@@ -264,8 +584,8 @@ diagnostics_snapshot=$(
   PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-diagnostics" snapshot
 )
 jq -e '
-  .healthy == true
-  and .versions == {"plugin":"0.7.0","pipewire":"1.6.8","wireplumber":"0.5.15"}
+  .healthy == false
+  and .versions == {"plugin":"0.7.1","pipewire":"1.6.8","wireplumber":"0.5.15"}
   and .graph.rate == 48000
   and .graph.quantum == 256
   and .graph.latencyMs == 5.3
@@ -299,7 +619,7 @@ support_report=$(
 )
 grep -q '^  playback: Browser -> Output Filter -> Wireless Headphones$' <<<"$support_report" ||
   fail "support report active route"
-grep -q '^  Advanced Audio Control: 0.7.0$' <<<"$support_report" ||
+grep -q '^  Advanced Audio Control: 0.7.1$' <<<"$support_report" ||
   fail "support report plugin version"
 grep -q '^  Peak DSP load: 5%$' <<<"$support_report" || fail "support report DSP load"
 ! grep -q 'bluez_output.test\|alsa_input.usb-microphone' <<<"$support_report" ||
@@ -308,6 +628,41 @@ grep -q 'Wireless Headphones \[redacted-address\]' <<<"$support_report" ||
   fail "support report hardware address redaction"
 ! grep -q '00:11:22:33:44:55' <<<"$support_report" ||
   fail "support report leaked a hardware address"
+
+privacy_fixture=$(mktemp -d)
+cp -a -- "$diagnostics_fixture/." "$privacy_fixture/"
+jq '
+  .[0].description = .[0].name
+  | .[1].description = "Receiver 001122334455"
+  | . += [{
+      "index": 102,
+      "name": "alsa_output.private_001122334455",
+      "description": "alsa_output.private_001122334455",
+      "state": "IDLE",
+      "sample_specification": "s16le 2ch 48000Hz",
+      "channel_map": "front-left,front-right",
+      "properties": {}
+    }]
+' "$privacy_fixture/sinks.json" >"$privacy_fixture/sinks.json.new"
+mv -f -- "$privacy_fixture/sinks.json.new" "$privacy_fixture/sinks.json"
+privacy_report=$(
+  USER=Browser HOSTNAME='Wireless Headphones' \
+  AUDIO_CONTROL_DIAGNOSTICS_FIXTURE_DIR="$privacy_fixture" \
+  AUDIO_CONTROL_RECOVERY_COMMAND=omarchy-restart-audio \
+  AUDIO_CONTROL_RECOVERY_LAUNCHER=omarchy-launch-floating-terminal-with-presentation \
+  AUDIO_CONTROL_SPEAKER_TEST_COMMAND=speaker-test \
+  AUDIO_CONTROL_CLIPBOARD_COMMAND=wl-copy \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-diagnostics" report
+)
+! grep -q 'Browser\|Wireless Headphones\|bluez_output.test\|alsa_output.private\|001122334455' \
+  <<<"$privacy_report" || fail "support report leaked a private identifier"
+grep -q '\[redacted-user\].*\[redacted-host\]' <<<"$privacy_report" ||
+  fail "support report username or hostname redaction"
+grep -q 'Unnamed output device' <<<"$privacy_report" ||
+  fail "support report raw-name fallback redaction"
+grep -q 'Receiver \[redacted-address\]' <<<"$privacy_report" ||
+  fail "support report compact hardware address redaction"
+rm -rf -- "$privacy_fixture"
 
 diagnostic_tmp=$(mktemp -d)
 clipboard_log="$diagnostic_tmp/clipboard"
@@ -338,20 +693,69 @@ if AUDIO_CONTROL_DIAGNOSTIC_SINK_FIXTURE="$diagnostics_fixture/sinks.json" \
   fail "speaker test accepted an absent output"
 fi
 
+duplicate_sink_fixture="$diagnostic_tmp/duplicate-sinks.json"
+jq '. + [.[0]]' "$diagnostics_fixture/sinks.json" >"$duplicate_sink_fixture"
+: >"$speaker_log"
+if AUDIO_CONTROL_DIAGNOSTIC_SINK_FIXTURE="$duplicate_sink_fixture" \
+  AUDIO_CONTROL_SPEAKER_TEST_COMMAND=speaker-test \
+  AUDIO_CONTROL_SPEAKER_TEST_LOG="$speaker_log" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-speaker-test" bluez_output.test >/dev/null 2>&1; then
+  fail "speaker test accepted an ambiguous output"
+fi
+[[ ! -s $speaker_log ]] || fail "ambiguous speaker output started playback"
+
+unsafe_diagnostics_fixture="$diagnostic_tmp/unsafe-fixtures"
+mkdir -- "$unsafe_diagnostics_fixture"
+cp -a -- "$diagnostics_fixture/." "$unsafe_diagnostics_fixture/"
+rm -f -- "$unsafe_diagnostics_fixture/metadata.txt" "$unsafe_diagnostics_fixture/dump.json" \
+  "$unsafe_diagnostics_fixture/sinks.json"
+ln -s -- /etc/passwd "$unsafe_diagnostics_fixture/metadata.txt"
+ln -s -- /etc/passwd "$unsafe_diagnostics_fixture/dump.json"
+truncate -s 16777217 "$unsafe_diagnostics_fixture/sinks.json"
+unsafe_diagnostics_snapshot=$(
+  AUDIO_CONTROL_DIAGNOSTICS_FIXTURE_DIR="$unsafe_diagnostics_fixture" \
+  AUDIO_CONTROL_RECOVERY_COMMAND=omarchy-restart-audio \
+  AUDIO_CONTROL_RECOVERY_LAUNCHER=omarchy-launch-floating-terminal-with-presentation \
+  AUDIO_CONTROL_SPEAKER_TEST_COMMAND=speaker-test \
+  AUDIO_CONTROL_CLIPBOARD_COMMAND=wl-copy \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-diagnostics" snapshot
+)
+jq -e '
+  .healthy == false
+  and .devices == []
+  and .capabilities.topology == false
+  and (.warnings | index("PipeWire graph settings could not be read.") != null)
+  and (.warnings | index("Playback devices could not be inspected.") != null)
+  and (.warnings | index("The active PipeWire route graph could not be inspected.") != null)
+' <<<"$unsafe_diagnostics_snapshot" >/dev/null ||
+  fail "unsafe or oversized diagnostics fixtures were consumed"
+
 AUDIO_CONTROL_RECOVERY_COMMAND=omarchy-restart-audio \
   AUDIO_CONTROL_RECOVERY_LAUNCHER=omarchy-launch-floating-terminal-with-presentation \
   AUDIO_CONTROL_RECOVERY_LOG="$recovery_log" PATH="$TEST_DIR/mocks:$PATH" \
   "$ROOT/scripts/audio-recovery"
-for _attempt in {1..50}; do
-  [[ -s $recovery_log ]] && break
-  sleep 0.01
-done
-grep -q '/omarchy-restart-audio$' "$recovery_log" || fail "guarded Omarchy recovery launch"
+grep -Eq '^launch=.*audio-recovery --run$' "$recovery_log" ||
+  fail "guarded Omarchy recovery launch"
+grep -q '^recovery=run$' "$recovery_log" || fail "Omarchy recovery execution"
+if AUDIO_CONTROL_RECOVERY_COMMAND=omarchy-restart-audio \
+  AUDIO_CONTROL_RECOVERY_LAUNCHER=omarchy-launch-floating-terminal-with-presentation \
+  AUDIO_CONTROL_RECOVERY_LOG="$recovery_log" AUDIO_CONTROL_RECOVERY_LAUNCH_FAIL=1 \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-recovery" >/dev/null 2>&1; then
+  fail "recovery launcher failure reported success"
+fi
+if AUDIO_CONTROL_RECOVERY_COMMAND=omarchy-restart-audio \
+  AUDIO_CONTROL_RECOVERY_LOG="$recovery_log" AUDIO_CONTROL_RECOVERY_EXIT=7 \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-recovery" --run >/dev/null 2>&1; then
+  fail "recovery command failure reported success"
+else
+  [[ $? == 7 ]] || fail "recovery command exit status was not preserved"
+fi
 echo "PASS: native diagnostics and guarded recovery"
 rm -rf -- "$diagnostic_tmp"
 
 route_log=$(mktemp)
-trap 'rm -f "$route_log"' EXIT
+route_read_state=$(mktemp)
+trap 'rm -f "$route_log" "$route_read_state"' EXIT
 
 AUDIO_CONTROL_ROUTE_LOG="$route_log" PATH="$TEST_DIR/mocks:$PATH" \
   "$ROOT/scripts/audio-stream-route-set" playback 300 101 override
@@ -388,13 +792,166 @@ EOF
 )
 [[ $(<"$route_log") == "$expected_route_log" ]] || fail "persistent recording target"
 
+: >"$route_log"
+if AUDIO_CONTROL_ROUTE_LOG="$route_log" AUDIO_CONTROL_ROUTE_METADATA_READ_FAIL=1 \
+  PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-stream-route-set" playback 300 101 override >/dev/null 2>&1; then
+  fail "stream route accepted unreadable persistence metadata"
+fi
+[[ ! -s $route_log ]] || fail "stream moved before persistence metadata validation"
+
+: >"$route_log"
+if AUDIO_CONTROL_ROUTE_LOG="$route_log" AUDIO_CONTROL_ROUTE_DUPLICATE_METADATA_VALUE=1 \
+  PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-stream-route-set" playback 300 101 override >/dev/null 2>&1; then
+  fail "stream route accepted ambiguous persistence metadata"
+fi
+[[ ! -s $route_log ]] || fail "stream moved after ambiguous persistence metadata"
+
+: >"$route_log"
+if AUDIO_CONTROL_ROUTE_LOG="$route_log" \
+  AUDIO_CONTROL_ROUTE_PREVIOUS_OBJECT=123456789012345678901 \
+  AUDIO_CONTROL_ROUTE_PREVIOUS_NODE=123456789012345678901 \
+  PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-stream-route-set" playback 300 101 override >/dev/null 2>&1; then
+  fail "stream route accepted unbounded persistence metadata"
+fi
+[[ ! -s $route_log ]] || fail "stream moved after malformed persistence metadata"
+
+: >"$route_log"
+if AUDIO_CONTROL_ROUTE_LOG="$route_log" \
+  AUDIO_CONTROL_ROUTE_PREVIOUS_OBJECT=-2 AUDIO_CONTROL_ROUTE_PREVIOUS_NODE=-2 \
+  PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-stream-route-set" playback 300 101 override >/dev/null 2>&1; then
+  fail "stream route accepted an invalid negative metadata target"
+fi
+[[ ! -s $route_log ]] || fail "stream moved after invalid negative metadata"
+
+: >"$route_log"
+if AUDIO_CONTROL_ROUTE_LOG="$route_log" AUDIO_CONTROL_ROUTE_ORIGINAL_SINK=100 \
+  AUDIO_CONTROL_ROUTE_DUPLICATE_ORIGINAL_OBJECT=1 PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-stream-route-set" playback 300 101 override >/dev/null 2>&1; then
+  fail "stream route accepted an ambiguous rollback endpoint"
+fi
+[[ ! -s $route_log ]] || fail "stream moved without a unique rollback endpoint"
+
+: >"$route_log"
+if AUDIO_CONTROL_ROUTE_LOG="$route_log" AUDIO_CONTROL_ROUTE_ORIGINAL_SINK=100 \
+  AUDIO_CONTROL_ROUTE_PREVIOUS_OBJECT=100 AUDIO_CONTROL_ROUTE_PREVIOUS_NODE=1000 \
+  AUDIO_CONTROL_ROUTE_METADATA_WRITE_FAIL=target.node PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-stream-route-set" playback 300 101 override >/dev/null 2>&1; then
+  fail "partially persisted stream route reported success"
+fi
+expected_route_log=$(cat <<'EOF'
+move-sink-input 300 101
+pw-metadata -n default -- 900 target.object 101 Spa:Id
+pw-metadata -n default -- 900 target.node 1001 Spa:Id
+move-sink-input 300 100
+pw-metadata -n default -- 900 target.object 100 Spa:Id
+pw-metadata -n default -- 900 target.node 1000 Spa:Id
+EOF
+)
+[[ $(<"$route_log") == "$expected_route_log" ]] || fail "partial stream route rollback"
+
+# Command status is not authoritative: accept a fully verified change even
+# when Pulse reports a late transport failure.
+: >"$route_log"
+AUDIO_CONTROL_ROUTE_LOG="$route_log" AUDIO_CONTROL_ROUTE_ORIGINAL_SINK=100 \
+  AUDIO_CONTROL_ROUTE_PREVIOUS_OBJECT=100 AUDIO_CONTROL_ROUTE_PREVIOUS_NODE=1000 \
+  AUDIO_CONTROL_ROUTE_MOVE_FAIL_AFTER_EFFECT_TARGET=101 PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-stream-route-set" playback 300 101 override ||
+  fail "verified route rejected after late move failure"
+
+: >"$route_log"
+AUDIO_CONTROL_ROUTE_LOG="$route_log" AUDIO_CONTROL_ROUTE_ORIGINAL_SINK=100 \
+  AUDIO_CONTROL_ROUTE_PREVIOUS_OBJECT=100 AUDIO_CONTROL_ROUTE_PREVIOUS_NODE=1000 \
+  AUDIO_CONTROL_ROUTE_METADATA_WRITE_FAIL=target.node \
+  AUDIO_CONTROL_ROUTE_METADATA_FAIL_AFTER_EFFECT=1 PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-stream-route-set" playback 300 101 override ||
+  fail "verified route rejected after late metadata failure"
+
+: >"$route_log"
+if AUDIO_CONTROL_ROUTE_LOG="$route_log" AUDIO_CONTROL_ROUTE_ORIGINAL_SINK=100 \
+  AUDIO_CONTROL_ROUTE_PREVIOUS_OBJECT=100 AUDIO_CONTROL_ROUTE_PREVIOUS_NODE=1000 \
+  AUDIO_CONTROL_ROUTE_MOVE_NO_EFFECT_TARGET=101 PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-stream-route-set" playback 300 101 override >/dev/null 2>&1; then
+  fail "stream route accepted a no-op move"
+fi
+[[ $(<"$route_log") == "move-sink-input 300 101" ]] ||
+  fail "no-op stream move wrote persistence metadata"
+
+: >"$route_log"
+if AUDIO_CONTROL_ROUTE_LOG="$route_log" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-stream-route-set" playback 300 999 override >/dev/null 2>&1; then
+  fail "stream route accepted an absent target"
+fi
+[[ ! -s $route_log ]] || fail "absent stream target changed live state"
+
+: >"$route_log"
+printf '0\n' >"$route_read_state"
+AUDIO_CONTROL_ROUTE_LOG="$route_log" AUDIO_CONTROL_ROUTE_READ_STATE="$route_read_state" \
+  AUDIO_CONTROL_ROUTE_STREAM_INDEX_REUSE=1 AUDIO_CONTROL_ROUTE_ORIGINAL_SINK=100 \
+  AUDIO_CONTROL_ROUTE_PREVIOUS_OBJECT=100 AUDIO_CONTROL_ROUTE_PREVIOUS_NODE=1000 \
+  PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-stream-route-set" playback 300 101 override ||
+  fail "identity-safe route rejected a reindexed stream"
+grep -q '^move-sink-input 302 101$' "$route_log" ||
+  fail "route mutation targeted a reused stream index"
+! grep -q '^move-sink-input 300 ' "$route_log" ||
+  fail "route mutation touched the replacement stream"
+
+: >"$route_log"
+printf '0\n' >"$route_read_state"
+AUDIO_CONTROL_ROUTE_LOG="$route_log" AUDIO_CONTROL_ROUTE_READ_STATE="$route_read_state" \
+  AUDIO_CONTROL_ROUTE_TARGET_REINDEX=1 AUDIO_CONTROL_ROUTE_ORIGINAL_SINK=100 \
+  AUDIO_CONTROL_ROUTE_PREVIOUS_OBJECT=100 AUDIO_CONTROL_ROUTE_PREVIOUS_NODE=1000 \
+  PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-stream-route-set" playback 300 101 override ||
+  fail "identity-safe route rejected a reindexed endpoint"
+grep -q '^move-sink-input 300 103$' "$route_log" ||
+  fail "route mutation targeted a reused endpoint index"
+grep -q '^pw-metadata -n default -- 900 target.object 103 Spa:Id$' "$route_log" ||
+  fail "route persistence retained a stale endpoint index"
+
+: >"$route_log"
+printf '0\n' >"$route_read_state"
+if AUDIO_CONTROL_ROUTE_LOG="$route_log" AUDIO_CONTROL_ROUTE_READ_STATE="$route_read_state" \
+  AUDIO_CONTROL_ROUTE_DUPLICATE_STREAM_OBJECT=1 AUDIO_CONTROL_ROUTE_ORIGINAL_SINK=100 \
+  PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-stream-route-set" playback 300 101 override >/dev/null 2>&1; then
+  fail "ambiguous live stream identity accepted"
+fi
+[[ ! -s $route_log ]] || fail "ambiguous live stream identity changed state"
+
 routes=$(AUDIO_CONTROL_ROUTE_LIST=1 PATH="$TEST_DIR/mocks:$PATH" \
   "$ROOT/scripts/audio-stream-routes")
 jq -e '
   .playback["300"] == {"target":"101","mode":"override"}
   and .recording["400"] == {"target":"201","mode":"override"}
 ' <<<"$routes" >/dev/null || fail "playback and recording route snapshot"
+for invalid_routes in \
+  '{"sink_inputs":{},"source_outputs":[]}' \
+  '{"sink_inputs":[{"index":300,"sink":101,"properties":{"object.id":"900"}},{"index":300,"sink":101,"properties":{"object.id":"902"}}],"source_outputs":[]}' \
+  '{"sink_inputs":[{"index":300,"sink":101,"properties":{"object.id":"900"}},{"index":302,"sink":101,"properties":{"object.id":"900"}}],"source_outputs":[]}' \
+  '{"sink_inputs":[{"index":300,"sink":101,"properties":{}}],"source_outputs":[]}'; do
+  if AUDIO_CONTROL_ROUTE_LIST=1 AUDIO_CONTROL_ROUTE_LIST_JSON="$invalid_routes" \
+      PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-stream-routes" \
+      >/dev/null 2>&1; then
+    fail "malformed stream route snapshot accepted"
+  fi
+done
+if AUDIO_CONTROL_ROUTE_LIST=1 AUDIO_CONTROL_ROUTE_LIST_OVERSIZED_METADATA=1 \
+    PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-stream-routes" \
+    >/dev/null 2>&1; then
+  fail "oversized persistent route metadata accepted"
+fi
+if AUDIO_CONTROL_ROUTE_LIST=1 AUDIO_CONTROL_ROUTE_LIST_INVALID_METADATA=1 \
+    PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-stream-routes" \
+    >/dev/null 2>&1; then
+  fail "invalid persistent route metadata accepted"
+fi
 echo "PASS: persistent application routing"
+rm -f -- "$route_read_state"
 
 output_default_log=$(mktemp)
 input_default_log=$(mktemp)
@@ -404,9 +961,47 @@ shared_preferences_output_lock="${shared_preferences}.output.lock"
 shared_preferences_input_lock="${shared_preferences}.input.lock"
 trap 'rm -f "$route_log" "$output_default_log" "$input_default_log" "$shared_preferences" "$shared_preferences_lock" "$shared_preferences_output_lock" "$shared_preferences_input_lock"' EXIT
 
+: >"$output_default_log"
+if AUDIO_CONTROL_OUTPUT_DEFAULT_LOG="$output_default_log" \
+  OMARCHY_AUDIO_PREFERENCES_FILE="$shared_preferences" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-output-set-default" 51 new-speakers stale-speakers \
+    >/dev/null 2>&1; then
+  fail "stale current default output guard accepted"
+fi
+[[ ! -s $output_default_log && ! -s $shared_preferences ]] ||
+  fail "stale current default output guard changed state"
+
+if AUDIO_CONTROL_OUTPUT_DEFAULT_LOG="$output_default_log" \
+  OMARCHY_AUDIO_PREFERENCES_FILE="$shared_preferences" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-output-set-default" 51 new-speakers old-speakers 999 \
+    >/dev/null 2>&1; then
+  fail "stale current default output object guard accepted"
+fi
+[[ ! -s $output_default_log && ! -s $shared_preferences ]] ||
+  fail "stale current default output object guard changed state"
+
+: >"$input_default_log"
+if AUDIO_CONTROL_INPUT_DEFAULT_LOG="$input_default_log" \
+  OMARCHY_AUDIO_PREFERENCES_FILE="$shared_preferences" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-input-set-default" 52 new-microphone stale-microphone \
+    >/dev/null 2>&1; then
+  fail "stale current default input guard accepted"
+fi
+[[ ! -s $input_default_log && ! -s $shared_preferences ]] ||
+  fail "stale current default input guard changed state"
+
+if AUDIO_CONTROL_INPUT_DEFAULT_LOG="$input_default_log" \
+  OMARCHY_AUDIO_PREFERENCES_FILE="$shared_preferences" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-input-set-default" 52 new-microphone old-microphone 999 \
+    >/dev/null 2>&1; then
+  fail "stale current default input object guard accepted"
+fi
+[[ ! -s $input_default_log && ! -s $shared_preferences ]] ||
+  fail "stale current default input object guard changed state"
+
 AUDIO_CONTROL_OUTPUT_DEFAULT_LOG="$output_default_log" \
   OMARCHY_AUDIO_PREFERENCES_FILE="$shared_preferences" PATH="$TEST_DIR/mocks:$PATH" \
-  "$ROOT/scripts/audio-output-set-default" 51 new-speakers old-speakers
+  "$ROOT/scripts/audio-output-set-default" 51 new-speakers old-speakers 50
 
 expected_output_default_log=$(cat <<'EOF'
 wpctl set-default 51
@@ -419,7 +1014,7 @@ EOF
 
 AUDIO_CONTROL_INPUT_DEFAULT_LOG="$input_default_log" \
   OMARCHY_AUDIO_PREFERENCES_FILE="$shared_preferences" PATH="$TEST_DIR/mocks:$PATH" \
-  "$ROOT/scripts/audio-input-set-default" 52 new-microphone old-microphone
+  "$ROOT/scripts/audio-input-set-default" 52 new-microphone old-microphone 60
 
 expected_input_default_log=$(cat <<'EOF'
 wpctl set-default 52
@@ -432,6 +1027,197 @@ EOF
 jq -e '
   .defaults == {"output":"new-speakers","input":"new-microphone"}
 ' "$shared_preferences" >/dev/null || fail "verified default devices"
+
+: >"$output_default_log"
+AUDIO_CONTROL_OUTPUT_DEFAULT_LOG="$output_default_log" \
+  AUDIO_CONTROL_DEFAULT_TARGET_REINDEX=output \
+  OMARCHY_AUDIO_PREFERENCES_FILE="$shared_preferences" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-output-set-default" 51 new-speakers old-speakers ||
+  fail "reindexed default output target rejected"
+grep -q '^pactl move-sink-input 300 new-speakers$' "$output_default_log" ||
+  fail "reindexed default output follower was not moved safely"
+
+: >"$input_default_log"
+AUDIO_CONTROL_INPUT_DEFAULT_LOG="$input_default_log" \
+  AUDIO_CONTROL_DEFAULT_TARGET_REINDEX=input \
+  OMARCHY_AUDIO_PREFERENCES_FILE="$shared_preferences" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-input-set-default" 52 new-microphone old-microphone ||
+  fail "reindexed default input target rejected"
+grep -q '^pactl move-source-output 400 new-microphone$' "$input_default_log" ||
+  fail "reindexed default input follower was not moved safely"
+
+: >"$output_default_log"
+if AUDIO_CONTROL_OUTPUT_DEFAULT_LOG="$output_default_log" \
+  AUDIO_CONTROL_DEFAULT_TARGET_OBJECT=999 OMARCHY_AUDIO_PREFERENCES_FILE="$shared_preferences" \
+  PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-output-set-default" 51 new-speakers old-speakers >/dev/null 2>&1; then
+  fail "stale default output node id accepted"
+else
+  [[ $? == 3 ]] || fail "stale default output node id reported wrong exit code"
+fi
+[[ ! -s $output_default_log ]] || fail "stale default output changed hardware"
+
+replacement_preferences=$(mktemp)
+: >"$output_default_log"
+if AUDIO_CONTROL_OUTPUT_DEFAULT_LOG="$output_default_log" \
+  AUDIO_CONTROL_DEFAULT_TARGET_REPLACED_AFTER_SET=output \
+  OMARCHY_AUDIO_PREFERENCES_FILE="$replacement_preferences" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-output-set-default" 51 new-speakers old-speakers \
+  >/dev/null 2>&1; then
+  fail "same-name replacement completed a default output change"
+fi
+expected_output_replacement_log=$(cat <<'EOF'
+wpctl set-default 51
+pactl set-default-sink new-speakers
+wpctl set-default 50
+pactl set-default-sink old-speakers
+EOF
+)
+[[ $(<"$output_default_log") == "$expected_output_replacement_log" ]] ||
+  fail "same-name default output replacement was not rolled back"
+[[ ! -s $replacement_preferences ]] ||
+  fail "same-name default output replacement was persisted"
+rm -f -- "$replacement_preferences" "${replacement_preferences}.lock" \
+  "${replacement_preferences}.output.lock"
+
+replacement_preferences=$(mktemp)
+: >"$output_default_log"
+if AUDIO_CONTROL_OUTPUT_DEFAULT_LOG="$output_default_log" \
+  AUDIO_CONTROL_DEFAULT_OLD_REPLACED_AFTER_SET=output \
+  OMARCHY_AUDIO_PREFERENCES_FILE="$replacement_preferences" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-output-set-default" 51 new-speakers old-speakers \
+    >/dev/null 2>&1; then
+  fail "replacement old output completed an unverifiable rollback"
+else
+  [[ $? == 4 ]] || fail "replacement old output reported a complete rollback"
+fi
+[[ $(<"$output_default_log") == $'wpctl set-default 51\npactl set-default-sink new-speakers' ]] ||
+  fail "default output rollback targeted a same-name replacement"
+[[ ! -s $replacement_preferences ]] || fail "unrestorable default output was persisted"
+rm -f -- "$replacement_preferences" "${replacement_preferences}.lock" \
+  "${replacement_preferences}.output.lock"
+
+: >"$output_default_log"
+if AUDIO_CONTROL_OUTPUT_DEFAULT_LOG="$output_default_log" \
+  AUDIO_CONTROL_DEFAULT_DUPLICATE_TARGET=output \
+  OMARCHY_AUDIO_PREFERENCES_FILE="$shared_preferences" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-output-set-default" 51 new-speakers old-speakers >/dev/null 2>&1; then
+  fail "ambiguous default output target accepted"
+fi
+[[ ! -s $output_default_log ]] || fail "ambiguous default output changed hardware"
+
+: >"$output_default_log"
+if AUDIO_CONTROL_OUTPUT_DEFAULT_LOG="$output_default_log" \
+  AUDIO_CONTROL_DEFAULT_DUPLICATE_STREAM=output \
+  OMARCHY_AUDIO_PREFERENCES_FILE="$shared_preferences" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-output-set-default" 51 new-speakers old-speakers >/dev/null 2>&1; then
+  fail "ambiguous playback follower identity accepted"
+fi
+[[ ! -s $output_default_log ]] || fail "ambiguous playback follower changed hardware"
+
+: >"$input_default_log"
+if AUDIO_CONTROL_INPUT_DEFAULT_LOG="$input_default_log" \
+  AUDIO_CONTROL_DEFAULT_DUPLICATE_TARGET=input \
+  OMARCHY_AUDIO_PREFERENCES_FILE="$shared_preferences" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-input-set-default" 52 new-microphone old-microphone >/dev/null 2>&1; then
+  fail "ambiguous default input target accepted"
+fi
+[[ ! -s $input_default_log ]] || fail "ambiguous default input changed hardware"
+
+replacement_preferences=$(mktemp)
+: >"$input_default_log"
+if AUDIO_CONTROL_INPUT_DEFAULT_LOG="$input_default_log" \
+  AUDIO_CONTROL_DEFAULT_TARGET_REPLACED_AFTER_SET=input \
+  OMARCHY_AUDIO_PREFERENCES_FILE="$replacement_preferences" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-input-set-default" 52 new-microphone old-microphone \
+  >/dev/null 2>&1; then
+  fail "same-name replacement completed a default input change"
+fi
+expected_input_replacement_log=$(cat <<'EOF'
+wpctl set-default 52
+pactl set-default-source new-microphone
+wpctl set-default 60
+pactl set-default-source old-microphone
+EOF
+)
+[[ $(<"$input_default_log") == "$expected_input_replacement_log" ]] ||
+  fail "same-name default input replacement was not rolled back"
+[[ ! -s $replacement_preferences ]] ||
+  fail "same-name default input replacement was persisted"
+rm -f -- "$replacement_preferences" "${replacement_preferences}.lock" \
+  "${replacement_preferences}.input.lock"
+
+replacement_preferences=$(mktemp)
+: >"$input_default_log"
+if AUDIO_CONTROL_INPUT_DEFAULT_LOG="$input_default_log" \
+  AUDIO_CONTROL_DEFAULT_OLD_REPLACED_AFTER_SET=input \
+  OMARCHY_AUDIO_PREFERENCES_FILE="$replacement_preferences" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-input-set-default" 52 new-microphone old-microphone \
+    >/dev/null 2>&1; then
+  fail "replacement old input completed an unverifiable rollback"
+else
+  [[ $? == 4 ]] || fail "replacement old input reported a complete rollback"
+fi
+[[ $(<"$input_default_log") == $'wpctl set-default 52\npactl set-default-source new-microphone' ]] ||
+  fail "default input rollback targeted a same-name replacement"
+[[ ! -s $replacement_preferences ]] || fail "unrestorable default input was persisted"
+rm -f -- "$replacement_preferences" "${replacement_preferences}.lock" \
+  "${replacement_preferences}.input.lock"
+
+: >"$input_default_log"
+if AUDIO_CONTROL_INPUT_DEFAULT_LOG="$input_default_log" \
+  AUDIO_CONTROL_DEFAULT_DUPLICATE_STREAM=input \
+  OMARCHY_AUDIO_PREFERENCES_FILE="$shared_preferences" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-input-set-default" 52 new-microphone old-microphone >/dev/null 2>&1; then
+  fail "ambiguous recording follower identity accepted"
+fi
+[[ ! -s $input_default_log ]] || fail "ambiguous recording follower changed hardware"
+
+: >"$output_default_log"
+if AUDIO_CONTROL_OUTPUT_DEFAULT_LOG="$output_default_log" \
+  AUDIO_CONTROL_DEFAULT_READ_FAIL=output OMARCHY_AUDIO_PREFERENCES_FILE="$shared_preferences" \
+  PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-output-set-default" 51 new-speakers old-speakers >/dev/null 2>&1; then
+  fail "default output changed without a rollback baseline"
+fi
+[[ ! -s $output_default_log ]] || fail "unreadable current default changed hardware"
+
+: >"$output_default_log"
+OMARCHY_AUDIO_PREFERENCES_FILE="$shared_preferences" \
+  AUDIO_CONTROL_OUTPUT_DEFAULT_LOG="$output_default_log" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-output-set-default" 50 old-speakers old-speakers 50 ||
+  fail "already-active default output rejected"
+[[ ! -s $output_default_log ]] || fail "already-active default output touched hardware"
+
+rollback_preferences=$(mktemp)
+: >"$output_default_log"
+if AUDIO_CONTROL_OUTPUT_DEFAULT_LOG="$output_default_log" \
+  AUDIO_CONTROL_DEFAULT_MOVE_FAIL_AFTER_EFFECT_TARGET=new-speakers \
+  OMARCHY_AUDIO_PREFERENCES_FILE="$rollback_preferences" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-output-set-default" 51 new-speakers old-speakers >/dev/null 2>&1; then
+  fail "partially moved default followers reported success"
+fi
+expected_output_rollback_log=$(cat <<'EOF'
+wpctl set-default 51
+pactl set-default-sink new-speakers
+pactl move-sink-input 300 new-speakers
+pactl move-sink-input 300 old-speakers
+wpctl set-default 50
+pactl set-default-sink old-speakers
+EOF
+)
+[[ $(<"$output_default_log") == "$expected_output_rollback_log" ]] ||
+  fail "default follower rollback after late move failure"
+[[ ! -s $rollback_preferences ]] || fail "rolled-back default output was persisted"
+
+: >"$output_default_log"
+AUDIO_CONTROL_OUTPUT_DEFAULT_LOG="$output_default_log" \
+  AUDIO_CONTROL_DEFAULT_SET_FAIL_AFTER_EFFECT_TARGET=new-speakers \
+  OMARCHY_AUDIO_PREFERENCES_FILE="$rollback_preferences" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-output-set-default" 51 new-speakers old-speakers ||
+  fail "verified default rejected after late setter failure"
+jq -e '.defaults.output == "new-speakers"' "$rollback_preferences" >/dev/null ||
+  fail "verified late default change was not persisted"
 
 failed_preferences=$(mktemp)
 failed_preferences_output_lock="${failed_preferences}.output.lock"
@@ -461,6 +1247,26 @@ fi
 [[ $(<"$invalid_preferences") == "$invalid_preferences_before" ]] ||
   fail "invalid shared preferences changed"
 
+multiple_preferences=$(mktemp)
+printf '{}\n{}\n' >"$multiple_preferences"
+if OMARCHY_AUDIO_PREFERENCES_FILE="$multiple_preferences" \
+  "$ROOT/scripts/audio-preferences" set-default output speakers >/dev/null 2>&1; then
+  fail "multiple-document audio preferences accepted"
+fi
+[[ $(wc -l <"$multiple_preferences") == 2 ]] ||
+  fail "multiple-document audio preferences overwritten"
+
+future_preferences=$(mktemp)
+printf '%s\n' '{"version":2,"defaults":{"output":"future-speakers"},"future":{"keep":true}}' \
+  >"$future_preferences"
+future_preferences_before=$(<"$future_preferences")
+if OMARCHY_AUDIO_PREFERENCES_FILE="$future_preferences" \
+  "$ROOT/scripts/audio-preferences" set-default output speakers >/dev/null 2>&1; then
+  fail "future-version audio preferences accepted"
+fi
+[[ $(<"$future_preferences") == "$future_preferences_before" ]] ||
+  fail "future-version audio preferences overwritten"
+
 OMARCHY_AUDIO_PREFERENCES_FILE="$shared_preferences" \
   "$ROOT/scripts/audio-preferences" set-default output headphones
 OMARCHY_AUDIO_PREFERENCES_FILE="$shared_preferences" \
@@ -474,7 +1280,10 @@ echo "PASS: verified default device routing"
 rm -f -- "$output_default_log" "$shared_preferences" "$shared_preferences_lock" \
   "$shared_preferences_output_lock" "$shared_preferences_input_lock" \
   "$failed_preferences" "$failed_preferences_output_lock" \
-  "$invalid_preferences" "$invalid_preferences_lock" "$invalid_preferences_output_lock"
+  "$invalid_preferences" "$invalid_preferences_lock" "$invalid_preferences_output_lock" \
+  "$rollback_preferences" "${rollback_preferences}.lock" "${rollback_preferences}.output.lock" \
+  "$multiple_preferences" "${multiple_preferences}.lock" \
+  "$future_preferences" "${future_preferences}.lock"
 
 port_log=$(mktemp)
 trap 'rm -f "$route_log" "$input_default_log" "$port_log"' EXIT
@@ -490,9 +1299,31 @@ jq -e '
   and .[1].direction == "input"
 ' <<<"$ports" >/dev/null || fail "multi-port endpoint discovery"
 
+: >"$port_log"
+if AUDIO_CONTROL_PORT_LOG="$port_log" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-port-set" input loopback-source two >/dev/null 2>&1; then
+  fail "nonstandard monitor source accepted as an input port target"
+else
+  [[ $? == 3 ]] || fail "monitor source port reported the wrong exit code"
+fi
+[[ ! -s $port_log ]] || fail "monitor source port changed hardware"
+
+object_ports=$(AUDIO_CONTROL_PORT_LOG="$port_log" AUDIO_CONTROL_PORT_OBJECT_ACTIVE=1 \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-ports")
+jq -e '
+  .[0].activePort == "analog-output-speaker"
+  and .[1].activePort == "analog-input-internal-mic"
+' <<<"$object_ports" >/dev/null || fail "object-form active port normalization"
+
+: >"$port_log"
+AUDIO_CONTROL_PORT_LOG="$port_log" AUDIO_CONTROL_PORT_OBJECT_ACTIVE=1 \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-port-set" \
+  output speakers analog-output-speaker
+[[ ! -s $port_log ]] || fail "object-form active port no-op detection"
+
 AUDIO_CONTROL_PORT_LOG="$port_log" PATH="$TEST_DIR/mocks:$PATH" \
   "$ROOT/scripts/audio-port-set" output speakers analog-output-headphones
-[[ $(<"$port_log") == "set-sink-port speakers analog-output-headphones" ]] ||
+[[ $(<"$port_log") == "set-sink-port 10 analog-output-headphones" ]] ||
   fail "audio port selection"
 if AUDIO_CONTROL_PORT_LOG="$port_log" PATH="$TEST_DIR/mocks:$PATH" \
   "$ROOT/scripts/audio-port-set" output speakers hdmi-output >/dev/null 2>&1; then
@@ -500,6 +1331,74 @@ if AUDIO_CONTROL_PORT_LOG="$port_log" PATH="$TEST_DIR/mocks:$PATH" \
 else
   [[ $? == 3 ]] || fail "unavailable audio port reported wrong exit code"
 fi
+
+: >"$port_log"
+if AUDIO_CONTROL_PORT_LOG="$port_log" \
+  AUDIO_CONTROL_PORT_SET_NO_EFFECT_TARGET=analog-output-headphones PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-port-set" output speakers analog-output-headphones >/dev/null 2>&1; then
+  fail "no-op audio port command reported success"
+fi
+[[ $(<"$port_log") == $'set-sink-port 10 analog-output-headphones\nset-sink-port 10 analog-output-speaker' ]] ||
+  fail "no-op audio port rollback"
+
+: >"$port_log"
+if AUDIO_CONTROL_PORT_LOG="$port_log" \
+  AUDIO_CONTROL_PORT_SET_FAIL_AFTER_EFFECT_TARGET=analog-output-headphones \
+  PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-port-set" output speakers analog-output-headphones >/dev/null 2>&1; then
+  fail "late-failing audio port change reported success"
+fi
+[[ $(<"$port_log") == $'set-sink-port 10 analog-output-headphones\nset-sink-port 10 analog-output-speaker' ]] ||
+  fail "late-failing audio port rollback"
+
+: >"$port_log"
+if AUDIO_CONTROL_PORT_LOG="$port_log" \
+  AUDIO_CONTROL_PORT_SET_WRONG_TARGET=analog-output-headphones \
+  AUDIO_CONTROL_PORT_WRONG_ACTIVE=unexpected-port \
+  AUDIO_CONTROL_PORT_SET_NO_EFFECT_TARGET=analog-output-speaker PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-port-set" output speakers analog-output-headphones >/dev/null 2>&1; then
+  fail "unrecoverable audio port mismatch reported success"
+else
+  [[ $? == 4 ]] || fail "unrecoverable audio port mismatch reported wrong exit code"
+fi
+
+for ambiguous_port_fixture in duplicate-endpoint duplicate-port missing-object; do
+  : >"$port_log"
+  case "$ambiguous_port_fixture" in
+    duplicate-endpoint) port_environment=AUDIO_CONTROL_PORT_DUPLICATE_ENDPOINT=1 ;;
+    duplicate-port) port_environment=AUDIO_CONTROL_PORT_DUPLICATE_PORT=1 ;;
+    missing-object) port_environment=AUDIO_CONTROL_PORT_MISSING_OBJECT=1 ;;
+  esac
+  if env "$port_environment" AUDIO_CONTROL_PORT_LOG="$port_log" \
+    PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-port-set" \
+      output speakers analog-output-headphones >/dev/null 2>&1; then
+    fail "$ambiguous_port_fixture audio port identity accepted"
+  else
+    [[ $? == 1 ]] || fail "$ambiguous_port_fixture audio port identity exit code"
+  fi
+  [[ ! -s $port_log ]] || fail "$ambiguous_port_fixture changed an audio port"
+done
+
+: >"$port_log"
+if AUDIO_CONTROL_PORT_LOG="$port_log" AUDIO_CONTROL_PORT_REINDEX_AFTER_SET=1 \
+  AUDIO_CONTROL_PORT_SET_NO_EFFECT_TARGET=analog-output-headphones \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-port-set" \
+    output speakers analog-output-headphones >/dev/null 2>&1; then
+  fail "reindexed no-op audio port command reported success"
+fi
+[[ $(<"$port_log") == $'set-sink-port 10 analog-output-headphones\nset-sink-port 12 analog-output-speaker' ]] ||
+  fail "reindexed audio endpoint was not rolled back by object identity"
+
+: >"$port_log"
+if AUDIO_CONTROL_PORT_LOG="$port_log" AUDIO_CONTROL_PORT_ORIGINAL_GONE_AFTER_SET=1 \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-port-set" \
+    output speakers analog-output-headphones >/dev/null 2>&1; then
+  fail "vanished audio endpoint port change reported success"
+else
+  [[ $? == 4 ]] || fail "vanished audio endpoint port change exit code"
+fi
+[[ $(<"$port_log") == 'set-sink-port 10 analog-output-headphones' ]] ||
+  fail "replacement endpoint received the vanished endpoint rollback"
 echo "PASS: audio port controls"
 
 policy_log=$(mktemp)
@@ -515,6 +1414,12 @@ jq -e '
   and ((.["device.routes.default-sink-volume"] - 0.4) | fabs) < 0.000001
   and .["node.stream.default-capture-volume"] == 1
 ' <<<"$policy" >/dev/null || fail "audio policy snapshot"
+
+if AUDIO_CONTROL_POLICY_LOG="$policy_log" AUDIO_CONTROL_POLICY_STATE="$policy_state" \
+  AUDIO_CONTROL_WPCTL_DUPLICATE_VALUE=1 PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-policy-settings" >/dev/null 2>&1; then
+  fail "ambiguous audio policy output accepted"
+fi
 
 policy=$(AUDIO_CONTROL_POLICY_LOG="$policy_log" AUDIO_CONTROL_POLICY_STATE="$policy_state" \
   PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-policy-settings" \
@@ -550,6 +1455,47 @@ fi
 jq -e 'has("linking.pause-playback") | not' "$policy_state" >/dev/null ||
   fail "failed audio policy write changed state"
 
+printf '{}\n' >"$policy_state"
+: >"$policy_log"
+if AUDIO_CONTROL_POLICY_LOG="$policy_log" AUDIO_CONTROL_POLICY_STATE="$policy_state" \
+  AUDIO_CONTROL_POLICY_NO_EFFECT=linking.pause-playback PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-policy-settings" set linking.pause-playback false >/dev/null 2>&1; then
+  fail "no-op audio policy write reported success"
+fi
+jq -e 'has("linking.pause-playback") | not' "$policy_state" >/dev/null ||
+  fail "no-op audio policy write changed state"
+
+printf '{}\n' >"$policy_state"
+AUDIO_CONTROL_POLICY_LOG="$policy_log" AUDIO_CONTROL_POLICY_STATE="$policy_state" \
+  AUDIO_CONTROL_POLICY_FAIL_AFTER_EFFECT=node.features.audio.mono PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-policy-settings" set node.features.audio.mono true >/dev/null ||
+  fail "verified policy rejected after late command failure"
+jq -e '.["node.features.audio.mono"] == true' "$policy_state" >/dev/null ||
+  fail "late policy change was not retained"
+
+printf '{}\n' >"$policy_state"
+if AUDIO_CONTROL_POLICY_LOG="$policy_log" AUDIO_CONTROL_POLICY_STATE="$policy_state" \
+  AUDIO_CONTROL_POLICY_WRONG_VALUE=linking.pause-playback \
+  AUDIO_CONTROL_POLICY_WRONG_ON_VALUE=false AUDIO_CONTROL_POLICY_WRONG_RAW=null \
+  PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-policy-settings" set linking.pause-playback false >/dev/null 2>&1; then
+  fail "wrong audio policy value reported success"
+fi
+jq -e '.["linking.pause-playback"] == true' "$policy_state" >/dev/null ||
+  fail "wrong audio policy value was not rolled back"
+
+printf '{}\n' >"$policy_state"
+if AUDIO_CONTROL_POLICY_LOG="$policy_log" AUDIO_CONTROL_POLICY_STATE="$policy_state" \
+  AUDIO_CONTROL_POLICY_WRONG_VALUE=linking.pause-playback \
+  AUDIO_CONTROL_POLICY_WRONG_ON_VALUE=false AUDIO_CONTROL_POLICY_WRONG_RAW=null \
+  AUDIO_CONTROL_POLICY_NO_EFFECT_VALUE='linking.pause-playback=true' \
+  PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-policy-settings" set linking.pause-playback false >/dev/null 2>&1; then
+  fail "unrecoverable audio policy mismatch reported success"
+else
+  [[ $? == 4 ]] || fail "unrecoverable audio policy mismatch reported wrong exit code"
+fi
+
 policy=$(AUDIO_CONTROL_POLICY_LOG="$policy_log" AUDIO_CONTROL_POLICY_STATE="$policy_state" \
   AUDIO_CONTROL_POLICY_UNSUPPORTED=monitor.alsa.autodetect-hdmi-channels \
   PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-policy-settings")
@@ -571,6 +1517,14 @@ fi
 if printf '%s\n' '[1,2]' | OMARCHY_AUDIO_SCENES_FILE="$scenes_file" PATH="$TEST_DIR/mocks:$PATH" \
   "$ROOT/scripts/audio-scenes" save Desk >/dev/null 2>&1; then
   fail "non-object audio scene accepted"
+fi
+if printf '{}\n{}\n' | OMARCHY_AUDIO_SCENES_FILE="$scenes_file" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-scenes" save Desk >/dev/null 2>&1; then
+  fail "multiple stdin scene documents accepted"
+fi
+if OMARCHY_AUDIO_SCENES_FILE="$scenes_file" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-scenes" save Desk '{} {}' >/dev/null 2>&1; then
+  fail "multiple argument scene documents accepted"
 fi
 printf '%s\n' "$scene_one" | OMARCHY_AUDIO_SCENES_FILE="$scenes_file" PATH="$TEST_DIR/mocks:$PATH" \
   "$ROOT/scripts/audio-scenes" save Desk >/dev/null
@@ -607,10 +1561,37 @@ OMARCHY_AUDIO_SCENES_FILE="$scenes_file" PATH="$TEST_DIR/mocks:$PATH" \
   "$ROOT/scripts/audio-scenes" delete Headset >/dev/null
 jq -e '[.scenes[].name] | index("Headset") | not' "$scenes_file" >/dev/null ||
   fail "audio scene deletion"
+printf '{}\n{}\n' >"$scenes_file"
+if OMARCHY_AUDIO_SCENES_FILE="$scenes_file" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-scenes" delete Desk >/dev/null 2>&1; then
+  fail "multiple-document scene store accepted"
+fi
+if printf '%s\n' "$scene_one" | OMARCHY_AUDIO_SCENES_FILE="$scenes_file" \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-scenes" save Desk >/dev/null 2>&1; then
+  fail "multiple-document scene store was overwritten"
+fi
+printf '%s\n' '{"version":2,"scenes":[],"future":{"keep":true}}' >"$scenes_file"
+future_scenes_before=$(<"$scenes_file")
+if OMARCHY_AUDIO_SCENES_FILE="$scenes_file" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-scenes" delete Desk >/dev/null 2>&1; then
+  fail "future-version scene store accepted"
+fi
+[[ $(<"$scenes_file") == "$future_scenes_before" ]] ||
+  fail "future-version scene store overwritten"
 echo "PASS: named audio scene storage"
 
 rules_file="$scenes_dir/audio-rules.json"
 export OMARCHY_AUDIO_RULES_FILE="$rules_file"
+printf '%s\n' \
+  '{"version":1,"appRules":[{"app":"Firefox","direction":"playback","target":"old-speakers"}],"devices":{"aliases":{},"favorites":[],"hidden":[]}}' \
+  >"$rules_file"
+"$ROOT/scripts/audio-app-rules" set-app firefox playback headphones
+jq -e '(.appRules | length) == 1
+  and .appRules[0] == {"app":"firefox","direction":"playback","target":"headphones"}' \
+  "$rules_file" >/dev/null || fail "mixed-case application rule replacement"
+"$ROOT/scripts/audio-app-rules" del-app FIREFOX playback
+jq -e '(.appRules | length) == 0' "$rules_file" >/dev/null ||
+  fail "mixed-case application rule deletion"
 "$ROOT/scripts/audio-app-rules" set-app "Firefox" playback speakers
 "$ROOT/scripts/audio-app-rules" set-app firefox recording usb-microphone
 jq -e '(.appRules | length) == 2 and .appRules[0].target == "speakers"' "$rules_file" >/dev/null ||
@@ -644,6 +1625,30 @@ printf '%s\n' '{}' >"$rules_file"
 "$ROOT/scripts/audio-app-rules" set-alias missing ""
 jq -e '.appRules == [] and .devices == {"aliases":{},"favorites":[],"hidden":[]}' \
   "$rules_file" >/dev/null || fail "sparse audio rules normalization"
+jq -nc '
+  {version:1, appRules:[], devices:{
+    aliases:(reduce range(0; 128) as $index
+      ({}; .["node-\($index)"] = "Alias \($index)")),
+    favorites:[], hidden:[]}}
+' >"$rules_file"
+"$ROOT/scripts/audio-app-rules" set-alias node-new "Newest alias"
+jq -e '
+  (.devices.aliases | length) == 128
+  and .devices.aliases["node-new"] == "Newest alias"
+  and (.devices.aliases | has("node-0") | not)
+' "$rules_file" >/dev/null || fail "audio alias registry cap"
+printf '{}\n{}\n' >"$rules_file"
+if "$ROOT/scripts/audio-app-rules" set-alias speakers Desk >/dev/null 2>&1; then
+  fail "multiple-document audio rules accepted"
+fi
+[[ $(wc -l <"$rules_file") == 2 ]] || fail "multiple-document audio rules overwritten"
+printf '%s\n' '{"version":2,"appRules":[],"devices":{},"future":{"keep":true}}' >"$rules_file"
+future_rules_before=$(<"$rules_file")
+if "$ROOT/scripts/audio-app-rules" set-alias speakers Desk >/dev/null 2>&1; then
+  fail "future-version audio rules accepted"
+fi
+[[ $(<"$rules_file") == "$future_rules_before" ]] ||
+  fail "future-version audio rules overwritten"
 unset OMARCHY_AUDIO_RULES_FILE
 echo "PASS: application rules and device preference store"
 rm -rf -- "$scenes_dir"
@@ -652,6 +1657,30 @@ microphone_test_dir=$(mktemp -d)
 microphone_test_log="$microphone_test_dir/commands.log"
 microphone_test_file="$microphone_test_dir/microphone-test.raw"
 trap 'rm -f "$route_log" "$input_default_log" "$port_log"; rm -rf "$microphone_test_dir"' EXIT
+
+microphone_pid_path="$microphone_test_file.pid"
+microphone_stop_path="$microphone_test_file.stop"
+microphone_lock_path="$microphone_test_file.lock"
+for unsafe_microphone_path in "$microphone_test_file" "$microphone_pid_path" \
+  "$microphone_stop_path" "$microphone_lock_path"; do
+  hardlink_target="$microphone_test_dir/hardlink-target"
+  touch "$hardlink_target"
+  ln -- "$hardlink_target" "$unsafe_microphone_path"
+  if AUDIO_CONTROL_MICROPHONE_TEST_FILE="$microphone_test_file" \
+    AUDIO_CONTROL_MICROPHONE_TEST_PID_FILE="$microphone_pid_path" \
+    AUDIO_CONTROL_MICROPHONE_TEST_STOP_FILE="$microphone_stop_path" \
+    AUDIO_CONTROL_MICROPHONE_TEST_LOCK_FILE="$microphone_lock_path" \
+    "$ROOT/scripts/audio-microphone-test" status >/dev/null 2>&1; then
+    fail "hard-linked microphone control path accepted"
+  fi
+  rm -f -- "$unsafe_microphone_path" "$hardlink_target"
+done
+
+if AUDIO_CONTROL_MICROPHONE_TEST_FILE="$microphone_test_file" \
+  AUDIO_CONTROL_MICROPHONE_TEST_PID_FILE="$microphone_test_file" \
+  "$ROOT/scripts/audio-microphone-test" status >/dev/null 2>&1; then
+  fail "overlapping microphone control paths accepted"
+fi
 
 microphone_test_status=$(AUDIO_CONTROL_MICROPHONE_TEST_FILE="$microphone_test_file" \
   "$ROOT/scripts/audio-microphone-test" status)
@@ -682,6 +1711,27 @@ AUDIO_CONTROL_MICROPHONE_TEST_FILE="$microphone_test_file" \
   "$ROOT/scripts/audio-microphone-test" clear
 [[ ! -e $microphone_test_file ]] || fail "microphone test cleanup"
 
+truncate -s 3 "$microphone_test_file"
+[[ $(AUDIO_CONTROL_MICROPHONE_TEST_FILE="$microphone_test_file" \
+  "$ROOT/scripts/audio-microphone-test" status) == empty ]] ||
+  fail "odd-sized microphone clip accepted"
+if AUDIO_CONTROL_MICROPHONE_TEST_FILE="$microphone_test_file" \
+  AUDIO_CONTROL_MICROPHONE_TEST_LOG="$microphone_test_log" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-microphone-test" play >/dev/null 2>&1; then
+  fail "odd-sized microphone clip played"
+fi
+truncate -s 480002 "$microphone_test_file"
+[[ $(AUDIO_CONTROL_MICROPHONE_TEST_FILE="$microphone_test_file" \
+  "$ROOT/scripts/audio-microphone-test" status) == empty ]] ||
+  fail "oversized microphone clip accepted"
+rm -f -- "$microphone_test_file"
+
+if AUDIO_CONTROL_MICROPHONE_TEST_FILE="$microphone_test_file" \
+  AUDIO_CONTROL_MICROPHONE_TEST_LOG="$microphone_test_log" PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-microphone-test" record $'bad\nsource' >/dev/null 2>&1; then
+  fail "control-bearing microphone identifier accepted"
+fi
+
 if AUDIO_CONTROL_MICROPHONE_TEST_FILE="$microphone_test_file" \
   AUDIO_CONTROL_MICROPHONE_TEST_LOG="$microphone_test_log" \
   AUDIO_CONTROL_MICROPHONE_TEST_RECORD_FAIL=1 PATH="$TEST_DIR/mocks:$PATH" \
@@ -689,6 +1739,18 @@ if AUDIO_CONTROL_MICROPHONE_TEST_FILE="$microphone_test_file" \
   fail "failed microphone test recording reported success"
 fi
 [[ ! -e $microphone_test_file ]] || fail "failed microphone test left a recording"
+
+if timeout 3 env AUDIO_CONTROL_MICROPHONE_TEST_FILE="$microphone_test_file" \
+  AUDIO_CONTROL_MICROPHONE_TEST_LOG="$microphone_test_log" \
+  AUDIO_CONTROL_MICROPHONE_TEST_RECORD_WAIT=1 \
+  AUDIO_CONTROL_MICROPHONE_TEST_RECORD_TIMEOUT=1 PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-microphone-test" record test-source >/dev/null 2>&1; then
+  fail "hung microphone recorder reported success"
+else
+  [[ $? != 124 ]] || fail "hung microphone recorder was not bounded"
+fi
+[[ ! -e $microphone_test_file && ! -e $microphone_test_file.pid ]] ||
+  fail "timed-out microphone recorder left private state"
 
 : >"$microphone_test_log"
 microphone_test_output="$microphone_test_dir/record-output"
@@ -703,6 +1765,12 @@ for _attempt in {1..100}; do
   sleep 0.01
 done
 [[ -s $microphone_test_file.pid ]] || fail "microphone test early-stop setup"
+if AUDIO_CONTROL_MICROPHONE_TEST_FILE="$microphone_test_file" \
+  AUDIO_CONTROL_MICROPHONE_TEST_LOG="$microphone_test_log" \
+  AUDIO_CONTROL_MICROPHONE_TEST_RECORD_WAIT=1 PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-microphone-test" record test-source >/dev/null 2>&1; then
+  fail "concurrent microphone recording accepted"
+fi
 AUDIO_CONTROL_MICROPHONE_TEST_FILE="$microphone_test_file" \
   "$ROOT/scripts/audio-microphone-test" stop
 microphone_test_exit=0
@@ -758,7 +1826,7 @@ for _attempt in {1..100}; do
   sleep 0.01
 done
 [[ -s $microphone_test_file.pid ]] || fail "microphone test hard-kill setup"
-microphone_test_orphan=$(<"$microphone_test_file.pid")
+read -r microphone_test_orphan _ <"$microphone_test_file.pid"
 kill -KILL "$microphone_test_pid"
 wait "$microphone_test_pid" 2>/dev/null || true
 AUDIO_CONTROL_MICROPHONE_TEST_FILE="$microphone_test_file" \
@@ -774,6 +1842,20 @@ fi
   fail "hard-killed microphone test left a control file"
 [[ -z $(find "$microphone_test_dir" -type f -name '.microphone-test.*.raw' -print -quit) ]] ||
   fail "hard-killed microphone test left a temporary file"
+
+# A stale identity file must never terminate an unrelated process whose PID
+# was recycled after a crashed recorder.
+sleep 30 &
+microphone_test_innocent=$!
+printf '%s 0\n' "$microphone_test_innocent" >"$microphone_test_file.pid"
+AUDIO_CONTROL_MICROPHONE_TEST_FILE="$microphone_test_file" \
+  "$ROOT/scripts/audio-microphone-test" clear
+microphone_test_innocent_survived=false
+kill -0 "$microphone_test_innocent" 2>/dev/null && microphone_test_innocent_survived=true
+kill "$microphone_test_innocent" 2>/dev/null || true
+wait "$microphone_test_innocent" 2>/dev/null || true
+$microphone_test_innocent_survived || fail "stale microphone PID killed an unrelated process"
+[[ ! -e $microphone_test_file.pid ]] || fail "stale microphone identity not removed"
 echo "PASS: private microphone record and playback test"
 rm -rf -- "$microphone_test_dir"
 
@@ -784,12 +1866,50 @@ bluetooth_preference=$(AUDIO_CONTROL_BLUETOOTH_PREFERENCE_LOG="$bluetooth_prefer
   AUDIO_CONTROL_BLUETOOTH_PREFERENCE_STATE="$bluetooth_preference_state" \
   PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-bluetooth-profile-preference")
 [[ $bluetooth_preference == quality ]] || fail "Bluetooth profile preference read"
+if AUDIO_CONTROL_BLUETOOTH_PREFERENCE_LOG="$bluetooth_preference_log" \
+  AUDIO_CONTROL_BLUETOOTH_PREFERENCE_STATE="$bluetooth_preference_state" \
+  AUDIO_CONTROL_WPCTL_DUPLICATE_VALUE=1 PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-bluetooth-profile-preference" >/dev/null 2>&1; then
+  fail "ambiguous Bluetooth profile preference accepted"
+fi
 bluetooth_preference=$(AUDIO_CONTROL_BLUETOOTH_PREFERENCE_LOG="$bluetooth_preference_log" \
   AUDIO_CONTROL_BLUETOOTH_PREFERENCE_STATE="$bluetooth_preference_state" \
   PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-bluetooth-profile-preference" latency)
 [[ $bluetooth_preference == latency ]] || fail "Bluetooth profile preference write"
 [[ $(<"$bluetooth_preference_log") == "settings --save bluetooth.profile-preference latency" ]] ||
   fail "Bluetooth profile preference command"
+
+# Reapplying the live value is a read-only no-op.
+AUDIO_CONTROL_BLUETOOTH_PREFERENCE_LOG="$bluetooth_preference_log" \
+  AUDIO_CONTROL_BLUETOOTH_PREFERENCE_STATE="$bluetooth_preference_state" \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-bluetooth-profile-preference" latency >/dev/null
+[[ $(wc -l <"$bluetooth_preference_log") == 1 ]] ||
+  fail "unchanged Bluetooth preference was rewritten"
+
+AUDIO_CONTROL_BLUETOOTH_PREFERENCE_LOG="$bluetooth_preference_log" \
+  AUDIO_CONTROL_BLUETOOTH_PREFERENCE_STATE="$bluetooth_preference_state" \
+  AUDIO_CONTROL_BLUETOOTH_PREFERENCE_FAIL_AFTER_EFFECT=1 PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-bluetooth-profile-preference" quality >/dev/null ||
+  fail "verified Bluetooth preference rejected after late failure"
+[[ $(<"$bluetooth_preference_state") == quality ]] ||
+  fail "late Bluetooth preference change was not retained"
+
+if AUDIO_CONTROL_BLUETOOTH_PREFERENCE_LOG="$bluetooth_preference_log" \
+  AUDIO_CONTROL_BLUETOOTH_PREFERENCE_STATE="$bluetooth_preference_state" \
+  AUDIO_CONTROL_BLUETOOTH_PREFERENCE_NO_EFFECT_VALUE=latency PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-bluetooth-profile-preference" latency >/dev/null 2>&1; then
+  fail "no-op Bluetooth preference write reported success"
+fi
+
+if AUDIO_CONTROL_BLUETOOTH_PREFERENCE_LOG="$bluetooth_preference_log" \
+  AUDIO_CONTROL_BLUETOOTH_PREFERENCE_STATE="$bluetooth_preference_state" \
+  AUDIO_CONTROL_BLUETOOTH_PREFERENCE_WRONG_VALUE=latency \
+  PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-bluetooth-profile-preference" latency >/dev/null 2>&1; then
+  fail "wrong Bluetooth preference value reported success"
+fi
+[[ $(<"$bluetooth_preference_state") == quality ]] ||
+  fail "wrong Bluetooth preference value was not rolled back"
 echo "PASS: Bluetooth profile preference"
 
 bluetooth_autoswitch_log=$(mktemp)
@@ -799,6 +1919,12 @@ bluetooth_autoswitch=$(AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_LOG="$bluetooth_autosw
   AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_STATE="$bluetooth_autoswitch_state" \
   PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-bluetooth-autoswitch")
 [[ $bluetooth_autoswitch == true ]] || fail "Bluetooth autoswitch read"
+if AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_LOG="$bluetooth_autoswitch_log" \
+  AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_STATE="$bluetooth_autoswitch_state" \
+  AUDIO_CONTROL_WPCTL_DUPLICATE_VALUE=1 PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-bluetooth-autoswitch" >/dev/null 2>&1; then
+  fail "ambiguous Bluetooth autoswitch value accepted"
+fi
 bluetooth_autoswitch=$(AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_LOG="$bluetooth_autoswitch_log" \
   AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_STATE="$bluetooth_autoswitch_state" \
   PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-bluetooth-autoswitch" off)
@@ -811,6 +1937,24 @@ if AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_LOG="$bluetooth_autoswitch_log" \
 fi
 [[ $(<"$bluetooth_autoswitch_state") == false ]] ||
   fail "failed Bluetooth autoswitch write changed state"
+
+AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_LOG="$bluetooth_autoswitch_log" \
+  AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_STATE="$bluetooth_autoswitch_state" \
+  AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_FAIL_AFTER_EFFECT=1 PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-bluetooth-autoswitch" on >/dev/null ||
+  fail "verified Bluetooth autoswitch rejected after late failure"
+[[ $(<"$bluetooth_autoswitch_state") == true ]] ||
+  fail "late Bluetooth autoswitch change was not retained"
+
+if AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_LOG="$bluetooth_autoswitch_log" \
+  AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_STATE="$bluetooth_autoswitch_state" \
+  AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_WRONG_VALUE=false \
+  AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_NO_EFFECT_VALUE=true PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-bluetooth-autoswitch" off >/dev/null 2>&1; then
+  fail "unrecoverable Bluetooth autoswitch mismatch reported success"
+else
+  [[ $? == 4 ]] || fail "unrecoverable Bluetooth autoswitch mismatch reported wrong exit code"
+fi
 echo "PASS: Bluetooth autoswitch failure handling"
 rm -f -- "$bluetooth_autoswitch_log" "$bluetooth_autoswitch_state"
 
@@ -841,8 +1985,34 @@ echo "PASS: safe profile filtering"
 
 profile_log=$(mktemp)
 profile_state=$(mktemp)
-trap 'rm -f "$route_log" "$input_default_log" "$port_log" "$bluetooth_preference_log" "$bluetooth_preference_state" "$profile_log" "$profile_state"' EXIT
+profile_identity_fixture=$(mktemp)
+profile_endpoint_read_state=$(mktemp)
+trap 'rm -f "$route_log" "$input_default_log" "$port_log" "$bluetooth_preference_log" "$bluetooth_preference_state" "$profile_log" "$profile_state" "$profile_identity_fixture" "$profile_endpoint_read_state"' EXIT
 printf 'old\n' >"$profile_state"
+
+for ambiguous_card_identity in duplicate-name duplicate-index duplicate-object invalid-index; do
+  case "$ambiguous_card_identity" in
+    duplicate-name) card_filter='.[1].name = .[0].name' ;;
+    duplicate-index) card_filter='.[1].index = .[0].index' ;;
+    duplicate-object) card_filter='map(.properties["object.id"] = ((.index + 100) | tostring)) | .[1].properties["object.id"] = .[0].properties["object.id"]' ;;
+    invalid-index) card_filter='.[0].index = "not-an-index"' ;;
+  esac
+  jq "$card_filter" "$TEST_DIR/fixtures/cards.json" >"$profile_identity_fixture"
+  if AUDIO_CONTROL_CARD_FIXTURE="$profile_identity_fixture" \
+    PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-profiles" >/dev/null 2>&1; then
+    fail "$ambiguous_card_identity card identity was listed"
+  fi
+  : >"$profile_log"
+  if AUDIO_CONTROL_CARD_FIXTURE="$profile_identity_fixture" \
+    AUDIO_CONTROL_PROFILE_LOG="$profile_log" AUDIO_CONTROL_PROFILE_STATE="$profile_state" \
+    PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-profile-set" \
+      alsa_card.usb-example-headset output:analog-stereo+input:mono-fallback \
+      >/dev/null 2>&1; then
+    fail "$ambiguous_card_identity card identity accepted a profile change"
+  fi
+  [[ ! -s $profile_log ]] || fail "$ambiguous_card_identity card identity changed hardware"
+done
+rm -f -- "$profile_identity_fixture"
 
 if AUDIO_CONTROL_CARD_FIXTURE="$TEST_DIR/fixtures/cards.json" \
   AUDIO_CONTROL_PROFILE_LOG="$profile_log" \
@@ -866,6 +2036,32 @@ AUDIO_CONTROL_CARD_FIXTURE="$TEST_DIR/fixtures/cards.json" \
   fail "unchanged audio profile rejected"
 [[ ! -s $profile_log ]] || fail "unchanged audio profile touched hardware"
 
+bluetooth_profile_preferences=$(mktemp)
+AUDIO_CONTROL_CARD_FIXTURE="$TEST_DIR/fixtures/cards.json" \
+  AUDIO_CONTROL_PROFILE_LOG="$profile_log" \
+  AUDIO_CONTROL_PROFILE_STATE="$profile_state" \
+  OMARCHY_AUDIO_PREFERENCES_FILE="$bluetooth_profile_preferences" \
+  PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-profile-set" \
+    bluez_card.00_11_22_33_44_55 a2dp-sink-aac >/dev/null 2>&1 ||
+  fail "active Bluetooth profile preference not saved"
+jq -e '.bluetoothProfiles["001122334455"] == "a2dp-sink-aac"' \
+  "$bluetooth_profile_preferences" >/dev/null || fail "Bluetooth profile preference content"
+[[ ! -s $profile_log ]] || fail "active Bluetooth profile preference touched hardware"
+
+printf '%s\n' 'not json' >"$bluetooth_profile_preferences"
+if AUDIO_CONTROL_CARD_FIXTURE="$TEST_DIR/fixtures/cards.json" \
+  AUDIO_CONTROL_PROFILE_LOG="$profile_log" \
+  AUDIO_CONTROL_PROFILE_STATE="$profile_state" \
+  OMARCHY_AUDIO_PREFERENCES_FILE="$bluetooth_profile_preferences" \
+  PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-profile-set" \
+    bluez_card.00_11_22_33_44_55 headset-head-unit-msbc >/dev/null 2>&1; then
+  fail "Bluetooth profile changed with an invalid preference store"
+fi
+[[ ! -s $profile_log ]] || fail "invalid Bluetooth preference store changed hardware"
+rm -f -- "$bluetooth_profile_preferences" "${bluetooth_profile_preferences}.lock"
+
 if AUDIO_CONTROL_CARD_FIXTURE="$TEST_DIR/fixtures/cards.json" \
   AUDIO_CONTROL_PROFILE_LOG="$profile_log" \
   AUDIO_CONTROL_PROFILE_STATE="$profile_state" \
@@ -885,21 +2081,141 @@ AUDIO_CONTROL_CARD_FIXTURE="$TEST_DIR/fixtures/cards.json" \
     alsa_card.usb-example-headset output:analog-stereo+input:mono-fallback
 
 expected_profile_log=$(cat <<'EOF'
-set-sink-mute 100 true
-set-source-mute 200 true
+set-sink-mute headset-output true
+set-source-mute headset-input true
 set-sink-input-mute 300 true
 set-card-profile alsa_card.usb-example-headset output:analog-stereo+input:mono-fallback
-set-sink-mute 101 true
-set-sink-volume 101 42% 21%
-set-sink-mute 101 false
-set-source-mute 200 true
-set-source-volume 200 36%
-set-source-mute 200 true
+set-sink-mute headset-output true
+set-sink-volume headset-output 42% 21%
+set-sink-mute headset-output false
+set-source-mute headset-input true
+set-source-volume headset-input 36%
+set-source-mute headset-input true
 set-sink-input-mute 300 false
 EOF
 )
 [[ $(<"$profile_log") == "$expected_profile_log" ]] || fail "safe profile transition order"
 echo "PASS: safe profile transition"
+
+# Live state, not a transport exit code, decides whether preparation and
+# restoration succeeded.
+: >"$profile_log"
+printf 'old\n' >"$profile_state"
+AUDIO_CONTROL_CARD_FIXTURE="$TEST_DIR/fixtures/cards.json" \
+  AUDIO_CONTROL_PROFILE_LOG="$profile_log" AUDIO_CONTROL_PROFILE_STATE="$profile_state" \
+  AUDIO_CONTROL_PROFILE_FAIL_AFTER_EFFECT_COMMAND='set-sink-mute headset-output true' \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-profile-set" \
+    alsa_card.usb-example-headset output:analog-stereo+input:mono-fallback >/dev/null ||
+  fail "verified endpoint mute rejected after late transport failure"
+
+: >"$profile_log"
+printf 'old\n' >"$profile_state"
+if AUDIO_CONTROL_CARD_FIXTURE="$TEST_DIR/fixtures/cards.json" \
+  AUDIO_CONTROL_PROFILE_LOG="$profile_log" AUDIO_CONTROL_PROFILE_STATE="$profile_state" \
+  AUDIO_CONTROL_PROFILE_NO_EFFECT_COMMAND='set-sink-mute headset-output true' \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-profile-set" \
+    alsa_card.usb-example-headset output:analog-stereo+input:mono-fallback >/dev/null 2>&1; then
+  fail "silent endpoint-mute no-op reported success"
+fi
+! grep -q '^set-card-profile ' "$profile_log" ||
+  fail "profile changed after an unverified preparation mute"
+
+for stream_churn in vanish reuse reindex; do
+  : >"$profile_log"
+  printf 'old\n' >"$profile_state"
+  case "$stream_churn" in
+    vanish) stream_environment=AUDIO_CONTROL_PROFILE_STREAM_VANISH=1 ;;
+    reuse) stream_environment=AUDIO_CONTROL_PROFILE_STREAM_REUSE=1 ;;
+    reindex) stream_environment=AUDIO_CONTROL_PROFILE_STREAM_REINDEX=1 ;;
+  esac
+  env "$stream_environment" AUDIO_CONTROL_CARD_FIXTURE="$TEST_DIR/fixtures/cards.json" \
+    AUDIO_CONTROL_PROFILE_LOG="$profile_log" AUDIO_CONTROL_PROFILE_STATE="$profile_state" \
+    PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-profile-set" \
+      alsa_card.usb-example-headset output:analog-stereo+input:mono-fallback >/dev/null ||
+    fail "profile stream $stream_churn handling"
+  if [[ $stream_churn == reindex ]]; then
+    grep -q '^set-sink-input-mute 302 false$' "$profile_log" ||
+      fail "reindexed stream was not restored by object identity"
+  else
+    ! grep -q '^set-sink-input-mute 300 false$' "$profile_log" ||
+      fail "$stream_churn stream inherited a stale mute restoration"
+  fi
+done
+echo "PASS: identity-safe profile stream restoration"
+
+: >"$profile_log"
+printf 'old\n' >"$profile_state"
+AUDIO_CONTROL_CARD_FIXTURE="$TEST_DIR/fixtures/cards.json" \
+  AUDIO_CONTROL_PROFILE_LOG="$profile_log" AUDIO_CONTROL_PROFILE_STATE="$profile_state" \
+  AUDIO_CONTROL_PROFILE_SET_FAIL_AFTER_EFFECT=1 PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-profile-set" \
+    alsa_card.usb-example-headset output:analog-stereo+input:mono-fallback >/dev/null ||
+  fail "verified profile rejected after late setter failure"
+
+: >"$profile_log"
+printf 'old\n' >"$profile_state"
+if AUDIO_CONTROL_CARD_FIXTURE="$TEST_DIR/fixtures/cards.json" \
+  AUDIO_CONTROL_PROFILE_LOG="$profile_log" AUDIO_CONTROL_PROFILE_STATE="$profile_state" \
+  AUDIO_CONTROL_PROFILE_NO_EFFECT=1 PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-profile-set" \
+    alsa_card.usb-example-headset output:analog-stereo+input:mono-fallback >/dev/null 2>&1; then
+  fail "no-op profile command reported success"
+fi
+[[ $(<"$profile_state") == old ]] || fail "no-op profile changed mock state"
+
+# If policy or a transport race lands on a third profile, the helper must
+# actively return to the original graph instead of merely reporting the
+# requested profile as unverified.
+: >"$profile_log"
+printf 'old\n' >"$profile_state"
+if AUDIO_CONTROL_CARD_FIXTURE="$TEST_DIR/fixtures/cards.json" \
+  AUDIO_CONTROL_PROFILE_LOG="$profile_log" AUDIO_CONTROL_PROFILE_STATE="$profile_state" \
+  AUDIO_CONTROL_PROFILE_FINAL_ACTIVE=output:iec958-stereo \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-profile-set" \
+    alsa_card.usb-example-headset output:analog-stereo+input:mono-fallback \
+    >/dev/null 2>&1; then
+  fail "wrong final profile reported success"
+else
+  [[ $? == 1 ]] || fail "restored wrong final profile reported wrong exit code"
+fi
+[[ $(<"$profile_state") == old ]] || fail "wrong final profile was not rolled back"
+[[ $(grep -c '^set-card-profile ' "$profile_log") == 2 ]] ||
+  fail "wrong final profile did not perform exactly one rollback"
+grep '^set-card-profile ' "$profile_log" | tail -n 1 |
+  grep -q '^set-card-profile alsa_card.usb-example-headset output:analog-stereo$' ||
+  fail "wrong final profile did not restore the original profile"
+grep -q '^set-sink-mute headset-output false$' "$profile_log" ||
+  fail "profile rollback did not restore output mute state"
+grep -q '^set-sink-input-mute 300 false$' "$profile_log" ||
+  fail "profile rollback did not restore stream mute state"
+echo "PASS: profile rollback from unintended final state"
+
+: >"$profile_log"
+printf 'old\n' >"$profile_state"
+if AUDIO_CONTROL_CARD_FIXTURE="$TEST_DIR/fixtures/cards.json" \
+  AUDIO_CONTROL_PROFILE_LOG="$profile_log" AUDIO_CONTROL_PROFILE_STATE="$profile_state" \
+  AUDIO_CONTROL_PROFILE_FAIL_ONCE_COMMAND='set-sink-mute headset-output true' \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-profile-set" \
+    alsa_card.usb-example-headset output:analog-stereo+input:mono-fallback >/dev/null 2>&1; then
+  fail "unsafe profile preparation reported success"
+else
+  [[ $? == 1 ]] || fail "restored profile preparation failure reported wrong exit code"
+fi
+grep -q '^set-sink-mute headset-output false$' "$profile_log" ||
+  fail "profile preparation failure did not restore output mute"
+
+: >"$profile_log"
+printf 'old\n' >"$profile_state"
+if AUDIO_CONTROL_CARD_FIXTURE="$TEST_DIR/fixtures/cards.json" \
+  AUDIO_CONTROL_PROFILE_LOG="$profile_log" AUDIO_CONTROL_PROFILE_STATE="$profile_state" \
+  AUDIO_CONTROL_PROFILE_FAIL_ONCE_COMMAND='set-source-mute headset-input true' \
+  AUDIO_CONTROL_PROFILE_NO_EFFECT_COMMAND='set-sink-mute headset-output false' \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-profile-set" \
+    alsa_card.usb-example-headset output:analog-stereo+input:mono-fallback >/dev/null 2>&1; then
+  fail "unrecoverable profile preparation reported success"
+else
+  [[ $? == 4 ]] || fail "unrecoverable profile preparation reported wrong exit code"
+fi
 
 : >"$profile_log"
 printf 'old\n' >"$profile_state"
@@ -911,19 +2227,19 @@ AUDIO_CONTROL_CARD_FIXTURE="$TEST_DIR/fixtures/cards.json" \
     alsa_card.pci-example-ucm 'HiFi (Mic1, Speaker)'
 
 expected_profile_log=$(cat <<'EOF'
-set-sink-mute 110 true
-set-source-mute 210 true
-set-source-mute 211 true
+set-sink-mute speaker-output true
+set-source-mute mic-a true
+set-source-mute mic-b true
 set-card-profile alsa_card.pci-example-ucm HiFi (Mic1, Speaker)
-set-sink-mute 120 true
-set-sink-volume 120 60% 45%
-set-sink-mute 120 false
-set-source-mute 221 true
-set-source-mute 220 true
-set-source-volume 221 70%
-set-source-mute 221 true
-set-source-volume 220 30%
-set-source-mute 220 false
+set-sink-mute speaker-output true
+set-sink-volume speaker-output 60% 45%
+set-sink-mute speaker-output false
+set-source-mute mic-b true
+set-source-mute mic-a true
+set-source-volume mic-b 70%
+set-source-mute mic-b true
+set-source-volume mic-a 30%
+set-source-mute mic-a false
 EOF
 )
 [[ $(<"$profile_log") == "$expected_profile_log" ]] ||
@@ -935,27 +2251,73 @@ echo "PASS: per-endpoint profile state preservation"
 : >"$profile_log"
 printf 'old\n' >"$profile_state"
 profile_warning="$TEST_DIR/vanish-warning"
-AUDIO_CONTROL_CARD_FIXTURE="$TEST_DIR/fixtures/cards.json" \
+if AUDIO_CONTROL_CARD_FIXTURE="$TEST_DIR/fixtures/cards.json" \
   AUDIO_CONTROL_PROFILE_LOG="$profile_log" \
   AUDIO_CONTROL_PROFILE_STATE="$profile_state" \
   AUDIO_CONTROL_PROFILE_VANISH_SINKS=1 \
   PATH="$TEST_DIR/mocks:$PATH" \
   "$ROOT/scripts/audio-profile-set" \
-    alsa_card.usb-example-headset output:analog-stereo+input:mono-fallback 2>"$profile_warning" ||
-  fail "vanishing endpoint transition failed outright"
-grep -q "did not reappear" "$profile_warning" || fail "missing vanishing endpoint warning"
+    alsa_card.usb-example-headset output:analog-stereo+input:mono-fallback 2>"$profile_warning"; then
+  fail "incomplete endpoint transition reported success"
+else
+  [[ $? == 4 ]] || fail "incomplete endpoint transition reported wrong exit code"
+fi
+grep -q "did not settle" "$profile_warning" || fail "missing incomplete endpoint warning"
 grep -q '^set-sink-input-mute 300 false$' "$profile_log" ||
   fail "sink input stayed muted after vanished endpoints"
-[[ $(grep -c '^set-source-mute 200 true$' "$profile_log") -ge 2 ]] ||
+[[ $(grep -c '^set-source-mute headset-input true$' "$profile_log") -ge 2 ]] ||
   fail "surviving source endpoint not unmuted after vanished endpoints"
 ! grep -q '^set-sink-volume ' "$profile_log" ||
   fail "volume restored onto a nonexistent sink"
 rm -f "$profile_warning"
 echo "PASS: vanished endpoint muting recovery"
 
+# Reusing a vanished endpoint's numeric index must not transfer its old mute
+# state to a different logical node.
+: >"$profile_log"
+printf 'old\n' >"$profile_state"
+if AUDIO_CONTROL_CARD_FIXTURE="$TEST_DIR/fixtures/cards.json" \
+  AUDIO_CONTROL_PROFILE_LOG="$profile_log" AUDIO_CONTROL_PROFILE_STATE="$profile_state" \
+  AUDIO_CONTROL_PROFILE_VANISH_SINKS=1 AUDIO_CONTROL_PROFILE_SOURCE_REUSE=1 \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-profile-set" \
+    alsa_card.usb-example-headset output:analog-stereo+input:mono-fallback >/dev/null 2>&1; then
+  fail "incomplete reused-index transition reported success"
+else
+  [[ $? == 4 ]] || fail "reused-index transition reported wrong exit code"
+fi
+! grep -q '^set-source-mute 200 ' "$profile_log" ||
+  fail "reused source index received the vanished endpoint state"
+grep -q '^set-source-mute replacement-input false$' "$profile_log" ||
+  fail "replacement source did not retain its own mute state"
+echo "PASS: profile endpoint index-reuse safety"
+
+# If a post-profile endpoint is replaced after the snapshot but before its
+# stored state is restored, no same-name successor may receive the old volume
+# or unmute operation.
+: >"$profile_log"
+: >"$profile_endpoint_read_state"
+printf 'old\n' >"$profile_state"
+if AUDIO_CONTROL_CARD_FIXTURE="$TEST_DIR/fixtures/cards.json" \
+  AUDIO_CONTROL_PROFILE_LOG="$profile_log" AUDIO_CONTROL_PROFILE_STATE="$profile_state" \
+  AUDIO_CONTROL_PROFILE_ENDPOINT_READ_STATE="$profile_endpoint_read_state" \
+  PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-profile-set" \
+    alsa_card.usb-example-headset output:analog-stereo+input:mono-fallback \
+    >/dev/null 2>&1; then
+  fail "replaced profile endpoint reported complete restoration"
+else
+  [[ $? == 4 ]] || fail "replaced profile endpoint reported wrong exit code"
+fi
+[[ $(grep -c '^set-sink-mute headset-output true$' "$profile_log") == 1 ]] ||
+  fail "same-name replacement received a stale mute operation"
+! grep -q '^set-sink-volume headset-output ' "$profile_log" ||
+  fail "same-name replacement inherited stale volume"
+! grep -q '^set-sink-mute headset-output false$' "$profile_log" ||
+  fail "same-name replacement inherited stale unmute state"
+echo "PASS: profile endpoint replacement safety"
+
 menu_tmp=$(mktemp -d)
 menu_file="$menu_tmp/omarchy-menu.jsonc"
-trap 'rm -f "$route_log" "$input_default_log" "$port_log" "$bluetooth_preference_log" "$bluetooth_preference_state" "$profile_log" "$profile_state"; rm -rf "$menu_tmp"' EXIT
+trap 'rm -f "$route_log" "$route_read_state" "$output_default_log" "$input_default_log" "$shared_preferences" "$shared_preferences_lock" "$shared_preferences_output_lock" "$shared_preferences_input_lock" "$port_log" "$policy_log" "$policy_state" "$bluetooth_preference_log" "$bluetooth_preference_state" "$bluetooth_autoswitch_log" "$bluetooth_autoswitch_state" "$profile_log" "$profile_state" "$profile_identity_fixture" "$profile_endpoint_read_state"; rm -rf "$microphone_test_dir" "$menu_tmp"' EXIT
 cat >"$menu_file" <<'EOF'
 {
   // Existing customization
@@ -982,12 +2344,62 @@ AUDIO_CONTROL_MENU_FILE="$menu_file" AUDIO_CONTROL_SKIP_MENU_REFRESH=1 \
   "$ROOT/scripts/audio-menu-entry" remove
 grep -q '"personal.notes"' "$menu_file" || fail "menu integration removed another entry"
 ! grep -q '"setup.audio"' "$menu_file" || fail "menu integration removal"
+
+cat >"$menu_file" <<'EOF'
+{
+  "personal.notes": {"label":"URL // stays literal"}, // trailing JSONC comma
+}
+EOF
+AUDIO_CONTROL_MENU_FILE="$menu_file" AUDIO_CONTROL_SKIP_MENU_REFRESH=1 \
+  "$ROOT/scripts/audio-menu-entry" install
+AUDIO_CONTROL_MENU_FILE="$menu_file" AUDIO_CONTROL_SKIP_MENU_REFRESH=1 \
+  "$ROOT/scripts/audio-menu-entry" install
+[[ $(grep -c '"setup.audio"' "$menu_file") == 1 ]] ||
+  fail "JSONC trailing-comma menu entry was duplicated"
+grep -q 'URL // stays literal' "$menu_file" || fail "JSONC string was treated as a comment"
+AUDIO_CONTROL_MENU_FILE="$menu_file" AUDIO_CONTROL_SKIP_MENU_REFRESH=1 \
+  "$ROOT/scripts/audio-menu-entry" remove
+! grep -q '"setup.audio"' "$menu_file" || fail "JSONC trailing-comma removal"
+
+printf '%s\n' '{"nested":{"setup.audio":{"label":"nested /* literal */"}}}' >"$menu_file"
+AUDIO_CONTROL_MENU_FILE="$menu_file" AUDIO_CONTROL_SKIP_MENU_REFRESH=1 \
+  "$ROOT/scripts/audio-menu-entry" install
+[[ $(grep -o '"setup.audio"' "$menu_file" | wc -l) == 2 ]] ||
+  fail "nested menu key was mistaken for the root integration entry"
+AUDIO_CONTROL_MENU_FILE="$menu_file" AUDIO_CONTROL_SKIP_MENU_REFRESH=1 \
+  "$ROOT/scripts/audio-menu-entry" remove
+[[ $(grep -o '"setup.audio"' "$menu_file" | wc -l) == 1 ]] ||
+  fail "minified menu removal damaged a nested key"
+
+printf '%s\n' '{"personal.notes":{"label":"Notes"}/*same-line block*/}' >"$menu_file"
+AUDIO_CONTROL_MENU_FILE="$menu_file" AUDIO_CONTROL_SKIP_MENU_REFRESH=1 \
+  "$ROOT/scripts/audio-menu-entry" install
+AUDIO_CONTROL_MENU_FILE="$menu_file" AUDIO_CONTROL_SKIP_MENU_REFRESH=1 \
+  "$ROOT/scripts/audio-menu-entry" remove
+grep -q 'same-line block' "$menu_file" || fail "same-line JSONC comment was lost"
+
+cat >"$menu_file" <<'EOF'
+{"setup\u002eaudio":{"label":"Existing escaped key"}}
+EOF
+escaped_menu_before=$(<"$menu_file")
+AUDIO_CONTROL_MENU_FILE="$menu_file" AUDIO_CONTROL_SKIP_MENU_REFRESH=1 \
+  "$ROOT/scripts/audio-menu-entry" install
+[[ $(<"$menu_file") == "$escaped_menu_before" ]] ||
+  fail "escaped root menu key was duplicated"
+
+printf '%s\n' '{"broken":,}' >"$menu_file"
+invalid_menu_before=$(<"$menu_file")
+if AUDIO_CONTROL_MENU_FILE="$menu_file" AUDIO_CONTROL_SKIP_MENU_REFRESH=1 \
+  "$ROOT/scripts/audio-menu-entry" install >/dev/null 2>&1; then
+  fail "syntactically invalid JSONC menu was rewritten"
+fi
+[[ $(<"$menu_file") == "$invalid_menu_before" ]] || fail "invalid JSONC menu changed"
 echo "PASS: menu integration"
 
 jq -e '
   .schemaVersion == 1
   and .id == "ssupt.audio-control"
-  and .version == "0.7.0"
+  and .version == "0.7.1"
   and .author == "ssupt"
   and (.kinds | index("bar-widget") != null)
   and (.kinds | index("panel") != null)

--- a/test/mocks/omarchy-audio-output-sink
+++ b/test/mocks/omarchy-audio-output-sink
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [[ ${AUDIO_CONTROL_OUTPUT_SINK_OVERSIZED:-0} == 1 ]]; then
+  printf '%02048d' 0
+  exit 0
+fi
+
+printf '%s' "${AUDIO_CONTROL_OUTPUT_SINK_RESPONSE:-physical-speakers}"
+exit "${AUDIO_CONTROL_OUTPUT_SINK_EXIT:-0}"

--- a/test/mocks/omarchy-audio-sink-availability
+++ b/test/mocks/omarchy-audio-sink-availability
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [[ ${AUDIO_CONTROL_SINK_AVAILABILITY_OVERSIZED:-0} == 1 ]]; then
+  printf '%01048577d' 0
+  exit 0
+fi
+
+printf '%s' "${AUDIO_CONTROL_SINK_AVAILABILITY_RESPONSE:-physical-speakers	1}"
+exit "${AUDIO_CONTROL_SINK_AVAILABILITY_EXIT:-0}"

--- a/test/mocks/omarchy-launch-floating-terminal-with-presentation
+++ b/test/mocks/omarchy-launch-floating-terminal-with-presentation
@@ -1,4 +1,6 @@
 #!/bin/bash
 
 [[ -n ${AUDIO_CONTROL_RECOVERY_LOG:-} ]] || exit 1
-printf '%s\n' "$*" >"$AUDIO_CONTROL_RECOVERY_LOG"
+printf 'launch=%s\n' "$*" >"$AUDIO_CONTROL_RECOVERY_LOG"
+[[ ${AUDIO_CONTROL_RECOVERY_LAUNCH_FAIL:-0} != 1 ]] || exit 1
+exec /bin/bash -c "$*"

--- a/test/mocks/omarchy-restart-audio
+++ b/test/mocks/omarchy-restart-audio
@@ -1,3 +1,5 @@
 #!/bin/bash
 
-exit 0
+[[ -n ${AUDIO_CONTROL_RECOVERY_LOG:-} ]] || exit 1
+printf 'recovery=run\n' >>"$AUDIO_CONTROL_RECOVERY_LOG"
+exit "${AUDIO_CONTROL_RECOVERY_EXIT:-0}"

--- a/test/mocks/pactl
+++ b/test/mocks/pactl
@@ -5,8 +5,79 @@ if [[ $* == "-f json list sinks" && -n ${AUDIO_CONTROL_DIAGNOSTIC_SINK_FIXTURE:-
   exit 0
 fi
 
+apply_profile_endpoint_commands() {
+  local endpoint_kind=$1 endpoint_json=$2
+  local operation target values command_line value values_json
+  local -a volume_values
+  declare -A command_counts=()
+
+  while read -r operation target values; do
+    [[ $operation == "set-${endpoint_kind}-mute" ||
+        $operation == "set-${endpoint_kind}-volume" ]] || continue
+    command_line="$operation $target${values:+ $values}"
+    command_counts["$command_line"]=$(( ${command_counts["$command_line"]:-0} + 1 ))
+    [[ ${AUDIO_CONTROL_PROFILE_FAIL_COMMAND:-} != "$command_line" ]] || continue
+    [[ ${AUDIO_CONTROL_PROFILE_NO_EFFECT_COMMAND:-} != "$command_line" ]] || continue
+    if [[ ${AUDIO_CONTROL_PROFILE_FAIL_ONCE_COMMAND:-} == "$command_line" &&
+        ${command_counts["$command_line"]} == 1 ]]; then
+      continue
+    fi
+
+    if [[ $operation == "set-${endpoint_kind}-mute" ]]; then
+      value=${values%% *}
+      [[ $value == true || $value == false ]] || continue
+      endpoint_json=$(jq -c --arg target "$target" --argjson value "$value" '
+        map(if .name == $target or (.index | tostring) == $target
+          then .mute = $value else . end)
+      ' <<<"$endpoint_json")
+      continue
+    fi
+
+    read -r -a volume_values <<<"$values"
+    (( ${#volume_values[@]} > 0 )) || continue
+    values_json=$(printf '%s\n' "${volume_values[@]}" |
+      jq -Rsc 'split("\n")[:-1]')
+    endpoint_json=$(jq -c --arg target "$target" --argjson values "$values_json" '
+      map(if .name == $target or (.index | tostring) == $target then
+        .volume |= (
+          to_entries as $channels
+          | reduce range(0; $channels | length) as $index
+              ({};
+                ($channels[$index]) as $channel
+                | ($values[if ($values | length) == 1 then 0 else $index end]
+                    // $values[0]) as $value
+                | .[$channel.key] = ($channel.value
+                    | if ($value | test("%$")) then
+                        del(.value) | .value_percent = $value
+                      else
+                        del(.value_percent) | .value = ($value | tonumber)
+                      end))
+        )
+      else . end)
+    ' <<<"$endpoint_json")
+  done <"$AUDIO_CONTROL_PROFILE_LOG"
+
+  printf '%s\n' "$endpoint_json"
+}
+
 if [[ $* == "-f json list cards" && -n ${AUDIO_CONTROL_CARD_FIXTURE:-} ]]; then
-  command cat "$AUDIO_CONTROL_CARD_FIXTURE"
+  if [[ ${AUDIO_CONTROL_PROFILE_FINAL_CARD_READ_FAIL:-0} == 1 &&
+      -n ${AUDIO_CONTROL_PROFILE_LOG:-} ]] &&
+      grep -q '^set-card-profile ' "$AUDIO_CONTROL_PROFILE_LOG" 2>/dev/null; then
+    exit 1
+  fi
+  if [[ -n ${AUDIO_CONTROL_PROFILE_LOG:-} && -n ${AUDIO_CONTROL_PROFILE_STATE:-}
+      && -s $AUDIO_CONTROL_PROFILE_LOG && $(<"$AUDIO_CONTROL_PROFILE_STATE") != old ]]; then
+    profile_change=$(sed -n 's/^set-card-profile //p' "$AUDIO_CONTROL_PROFILE_LOG" | tail -n 1)
+    profile_card=${profile_change%% *}
+    profile_value=${profile_change#* }
+    profile_value=${AUDIO_CONTROL_PROFILE_FINAL_ACTIVE:-$profile_value}
+    jq --arg card "$profile_card" --arg profile "$profile_value" '
+      map(if .name == $card then .active_profile = $profile else . end)
+    ' "$AUDIO_CONTROL_CARD_FIXTURE"
+  else
+    command cat "$AUDIO_CONTROL_CARD_FIXTURE"
+  fi
   exit 0
 fi
 
@@ -31,46 +102,164 @@ fi
 if [[ -n ${AUDIO_CONTROL_OUTPUT_DEFAULT_LOG:-} ]]; then
   case "$*" in
     "get-default-sink")
-      if grep -q '^pactl set-default-sink new-speakers$' "$AUDIO_CONTROL_OUTPUT_DEFAULT_LOG" 2>/dev/null; then
-        echo "new-speakers"
-      else
-        echo "old-speakers"
-      fi
+      [[ ${AUDIO_CONTROL_DEFAULT_READ_FAIL:-} != output ]] || exit 1
+      default_sink=old-speakers
+      while read -r command_name operation requested_sink; do
+        [[ $command_name == pactl && $operation == set-default-sink ]] || continue
+        [[ ${AUDIO_CONTROL_DEFAULT_SET_FAIL_TARGET:-} == "$requested_sink" ]] && continue
+        [[ ${AUDIO_CONTROL_DEFAULT_SET_NO_EFFECT_TARGET:-} == "$requested_sink" ]] && continue
+        default_sink=$requested_sink
+      done <"$AUDIO_CONTROL_OUTPUT_DEFAULT_LOG"
+      printf '%s\n' "$default_sink"
       exit 0
       ;;
     "-f json list sinks")
-      echo '[{"index":100,"name":"old-speakers"},{"index":101,"name":"new-speakers"}]'
+      [[ ${AUDIO_CONTROL_DEFAULT_LIST_FAIL:-} != output ]] || exit 1
+      default_target_index=101
+      default_target_object=${AUDIO_CONTROL_DEFAULT_TARGET_OBJECT:-51}
+      default_old_object=50
+      if [[ ${AUDIO_CONTROL_DEFAULT_TARGET_REINDEX:-} == output ]] &&
+          grep -q '^pactl set-default-sink new-speakers$' \
+            "$AUDIO_CONTROL_OUTPUT_DEFAULT_LOG" 2>/dev/null; then
+        default_target_index=103
+      fi
+      if [[ ${AUDIO_CONTROL_DEFAULT_TARGET_REPLACED_AFTER_SET:-} == output ]] &&
+          grep -q '^pactl set-default-sink new-speakers$' \
+            "$AUDIO_CONTROL_OUTPUT_DEFAULT_LOG" 2>/dev/null; then
+        default_target_object=53
+      fi
+      if [[ ${AUDIO_CONTROL_DEFAULT_OLD_REPLACED_AFTER_SET:-} == output ]] &&
+          grep -q '^pactl set-default-sink new-speakers$' \
+            "$AUDIO_CONTROL_OUTPUT_DEFAULT_LOG" 2>/dev/null; then
+        default_old_object=59
+      fi
+      if [[ ${AUDIO_CONTROL_DEFAULT_TARGET_ABSENT:-0} == 1 ]]; then
+        printf '[{"index":100,"name":"old-speakers","properties":{"object.id":"%s"}}]\n' \
+          "$default_old_object"
+      elif [[ ${AUDIO_CONTROL_DEFAULT_DUPLICATE_TARGET:-} == output ]]; then
+        printf '[{"index":100,"name":"old-speakers","properties":{"object.id":"%s"}},{"index":%s,"name":"new-speakers","properties":{"object.id":"%s"}},{"index":102,"name":"new-speakers","properties":{"object.id":"53"}}]\n' \
+          "$default_old_object" "$default_target_index" "$default_target_object"
+      else
+        printf '[{"index":100,"name":"old-speakers","properties":{"object.id":"%s"}},{"index":%s,"name":"new-speakers","properties":{"object.id":"%s"}}]\n' \
+          "$default_old_object" "$default_target_index" "$default_target_object"
+      fi
       exit 0
       ;;
     "-f json list sink-inputs")
-      echo '[{"index":300,"sink":100,"properties":{"object.id":"900","application.name":"Player"}},{"index":301,"sink":100,"properties":{"object.id":"901","application.name":"Pinned"}}]'
+      input_sink=100
+      while read -r command_name operation input_index requested_sink; do
+        [[ $command_name == pactl && $operation == move-sink-input && $input_index == 300 ]] || continue
+        [[ ${AUDIO_CONTROL_DEFAULT_MOVE_FAIL_TARGET:-} == "$requested_sink" ]] && continue
+        [[ ${AUDIO_CONTROL_DEFAULT_MOVE_NO_EFFECT_TARGET:-} == "$requested_sink" ]] && continue
+        if [[ $requested_sink == new-speakers ]]; then
+          input_sink=101
+          [[ ${AUDIO_CONTROL_DEFAULT_TARGET_REINDEX:-} != output ]] || input_sink=103
+        else
+          input_sink=100
+        fi
+      done <"$AUDIO_CONTROL_OUTPUT_DEFAULT_LOG"
+      if [[ ${AUDIO_CONTROL_DEFAULT_DUPLICATE_STREAM:-} == output ]]; then
+        printf '[{"index":300,"sink":%s,"properties":{"object.id":"900","application.name":"Player"}},{"index":302,"sink":%s,"properties":{"object.id":"900","application.name":"Duplicate"}},{"index":301,"sink":100,"properties":{"object.id":"901","application.name":"Pinned"}}]\n' \
+          "$input_sink" "$input_sink"
+      else
+        printf '[{"index":300,"sink":%s,"properties":{"object.id":"900","application.name":"Player"}},{"index":301,"sink":100,"properties":{"object.id":"901","application.name":"Pinned"}}]\n' "$input_sink"
+      fi
       exit 0
       ;;
-    "set-default-sink new-speakers"|"move-sink-input 300 new-speakers")
+    set-default-sink\ *)
+      requested_sink=${2:-}
       printf 'pactl %s\n' "$*" >>"$AUDIO_CONTROL_OUTPUT_DEFAULT_LOG"
+      [[ ${AUDIO_CONTROL_DEFAULT_SET_FAIL_TARGET:-} == "$requested_sink" ]] && exit 1
+      [[ ${AUDIO_CONTROL_DEFAULT_SET_FAIL_AFTER_EFFECT_TARGET:-} == "$requested_sink" ]] && exit 1
+      exit 0
+      ;;
+    move-sink-input\ 300\ *)
+      requested_sink=${3:-}
+      printf 'pactl %s\n' "$*" >>"$AUDIO_CONTROL_OUTPUT_DEFAULT_LOG"
+      [[ ${AUDIO_CONTROL_DEFAULT_MOVE_FAIL_TARGET:-} == "$requested_sink" ]] && exit 1
+      [[ ${AUDIO_CONTROL_DEFAULT_MOVE_FAIL_AFTER_EFFECT_TARGET:-} == "$requested_sink" ]] && exit 1
       exit 0
       ;;
   esac
 fi
 
 if [[ -n ${AUDIO_CONTROL_ROUTE_LIST:-} && $* == "-f json list" ]]; then
-  echo '{"sink_inputs":[{"index":300,"sink":101,"properties":{"object.id":"900"}}],"source_outputs":[{"index":400,"source":201,"properties":{"object.id":"901"}}]}'
+  if [[ -n ${AUDIO_CONTROL_ROUTE_LIST_JSON:-} ]]; then
+    printf '%s\n' "$AUDIO_CONTROL_ROUTE_LIST_JSON"
+  else
+    echo '{"sink_inputs":[{"index":300,"sink":101,"properties":{"object.id":"900"}}],"source_outputs":[{"index":400,"source":201,"properties":{"object.id":"901"}}]}'
+  fi
   exit 0
 fi
 
 if [[ -n ${AUDIO_CONTROL_PORT_LOG:-} ]]; then
-  port_sinks='[{"name":"speakers","description":"Built-in Audio","active_port":"analog-output-speaker","ports":[{"name":"analog-output-speaker","description":"Speakers","availability":"available"},{"name":"analog-output-headphones","description":"Headphones","availability":"available"},{"name":"hdmi-output","description":"HDMI","availability":"not available"}]}]'
-  port_sources='[{"name":"microphone","description":"Built-in Audio","active_port":"analog-input-internal-mic","ports":[{"name":"analog-input-internal-mic","description":"Internal Microphone","availability":"available"},{"name":"analog-input-headset-mic","description":"Headset Microphone","availability":"available"}]},{"name":"speakers.monitor","description":"Monitor","active_port":"analog-output-speaker","ports":[{"name":"one","description":"One","availability":"available"},{"name":"two","description":"Two","availability":"available"}]}]'
+  active_output_port=analog-output-speaker
+  port_command_count=0
+  while read -r operation endpoint_name requested_port; do
+    [[ $operation == set-sink-port ]] || continue
+    port_command_count=$((port_command_count + 1))
+    if [[ ${AUDIO_CONTROL_PORT_REINDEX_AFTER_SET:-0} == 1 ]]; then
+      if (( port_command_count == 1 )); then
+        [[ $endpoint_name == 10 || $endpoint_name == speakers ]] || continue
+      else
+        [[ $endpoint_name == 12 ]] || continue
+      fi
+    else
+      [[ $endpoint_name == 10 || $endpoint_name == speakers ]] || continue
+    fi
+    [[ ${AUDIO_CONTROL_PORT_SET_FAIL_TARGET:-} == "$requested_port" ]] && continue
+    [[ ${AUDIO_CONTROL_PORT_SET_NO_EFFECT_TARGET:-} == "$requested_port" ]] && continue
+    if [[ ${AUDIO_CONTROL_PORT_SET_WRONG_TARGET:-} == "$requested_port" ]]; then
+      active_output_port=${AUDIO_CONTROL_PORT_WRONG_ACTIVE:-analog-output-speaker}
+    else
+      active_output_port=$requested_port
+    fi
+  done <"$AUDIO_CONTROL_PORT_LOG"
+  active_output_json='"'"$active_output_port"'"'
+  active_input_json='"analog-input-internal-mic"'
+  active_monitor_json='"analog-output-speaker"'
+  if [[ ${AUDIO_CONTROL_PORT_OBJECT_ACTIVE:-0} == 1 ]]; then
+    active_output_json='{"name":"'"$active_output_port"'"}'
+    active_input_json='{"name":"analog-input-internal-mic"}'
+    active_monitor_json='{"name":"analog-output-speaker"}'
+  fi
+  output_ports='[{"name":"analog-output-speaker","description":"Speakers","availability":"available"},{"name":"analog-output-headphones","description":"Headphones","availability":"available"},{"name":"hdmi-output","description":"HDMI","availability":"not available"}]'
+  if [[ ${AUDIO_CONTROL_PORT_DUPLICATE_PORT:-0} == 1 ]]; then
+    output_ports='[{"name":"analog-output-speaker","description":"Speakers","availability":"available"},{"name":"analog-output-headphones","description":"Headphones","availability":"available"},{"name":"analog-output-headphones","description":"Duplicate","availability":"available"}]'
+  fi
+  output_properties='"properties":{"object.id":"700"},'
+  [[ ${AUDIO_CONTROL_PORT_MISSING_OBJECT:-0} != 1 ]] || output_properties=
+  port_sinks='[{"index":10,'"$output_properties"'"name":"speakers","description":"Built-in Audio","active_port":'"$active_output_json"',"ports":'"$output_ports"'}]'
+  if (( port_command_count > 0 )) && [[ ${AUDIO_CONTROL_PORT_ORIGINAL_GONE_AFTER_SET:-0} == 1 ]]; then
+    port_sinks='[{"index":10,"properties":{"object.id":"701"},"name":"speakers","description":"Replacement","active_port":"analog-output-speaker","ports":'"$output_ports"'}]'
+  elif (( port_command_count > 0 )) && [[ ${AUDIO_CONTROL_PORT_REINDEX_AFTER_SET:-0} == 1 ]]; then
+    port_sinks='[{"index":10,"properties":{"object.id":"701"},"name":"speakers","description":"Replacement","active_port":"analog-output-speaker","ports":'"$output_ports"'},{"index":12,"properties":{"object.id":"700"},"name":"speakers","description":"Built-in Audio","active_port":'"$active_output_json"',"ports":'"$output_ports"'}]'
+  elif [[ ${AUDIO_CONTROL_PORT_DUPLICATE_ENDPOINT:-0} == 1 ]]; then
+    port_sinks='[{"index":10,"properties":{"object.id":"700"},"name":"speakers","description":"Built-in Audio","active_port":'"$active_output_json"',"ports":'"$output_ports"'},{"index":11,"properties":{"object.id":"701"},"name":"speakers","description":"Duplicate","active_port":"analog-output-speaker","ports":'"$output_ports"'}]'
+  fi
+  port_sources='[{"index":20,"properties":{"object.id":"800"},"name":"microphone","description":"Built-in Audio","active_port":'"$active_input_json"',"ports":[{"name":"analog-input-internal-mic","description":"Internal Microphone","availability":"available"},{"name":"analog-input-headset-mic","description":"Headset Microphone","availability":"available"}]},{"index":21,"properties":{"object.id":"801"},"name":"speakers.monitor","description":"Monitor","active_port":'"$active_monitor_json"',"ports":[{"name":"one","description":"One","availability":"available"},{"name":"two","description":"Two","availability":"available"}]},{"index":22,"properties":{"object.id":"802","device.class":"monitor"},"name":"loopback-source","description":"Nonstandard monitor","active_port":"one","ports":[{"name":"one","description":"One","availability":"available"},{"name":"two","description":"Two","availability":"available"}]}]'
   case "$*" in
     "-f json list")
       printf '{"sinks":%s,"sources":%s}\n' "$port_sinks" "$port_sources"
       exit 0
       ;;
     "-f json list sinks")
+      [[ ${AUDIO_CONTROL_PORT_LIST_FAIL_WHEN_ACTIVE:-} != "$active_output_port" ]] || exit 1
       printf '%s\n' "$port_sinks"
       exit 0
       ;;
-    "set-sink-port speakers analog-output-headphones")
+    "-f json list sources")
+      printf '%s\n' "$port_sources"
+      exit 0
+      ;;
+    set-sink-port\ *\ *)
+      requested_port=${3:-}
+      printf '%s\n' "$*" >>"$AUDIO_CONTROL_PORT_LOG"
+      [[ ${AUDIO_CONTROL_PORT_SET_FAIL_TARGET:-} == "$requested_port" ]] && exit 1
+      [[ ${AUDIO_CONTROL_PORT_SET_FAIL_AFTER_EFFECT_TARGET:-} == "$requested_port" ]] && exit 1
+      exit 0
+      ;;
+    set-source-port\ *\ *)
       printf '%s\n' "$*" >>"$AUDIO_CONTROL_PORT_LOG"
       exit 0
       ;;
@@ -79,16 +268,67 @@ fi
 
 if [[ -n ${AUDIO_CONTROL_ROUTE_LOG:-} ]]; then
   case "$*" in
-    "move-sink-input 300 101")
+    move-sink-input\ *\ *)
       printf '%s\n' "$*" >>"$AUDIO_CONTROL_ROUTE_LOG"
+      [[ ${AUDIO_CONTROL_ROUTE_MOVE_FAIL_TARGET:-} == "${!#}" ]] && exit 1
+      [[ ${AUDIO_CONTROL_ROUTE_MOVE_FAIL_AFTER_EFFECT_TARGET:-} == "${!#}" ]] && exit 1
       exit 0
       ;;
-    "move-source-output 400 201")
+    move-source-output\ *\ *)
       printf '%s\n' "$*" >>"$AUDIO_CONTROL_ROUTE_LOG"
+      [[ ${AUDIO_CONTROL_ROUTE_MOVE_FAIL_TARGET:-} == "${!#}" ]] && exit 1
+      [[ ${AUDIO_CONTROL_ROUTE_MOVE_FAIL_AFTER_EFFECT_TARGET:-} == "${!#}" ]] && exit 1
       exit 0
       ;;
     "-f json list")
-      echo '{"sink_inputs":[{"index":300,"sink":101,"properties":{"object.id":"900"}}],"source_outputs":[{"index":400,"source":201,"properties":{"object.id":"901"}}],"sinks":[{"index":101,"properties":{"object.id":"1001"}}],"sources":[{"index":201,"properties":{"object.id":"2001"}}]}'
+      route_read_count=1
+      if [[ -n ${AUDIO_CONTROL_ROUTE_READ_STATE:-} ]]; then
+        route_read_count=$(<"$AUDIO_CONTROL_ROUTE_READ_STATE")
+        [[ $route_read_count =~ ^[0-9]+$ ]] || route_read_count=0
+        route_read_count=$((route_read_count + 1))
+        printf '%s\n' "$route_read_count" >"$AUDIO_CONTROL_ROUTE_READ_STATE"
+      fi
+      route_stream_index=300
+      if (( route_read_count > 1 )) && [[ ${AUDIO_CONTROL_ROUTE_STREAM_REINDEX:-0} == 1 ||
+          ${AUDIO_CONTROL_ROUTE_STREAM_INDEX_REUSE:-0} == 1 ]]; then
+        route_stream_index=302
+      fi
+      route_target_index=101
+      if (( route_read_count > 1 )) && [[ ${AUDIO_CONTROL_ROUTE_TARGET_REINDEX:-0} == 1 ]]; then
+        route_target_index=103
+      fi
+      route_original_index=100
+      if (( route_read_count > 1 )) && [[ ${AUDIO_CONTROL_ROUTE_ORIGINAL_REINDEX:-0} == 1 ]]; then
+        route_original_index=104
+      fi
+      route_sink=${AUDIO_CONTROL_ROUTE_ORIGINAL_SINK:-101}
+      route_source=${AUDIO_CONTROL_ROUTE_ORIGINAL_SOURCE:-201}
+      while read -r route_kind route_index route_target; do
+        [[ -n $route_kind ]] || continue
+        [[ ${AUDIO_CONTROL_ROUTE_MOVE_FAIL_TARGET:-} == "$route_target" ]] && continue
+        [[ ${AUDIO_CONTROL_ROUTE_MOVE_NO_EFFECT_TARGET:-} == "$route_target" ]] && continue
+        if [[ $route_kind == move-sink-input && $route_index == "$route_stream_index" ]]; then
+          route_sink=$route_target
+        elif [[ $route_kind == move-source-output && $route_index == 400 ]]; then
+          route_source=$route_target
+        fi
+      done <"$AUDIO_CONTROL_ROUTE_LOG"
+      sink_inputs='[{"index":'"$route_stream_index"',"sink":'"$route_sink"',"properties":{"object.id":"900"}}]'
+      if (( route_read_count > 1 )) && [[ ${AUDIO_CONTROL_ROUTE_STREAM_INDEX_REUSE:-0} == 1 ]]; then
+        sink_inputs='[{"index":300,"sink":100,"properties":{"object.id":"999"}},{"index":302,"sink":'"$route_sink"',"properties":{"object.id":"900"}}]'
+      elif (( route_read_count > 1 )) && [[ ${AUDIO_CONTROL_ROUTE_DUPLICATE_STREAM_OBJECT:-0} == 1 ]]; then
+        sink_inputs='[{"index":300,"sink":'"$route_sink"',"properties":{"object.id":"900"}},{"index":302,"sink":'"$route_sink"',"properties":{"object.id":"900"}}]'
+      fi
+      sinks='[{"index":'"$route_original_index"',"properties":{"object.id":"1000"}},{"index":'"$route_target_index"',"properties":{"object.id":"1001"}}]'
+      if (( route_read_count > 1 )) && [[ ${AUDIO_CONTROL_ROUTE_TARGET_REINDEX:-0} == 1 ]]; then
+        sinks='[{"index":100,"properties":{"object.id":"1000"}},{"index":101,"properties":{"object.id":"1999"}},{"index":103,"properties":{"object.id":"1001"}}]'
+      elif (( route_read_count > 1 )) && [[ ${AUDIO_CONTROL_ROUTE_ORIGINAL_REINDEX:-0} == 1 ]]; then
+        sinks='[{"index":100,"properties":{"object.id":"1998"}},{"index":104,"properties":{"object.id":"1000"}},{"index":101,"properties":{"object.id":"1001"}}]'
+      elif [[ ${AUDIO_CONTROL_ROUTE_DUPLICATE_ORIGINAL_OBJECT:-0} == 1 ]]; then
+        sinks='[{"index":100,"properties":{"object.id":"1000"}},{"index":101,"properties":{"object.id":"1001"}},{"index":102,"properties":{"object.id":"1000"}}]'
+      fi
+      printf '{"sink_inputs":%s,"source_outputs":[{"index":400,"source":%s,"properties":{"object.id":"901"}}],"sinks":%s,"sources":[{"index":200,"properties":{"object.id":"2000"}},{"index":201,"properties":{"object.id":"2001"}}]}\n' \
+        "$sink_inputs" "$route_source" "$sinks"
       exit 0
       ;;
   esac
@@ -97,23 +337,82 @@ fi
 if [[ -n ${AUDIO_CONTROL_INPUT_DEFAULT_LOG:-} ]]; then
   case "$*" in
     "get-default-source")
-      if grep -q '^pactl set-default-source new-microphone$' "$AUDIO_CONTROL_INPUT_DEFAULT_LOG" 2>/dev/null; then
-        echo "new-microphone"
-      else
-        echo "old-microphone"
-      fi
+      [[ ${AUDIO_CONTROL_DEFAULT_READ_FAIL:-} != input ]] || exit 1
+      default_source=old-microphone
+      while read -r command_name operation requested_source; do
+        [[ $command_name == pactl && $operation == set-default-source ]] || continue
+        [[ ${AUDIO_CONTROL_DEFAULT_SET_FAIL_TARGET:-} == "$requested_source" ]] && continue
+        [[ ${AUDIO_CONTROL_DEFAULT_SET_NO_EFFECT_TARGET:-} == "$requested_source" ]] && continue
+        default_source=$requested_source
+      done <"$AUDIO_CONTROL_INPUT_DEFAULT_LOG"
+      printf '%s\n' "$default_source"
       exit 0
       ;;
     "-f json list sources")
-      echo '[{"index":200,"name":"old-microphone"},{"index":201,"name":"new-microphone"}]'
+      [[ ${AUDIO_CONTROL_DEFAULT_LIST_FAIL:-} != input ]] || exit 1
+      default_target_index=201
+      default_target_object=${AUDIO_CONTROL_DEFAULT_TARGET_OBJECT:-52}
+      default_old_object=60
+      if [[ ${AUDIO_CONTROL_DEFAULT_TARGET_REINDEX:-} == input ]] &&
+          grep -q '^pactl set-default-source new-microphone$' \
+            "$AUDIO_CONTROL_INPUT_DEFAULT_LOG" 2>/dev/null; then
+        default_target_index=203
+      fi
+      if [[ ${AUDIO_CONTROL_DEFAULT_TARGET_REPLACED_AFTER_SET:-} == input ]] &&
+          grep -q '^pactl set-default-source new-microphone$' \
+            "$AUDIO_CONTROL_INPUT_DEFAULT_LOG" 2>/dev/null; then
+        default_target_object=62
+      fi
+      if [[ ${AUDIO_CONTROL_DEFAULT_OLD_REPLACED_AFTER_SET:-} == input ]] &&
+          grep -q '^pactl set-default-source new-microphone$' \
+            "$AUDIO_CONTROL_INPUT_DEFAULT_LOG" 2>/dev/null; then
+        default_old_object=69
+      fi
+      if [[ ${AUDIO_CONTROL_DEFAULT_TARGET_ABSENT:-0} == 1 ]]; then
+        printf '[{"index":200,"name":"old-microphone","properties":{"object.id":"%s"}}]\n' \
+          "$default_old_object"
+      elif [[ ${AUDIO_CONTROL_DEFAULT_DUPLICATE_TARGET:-} == input ]]; then
+        printf '[{"index":200,"name":"old-microphone","properties":{"object.id":"%s"}},{"index":%s,"name":"new-microphone","properties":{"object.id":"%s"}},{"index":202,"name":"new-microphone","properties":{"object.id":"62"}}]\n' \
+          "$default_old_object" "$default_target_index" "$default_target_object"
+      else
+        printf '[{"index":200,"name":"old-microphone","properties":{"object.id":"%s"}},{"index":%s,"name":"new-microphone","properties":{"object.id":"%s"}}]\n' \
+          "$default_old_object" "$default_target_index" "$default_target_object"
+      fi
       exit 0
       ;;
     "-f json list source-outputs")
-      echo '[{"index":400,"source":200,"properties":{"object.id":"901"}},{"index":401,"source":200,"properties":{"object.id":"902"}}]'
+      output_source=200
+      while read -r command_name operation output_index requested_source; do
+        [[ $command_name == pactl && $operation == move-source-output && $output_index == 400 ]] || continue
+        [[ ${AUDIO_CONTROL_DEFAULT_MOVE_FAIL_TARGET:-} == "$requested_source" ]] && continue
+        [[ ${AUDIO_CONTROL_DEFAULT_MOVE_NO_EFFECT_TARGET:-} == "$requested_source" ]] && continue
+        if [[ $requested_source == new-microphone ]]; then
+          output_source=201
+          [[ ${AUDIO_CONTROL_DEFAULT_TARGET_REINDEX:-} != input ]] || output_source=203
+        else
+          output_source=200
+        fi
+      done <"$AUDIO_CONTROL_INPUT_DEFAULT_LOG"
+      if [[ ${AUDIO_CONTROL_DEFAULT_DUPLICATE_STREAM:-} == input ]]; then
+        printf '[{"index":400,"source":%s,"properties":{"object.id":"901"}},{"index":402,"source":%s,"properties":{"object.id":"901"}},{"index":401,"source":200,"properties":{"object.id":"902"}}]\n' \
+          "$output_source" "$output_source"
+      else
+        printf '[{"index":400,"source":%s,"properties":{"object.id":"901"}},{"index":401,"source":200,"properties":{"object.id":"902"}}]\n' "$output_source"
+      fi
       exit 0
       ;;
-    "set-default-source new-microphone"|"move-source-output 400 new-microphone")
+    set-default-source\ *)
+      requested_source=${2:-}
       printf 'pactl %s\n' "$*" >>"$AUDIO_CONTROL_INPUT_DEFAULT_LOG"
+      [[ ${AUDIO_CONTROL_DEFAULT_SET_FAIL_TARGET:-} == "$requested_source" ]] && exit 1
+      [[ ${AUDIO_CONTROL_DEFAULT_SET_FAIL_AFTER_EFFECT_TARGET:-} == "$requested_source" ]] && exit 1
+      exit 0
+      ;;
+    move-source-output\ 400\ *)
+      requested_source=${3:-}
+      printf 'pactl %s\n' "$*" >>"$AUDIO_CONTROL_INPUT_DEFAULT_LOG"
+      [[ ${AUDIO_CONTROL_DEFAULT_MOVE_FAIL_TARGET:-} == "$requested_source" ]] && exit 1
+      [[ ${AUDIO_CONTROL_DEFAULT_MOVE_FAIL_AFTER_EFFECT_TARGET:-} == "$requested_source" ]] && exit 1
       exit 0
       ;;
   esac
@@ -125,45 +424,125 @@ if [[ -n ${AUDIO_CONTROL_PROFILE_LOG:-} && -n ${AUDIO_CONTROL_PROFILE_STATE:-} ]
   case "$*" in
     "-f json list sinks")
       if [[ ${AUDIO_CONTROL_MULTI_PROFILE:-0} == 1 && $state == old ]]; then
-        echo '[{"index":110,"name":"speaker-output","card":40,"volume":{"front-left":{"value_percent":"60%"},"front-right":{"value_percent":"45%"}},"mute":false}]'
+        profile_endpoint_json='[{"index":110,"name":"speaker-output","card":40,"properties":{"object.id":"1110"},"volume":{"front-left":{"value_percent":"60%"},"front-right":{"value_percent":"45%"}},"mute":false}]'
       elif [[ ${AUDIO_CONTROL_MULTI_PROFILE:-0} == 1 ]]; then
-        echo '[{"index":120,"name":"speaker-output","card":40,"volume":{"front-left":{"value_percent":"100%"},"front-right":{"value_percent":"100%"}},"mute":false}]'
+        profile_endpoint_json='[{"index":120,"name":"speaker-output","card":40,"properties":{"object.id":"1120"},"volume":{"front-left":{"value_percent":"100%"},"front-right":{"value_percent":"100%"}},"mute":false}]'
+      elif [[ $state != old && -n ${AUDIO_CONTROL_PROFILE_ENDPOINT_READ_STATE:-} ]]; then
+        endpoint_read_count=0
+        [[ ! -s $AUDIO_CONTROL_PROFILE_ENDPOINT_READ_STATE ]] ||
+          endpoint_read_count=$(<"$AUDIO_CONTROL_PROFILE_ENDPOINT_READ_STATE")
+        [[ $endpoint_read_count =~ ^[0-9]+$ ]] || endpoint_read_count=0
+        endpoint_read_count=$((endpoint_read_count + 1))
+        printf '%s\n' "$endpoint_read_count" >"$AUDIO_CONTROL_PROFILE_ENDPOINT_READ_STATE"
+        if (( endpoint_read_count >= 3 )); then
+          profile_endpoint_json='[{"index":101,"name":"headset-output","card":10,"properties":{"object.id":"1199"},"volume":{"front-left":{"value_percent":"90%"},"front-right":{"value_percent":"90%"}},"mute":false}]'
+        else
+          profile_endpoint_json='[{"index":101,"name":"headset-output","card":10,"properties":{"object.id":"1101"},"volume":{"front-left":{"value_percent":"100%"},"front-right":{"value_percent":"100%"}},"mute":false}]'
+        fi
       elif [[ $state != old && ${AUDIO_CONTROL_PROFILE_VANISH_SINKS:-0} == 1 ]]; then
-        echo '[]'
+        profile_endpoint_json='[]'
       elif [[ $state == old ]]; then
-        echo '[{"index":100,"name":"headset-output","card":10,"volume":{"front-left":{"value_percent":"42%"},"front-right":{"value_percent":"21%"}},"mute":false}]'
+        profile_endpoint_json='[{"index":100,"name":"headset-output","card":10,"properties":{"object.id":"1100"},"volume":{"front-left":{"value_percent":"42%"},"front-right":{"value_percent":"21%"}},"mute":false}]'
       else
-        echo '[{"index":101,"name":"headset-output","card":10,"volume":{"front-left":{"value_percent":"100%"},"front-right":{"value_percent":"100%"}},"mute":false}]'
+        profile_endpoint_json='[{"index":101,"name":"headset-output","card":10,"properties":{"object.id":"1101"},"volume":{"front-left":{"value_percent":"100%"},"front-right":{"value_percent":"100%"}},"mute":false}]'
       fi
+      apply_profile_endpoint_commands sink "$profile_endpoint_json"
       exit 0
       ;;
     "-f json list sources")
       if [[ ${AUDIO_CONTROL_MULTI_PROFILE:-0} == 1 && $state == old ]]; then
-        echo '[{"index":210,"name":"mic-a","card":40,"volume":{"mono":{"value_percent":"30%"}},"mute":false},{"index":211,"name":"mic-b","card":40,"volume":{"mono":{"value_percent":"70%"}},"mute":true}]'
+        profile_endpoint_json='[{"index":210,"name":"mic-a","card":40,"properties":{"object.id":"1210"},"volume":{"mono":{"value_percent":"30%"}},"mute":false},{"index":211,"name":"mic-b","card":40,"properties":{"object.id":"1211"},"volume":{"mono":{"value_percent":"70%"}},"mute":true}]'
       elif [[ ${AUDIO_CONTROL_MULTI_PROFILE:-0} == 1 ]]; then
-        echo '[{"index":221,"name":"mic-b","card":40,"volume":{"mono":{"value_percent":"100%"}},"mute":false},{"index":220,"name":"mic-a","card":40,"volume":{"mono":{"value_percent":"100%"}},"mute":false}]'
+        profile_endpoint_json='[{"index":221,"name":"mic-b","card":40,"properties":{"object.id":"1221"},"volume":{"mono":{"value_percent":"100%"}},"mute":false},{"index":220,"name":"mic-a","card":40,"properties":{"object.id":"1220"},"volume":{"mono":{"value_percent":"100%"}},"mute":false}]'
       elif [[ $state != old && ${AUDIO_CONTROL_PROFILE_VANISH_SOURCES:-0} == 1 ]]; then
-        echo '[]'
+        profile_endpoint_json='[]'
+      elif [[ $state != old && ${AUDIO_CONTROL_PROFILE_SOURCE_REUSE:-0} == 1 ]]; then
+        profile_endpoint_json='[{"index":200,"name":"replacement-input","card":10,"properties":{"object.id":"2299"},"volume":{"mono":{"value_percent":"90%"}},"mute":false}]'
       else
-        echo '[{"index":200,"name":"headset-input","card":10,"volume":{"mono":{"value_percent":"36%"}},"mute":true}]'
+        if [[ $state == old ]]; then
+          profile_endpoint_json='[{"index":200,"name":"headset-input","card":10,"properties":{"object.id":"1200"},"volume":{"mono":{"value_percent":"36%"}},"mute":true}]'
+        else
+          profile_endpoint_json='[{"index":200,"name":"headset-input","card":10,"properties":{"object.id":"1201"},"volume":{"mono":{"value_percent":"36%"}},"mute":true}]'
+        fi
       fi
+      apply_profile_endpoint_commands source "$profile_endpoint_json"
       exit 0
       ;;
     "-f json list sink-inputs")
       if [[ ${AUDIO_CONTROL_MULTI_PROFILE:-0} == 1 ]]; then
         echo '[]'
+      elif [[ $state != old && ${AUDIO_CONTROL_PROFILE_STREAM_VANISH:-0} == 1 ]]; then
+        echo '[]'
       else
-        echo '[{"index":300,"sink":100,"mute":false}]'
+        input_object=900
+        [[ $state == old || ${AUDIO_CONTROL_PROFILE_STREAM_REUSE:-0} != 1 ]] || input_object=901
+        input_index=300
+        [[ $state == old || ${AUDIO_CONTROL_PROFILE_STREAM_REINDEX:-0} != 1 ]] || input_index=302
+        input_mute=false
+        after_profile=false
+        declare -A input_command_count=()
+        while read -r profile_operation profile_index profile_value; do
+          if [[ $profile_operation == set-card-profile ]]; then
+            after_profile=true
+            continue
+          fi
+          [[ $profile_operation == set-sink-input-mute ]] || continue
+          if [[ $state != old && ${AUDIO_CONTROL_PROFILE_STREAM_REUSE:-0} == 1 &&
+              $after_profile == false ]]; then
+            continue
+          fi
+          if [[ $profile_index != "$input_index" ]]; then
+            [[ $input_object == 900 && $profile_index == 300 &&
+                ${AUDIO_CONTROL_PROFILE_STREAM_REINDEX:-0} == 1 ]] || continue
+          fi
+          profile_line="$profile_operation $profile_index $profile_value"
+          input_command_count["$profile_line"]=$(( ${input_command_count["$profile_line"]:-0} + 1 ))
+          [[ ${AUDIO_CONTROL_PROFILE_FAIL_COMMAND:-} != "$profile_line" ]] || continue
+          if [[ ${AUDIO_CONTROL_PROFILE_FAIL_ONCE_COMMAND:-} == "$profile_line" &&
+              ${input_command_count["$profile_line"]} == 1 ]]; then
+            continue
+          fi
+          input_mute=$profile_value
+        done <"$AUDIO_CONTROL_PROFILE_LOG"
+        printf '[{"index":%s,"sink":100,"mute":%s,"properties":{"object.id":"%s"}}]\n' \
+          "$input_index" "$input_mute" "$input_object"
       fi
       exit 0
       ;;
     set-card-profile\ *)
       printf '%s\n' "$*" >>"$AUDIO_CONTROL_PROFILE_LOG"
-      printf 'new\n' >"$AUDIO_CONTROL_PROFILE_STATE"
+      if [[ ${AUDIO_CONTROL_PROFILE_SET_FAIL:-0} == 1 ]]; then
+        exit 1
+      fi
+      if [[ ${AUDIO_CONTROL_PROFILE_NO_EFFECT:-0} != 1 ]]; then
+        original_profile=$(jq -r --arg card "${2:-}" '
+          [.[] | select(.name == $card)]
+          | if length == 1 then (.[0].active_profile // "") else "" end
+        ' "$AUDIO_CONTROL_CARD_FIXTURE")
+        if [[ -n $original_profile && ${3:-} == "$original_profile" ]]; then
+          printf 'old\n' >"$AUDIO_CONTROL_PROFILE_STATE"
+        else
+          printf 'new\n' >"$AUDIO_CONTROL_PROFILE_STATE"
+        fi
+      fi
+      [[ ${AUDIO_CONTROL_PROFILE_SET_FAIL_AFTER_EFFECT:-0} != 1 ]] || exit 1
       exit 0
       ;;
     set-sink-*|set-source-*)
       printf '%s\n' "$*" >>"$AUDIO_CONTROL_PROFILE_LOG"
+      if [[ -n ${AUDIO_CONTROL_PROFILE_FAIL_COMMAND:-} &&
+          $* == "$AUDIO_CONTROL_PROFILE_FAIL_COMMAND" ]]; then
+        exit 1
+      fi
+      if [[ -n ${AUDIO_CONTROL_PROFILE_FAIL_ONCE_COMMAND:-} &&
+          $* == "$AUDIO_CONTROL_PROFILE_FAIL_ONCE_COMMAND" ]] &&
+          (( $(grep -Fxc -- "$*" "$AUDIO_CONTROL_PROFILE_LOG") == 1 )); then
+        exit 1
+      fi
+      if [[ -n ${AUDIO_CONTROL_PROFILE_FAIL_AFTER_EFFECT_COMMAND:-} &&
+          $* == "$AUDIO_CONTROL_PROFILE_FAIL_AFTER_EFFECT_COMMAND" ]]; then
+        exit 1
+      fi
       exit 0
       ;;
   esac

--- a/test/mocks/pw-metadata
+++ b/test/mocks/pw-metadata
@@ -1,6 +1,17 @@
 #!/bin/bash
 
 if [[ -n ${AUDIO_CONTROL_ROUTE_LIST:-} ]]; then
+  if [[ ${AUDIO_CONTROL_ROUTE_LIST_INVALID_METADATA:-0} == 1 ]]; then
+    echo "update: id:900 key:'target.object' value:'-2' type:'Spa:Id'"
+    exit 0
+  fi
+  if [[ ${AUDIO_CONTROL_ROUTE_LIST_OVERSIZED_METADATA:-0} == 1 ]]; then
+    for (( metadata_id = 1; metadata_id <= 4097; metadata_id++ )); do
+      printf "update: id:%s key:'target.object' value:'101' type:'Spa:Id'\n" \
+        "$metadata_id"
+    done
+    exit 0
+  fi
   cat <<'EOF'
 update: id:900 key:'target.object' value:'101' type:'Spa:Id'
 update: id:901 key:'target.node' value:'2001' type:'Spa:Id'
@@ -23,4 +34,46 @@ fi
   exit 1
 }
 
+if [[ $* == "-n default" ]]; then
+  [[ ${AUDIO_CONTROL_ROUTE_METADATA_READ_FAIL:-0} != 1 ]] || exit 1
+  if [[ ${AUDIO_CONTROL_ROUTE_METADATA_READ_FAIL_AFTER_WRITES:-0} == 1 ]] &&
+      grep -q '^pw-metadata ' "$AUDIO_CONTROL_ROUTE_LOG" 2>/dev/null; then
+    exit 1
+  fi
+  object_900=${AUDIO_CONTROL_ROUTE_PREVIOUS_OBJECT:--1}
+  node_900=${AUDIO_CONTROL_ROUTE_PREVIOUS_NODE:--1}
+  object_901=${AUDIO_CONTROL_ROUTE_PREVIOUS_OBJECT:--1}
+  node_901=${AUDIO_CONTROL_ROUTE_PREVIOUS_NODE:--1}
+  while read -r command_name option_name metadata_name separator object_id key value value_type; do
+    [[ $command_name == pw-metadata && $separator == -- ]] || continue
+    if [[ -n ${AUDIO_CONTROL_ROUTE_METADATA_WRITE_FAIL:-} &&
+        $key == "$AUDIO_CONTROL_ROUTE_METADATA_WRITE_FAIL" &&
+        ${AUDIO_CONTROL_ROUTE_METADATA_FAIL_AFTER_EFFECT:-0} != 1 ]]; then
+      continue
+    fi
+    [[ ${AUDIO_CONTROL_ROUTE_METADATA_NO_EFFECT:-} == "$key" ]] && continue
+    case "$object_id:$key" in
+      900:target.object) object_900=$value ;;
+      900:target.node) node_900=$value ;;
+      901:target.object) object_901=$value ;;
+      901:target.node) node_901=$value ;;
+    esac
+  done <"$AUDIO_CONTROL_ROUTE_LOG"
+  if [[ ${AUDIO_CONTROL_ROUTE_DUPLICATE_METADATA_VALUE:-0} == 1 ]]; then
+    printf "update: id:900 key:'target.object' value:'%s' type:'Spa:Id'\n" \
+      "$object_900"
+  fi
+  cat <<EOF
+update: id:900 key:'target.object' value:'$object_900' type:'Spa:Id'
+update: id:900 key:'target.node' value:'$node_900' type:'Spa:Id'
+update: id:901 key:'target.object' value:'$object_901' type:'Spa:Id'
+update: id:901 key:'target.node' value:'$node_901' type:'Spa:Id'
+EOF
+  exit 0
+fi
+
 printf 'pw-metadata %s\n' "$*" >>"$AUDIO_CONTROL_ROUTE_LOG"
+if [[ -n ${AUDIO_CONTROL_ROUTE_METADATA_WRITE_FAIL:-} &&
+      $* == *" ${AUDIO_CONTROL_ROUTE_METADATA_WRITE_FAIL} "* ]]; then
+  exit 1
+fi

--- a/test/mocks/pw-record
+++ b/test/mocks/pw-record
@@ -5,7 +5,10 @@
 [[ ${AUDIO_CONTROL_MICROPHONE_TEST_RECORD_FAIL:-0} == 1 ]] && exit 1
 if [[ ${AUDIO_CONTROL_MICROPHONE_TEST_RECORD_WAIT:-0} == 1 ]]; then
   truncate -s 96000 "${!#}"
-  while true; do sleep 0.05; done
+  # Model pw-record as one long-lived process. Using a shell sleep loop here
+  # leaves a short-lived descendant holding inherited lock descriptors after
+  # the mock itself is killed, unlike the real recorder binary.
+  exec tail -f /dev/null
 fi
 truncate -s "${AUDIO_CONTROL_MICROPHONE_TEST_RECORD_BYTES:-480000}" "${!#}"
 exit "${AUDIO_CONTROL_MICROPHONE_TEST_RECORD_STATUS:-0}"

--- a/test/mocks/wpctl
+++ b/test/mocks/wpctl
@@ -4,13 +4,15 @@ if [[ -n ${AUDIO_CONTROL_DEFAULT_FAILURE:-} && $1 == "set-default" ]]; then
   exit 1
 fi
 
-if [[ -n ${AUDIO_CONTROL_OUTPUT_DEFAULT_LOG:-} && $* == "set-default 51" ]]; then
+if [[ -n ${AUDIO_CONTROL_OUTPUT_DEFAULT_LOG:-} && $1 == "set-default" ]]; then
   printf 'wpctl %s\n' "$*" >>"$AUDIO_CONTROL_OUTPUT_DEFAULT_LOG"
+  [[ ${AUDIO_CONTROL_DEFAULT_WPCTL_FAIL_ID:-} == "${2:-}" ]] && exit 1
   exit 0
 fi
 
-if [[ -n ${AUDIO_CONTROL_INPUT_DEFAULT_LOG:-} && $* == "set-default 52" ]]; then
+if [[ -n ${AUDIO_CONTROL_INPUT_DEFAULT_LOG:-} && $1 == "set-default" ]]; then
   printf 'wpctl %s\n' "$*" >>"$AUDIO_CONTROL_INPUT_DEFAULT_LOG"
+  [[ ${AUDIO_CONTROL_DEFAULT_WPCTL_FAIL_ID:-} == "${2:-}" ]] && exit 1
   exit 0
 fi
 
@@ -39,10 +41,19 @@ if [[ -n ${AUDIO_CONTROL_POLICY_STATE:-} ]]; then
     [[ -n ${AUDIO_CONTROL_POLICY_LOG:-} ]] &&
       printf 'settings --save %s %s\n' "$setting" "$value" >>"$AUDIO_CONTROL_POLICY_LOG"
     [[ ${AUDIO_CONTROL_POLICY_FAIL:-} == 1 || ${AUDIO_CONTROL_POLICY_FAIL:-} == "$setting" ]] && exit 1
+    [[ ${AUDIO_CONTROL_POLICY_NO_EFFECT:-} == "$setting" ||
+        ${AUDIO_CONTROL_POLICY_NO_EFFECT_VALUE:-} == "$setting=$value" ]] && exit 0
+    stored_value=$value
+    if [[ ${AUDIO_CONTROL_POLICY_WRONG_VALUE:-} == "$setting" &&
+        ( -z ${AUDIO_CONTROL_POLICY_WRONG_ON_VALUE:-} ||
+          ${AUDIO_CONTROL_POLICY_WRONG_ON_VALUE:-} == "$value" ) ]]; then
+      stored_value=${AUDIO_CONTROL_POLICY_WRONG_RAW:-null}
+    fi
     temporary_file="${state_file}.tmp"
-    jq --arg setting "$setting" --argjson value "$value" \
+    jq --arg setting "$setting" --argjson value "$stored_value" \
       '.[$setting] = $value' "$state_file" >"$temporary_file"
     mv -f -- "$temporary_file" "$state_file"
+    [[ ${AUDIO_CONTROL_POLICY_FAIL_AFTER_EFFECT:-} != "$setting" ]] || exit 1
     exit 0
   fi
 
@@ -55,6 +66,8 @@ if [[ -n ${AUDIO_CONTROL_POLICY_STATE:-} ]]; then
     value=$(jq -r --arg setting "$setting" --arg fallback "$fallback" \
       'if has($setting) then .[$setting] else ($fallback | fromjson) end' "$state_file")
     printf 'Value: %s\n' "$value"
+    [[ ${AUDIO_CONTROL_WPCTL_DUPLICATE_VALUE:-0} != 1 ]] ||
+      printf 'Value: %s\n' "$value"
     exit 0
   fi
 fi
@@ -65,13 +78,20 @@ if [[ -n ${AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_LOG:-} ]]; then
     "settings --save bluetooth.autoswitch-to-headset-profile true"|"settings --save bluetooth.autoswitch-to-headset-profile false")
       printf '%s\n' "$*" >>"$AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_LOG"
       [[ ${AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_FAIL:-0} == 1 ]] && exit 1
-      printf '%s\n' "${!#}" >"$state_file"
+      requested=${!#}
+      [[ ${AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_NO_EFFECT_VALUE:-} == "$requested" ]] && exit 0
+      stored=$requested
+      [[ ${AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_WRONG_VALUE:-} == "$requested" ]] && stored=invalid
+      printf '%s\n' "$stored" >"$state_file"
+      [[ ${AUDIO_CONTROL_BLUETOOTH_AUTOSWITCH_FAIL_AFTER_EFFECT:-0} != 1 ]] || exit 1
       exit 0
       ;;
     "settings bluetooth.autoswitch-to-headset-profile")
       value=true
       [[ -s $state_file ]] && value=$(<"$state_file")
       printf 'Value: %s\n' "$value"
+      [[ ${AUDIO_CONTROL_WPCTL_DUPLICATE_VALUE:-0} != 1 ]] ||
+        printf 'Value: %s\n' "$value"
       exit 0
       ;;
   esac
@@ -82,13 +102,21 @@ if [[ -n ${AUDIO_CONTROL_BLUETOOTH_PREFERENCE_LOG:-} ]]; then
   case "$*" in
     "settings --save bluetooth.profile-preference quality"|"settings --save bluetooth.profile-preference latency")
       printf '%s\n' "$*" >>"$AUDIO_CONTROL_BLUETOOTH_PREFERENCE_LOG"
-      printf '%s\n' "${!#}" >"$state_file"
+      requested=${!#}
+      [[ ${AUDIO_CONTROL_BLUETOOTH_PREFERENCE_FAIL:-0} != 1 ]] || exit 1
+      [[ ${AUDIO_CONTROL_BLUETOOTH_PREFERENCE_NO_EFFECT_VALUE:-} == "$requested" ]] && exit 0
+      stored=$requested
+      [[ ${AUDIO_CONTROL_BLUETOOTH_PREFERENCE_WRONG_VALUE:-} == "$requested" ]] && stored=invalid
+      printf '%s\n' "$stored" >"$state_file"
+      [[ ${AUDIO_CONTROL_BLUETOOTH_PREFERENCE_FAIL_AFTER_EFFECT:-0} != 1 ]] || exit 1
       exit 0
       ;;
     "settings bluetooth.profile-preference")
       value=quality
       [[ -s $state_file ]] && value=$(<"$state_file")
       printf 'Value: %s\n' "$value"
+      [[ ${AUDIO_CONTROL_WPCTL_DUPLICATE_VALUE:-0} != 1 ]] ||
+        printf 'Value: %s\n' "$value"
       exit 0
       ;;
   esac


### PR DESCRIPTION
## Summary

- make device, profile, route, port, policy, and scene mutations transactional and identity-safe
- harden persistence, diagnostics, helper isolation, and stale QML object handling
- add adversarial regression coverage and bump the plugin version to 0.7.1

## Validation

- ./test/all (24 groups passed)
- omarchy-plugin-validate .
- qmllint ./*.qml
- bash -n scripts/* scripts/.audio-common test/all test/mocks/*
- node --check Model.js
- git diff --check