### PR TITLE
feat: add resilient multi-output groups

### DIFF
--- a/AdvancedAudio.qml
+++ b/AdvancedAudio.qml
@@ -26,7 +26,31 @@ Item {
     scriptPath: runtime.script("audio-app-rules")
     onRulesChanged: root.clampCursor()
     onWriteFinished: function(success) {
-      if (!success) root.showSceneStatus(rulesStore.error, true)
+      if (!success) root.showRoutingStatus(rulesStore.error, true)
+    }
+  }
+  AudioOutputGroupsController {
+    id: outputGroupController
+    scriptPath: runtime.script("audio-output-groups")
+    groups: rulesStore.outputGroups
+    autoReconcile: window.visible
+    onOperationFinished: function(action, _groupId, success, exitCode) {
+      if (success) {
+        if (action === "create") {
+          root.newOutputGroupName = ""
+          root.newOutputGroupMembers = []
+          root.showOutputGroupStatus("Created output group", false)
+        } else if (action === "update") {
+          root.showOutputGroupStatus("Updated output group", false)
+        } else if (action === "delete") {
+          root.showOutputGroupStatus("Deleted output group", false)
+        }
+      } else if (action !== "reconcile") {
+        root.showOutputGroupStatus(exitCode === 3
+          ? "Switch away from the group and make sure every selected output is connected"
+          : outputGroupController.error, true)
+      }
+      root.clampCursor()
     }
   }
   AudioDiagnosticsController {
@@ -39,8 +63,10 @@ Item {
   }
 
   property var shell: null
+  property var manifest: null
   property bool closingFromHost: false
   property bool openRequested: false
+  property bool quickPanelProxyOpen: false
   property bool windowRuleReady: false
   property bool recoveryConfirmOpen: false
   readonly property bool opened: window.visible
@@ -63,8 +89,10 @@ Item {
   property bool sceneReloadPending: false
   readonly property var audioRules: rulesStore.rules
   property string newRuleApp: ""
+  property string newOutputGroupName: ""
+  property var newOutputGroupMembers: []
   property string aliasEditingDevice: ""
-  readonly property bool routingMutation: rulesStore.busy
+  readonly property bool routingMutation: rulesStore.busy || outputGroupController.busy
   readonly property bool diagnosticsMutationBusy: diagnostics.speakerTesting
     || diagnostics.recovering
   readonly property bool graphMutationBusy: sceneController.busy
@@ -75,6 +103,10 @@ Item {
   property var pendingSceneSave: null
   property string sceneStatus: ""
   property bool sceneStatusIsError: false
+  property string outputGroupStatus: ""
+  property bool outputGroupStatusIsError: false
+  property string routingStatus: ""
+  property bool routingStatusIsError: false
   property string profileLoadError: ""
   property string portLoadError: ""
   property string profileSetError: ""
@@ -91,9 +123,14 @@ Item {
   readonly property string pendingPolicyKey: policy.pendingKey
   readonly property string policyError: policy.error
   readonly property string error: {
-    var errors = [profileSetError, portSetError, bluetoothAutoswitchError,
-      bluetoothPreferenceError, settingsSaveError, settingsFormatError,
-      policyError, profileLoadError, portLoadError]
+    var errors = activeTab === 0
+      ? [profileSetError, portSetError, settingsSaveError, settingsFormatError,
+        profileLoadError, portLoadError]
+      : (activeTab === 1
+        ? [profileSetError, bluetoothAutoswitchError, bluetoothPreferenceError,
+          profileLoadError]
+        : (activeTab === 2
+          ? [settingsSaveError, settingsFormatError, policyError] : []))
     for (var i = 0; i < errors.length; i++) if (errors[i] !== "") return errors[i]
     return ""
   }
@@ -149,7 +186,8 @@ Item {
     }
   }
   readonly property var rawInputDevice: Pipewire.defaultAudioSource
-  readonly property var inputDevice: usableInputNode(rawInputDevice) ? rawInputDevice : null
+  readonly property var inputDevice: usableInputNode(rawInputDevice)
+    && mutableAudioNode(rawInputDevice) ? rawInputDevice : null
   readonly property bool inputDeviceMuted: audioNodeMuted(inputDevice, true)
   readonly property bool outputBalanceAvailable: balanceAvailable(outputDevice)
   readonly property bool inputBalanceAvailable: balanceAvailable(inputDevice)
@@ -168,10 +206,16 @@ Item {
     + availablePolicyExperimental.length
   readonly property int captureNotificationIndex: wireplumberPolicyItemCount
   readonly property int policyItemCount: wireplumberPolicyItemCount + 1
+  readonly property int outputGroupCreateIndex: 0
+  readonly property int outputGroupStartIndex: 1
+  readonly property int newRuleAppIndex: outputGroupStartIndex + audioRules.outputGroups.length
+  readonly property int newRuleDeviceIndex: newRuleAppIndex + 1
+  readonly property int routingRuleStartIndex: newRuleDeviceIndex + 1
+  readonly property int managedDeviceStartIndex: routingRuleStartIndex + audioRules.appRules.length
   readonly property int itemCount: activeTab === 5
     ? diagnosticsView.itemCount
     : (activeTab === 4
-      ? 2 + audioRules.appRules.length + managedDevices.length
+      ? managedDeviceStartIndex + managedDevices.length
       : (activeTab === 3
         ? 1 + audioScenes.length
         : (activeTab === 0
@@ -190,18 +234,31 @@ Item {
   }
   onOutputDeviceChanged: enforceOutputVolumeLimit()
 
+  function pluginId() {
+    var id = manifest && typeof manifest.id === "string" ? String(manifest.id) : ""
+    return id !== "" ? id : "ssupt.audio-control"
+  }
+
+  function toggleQuickPanel() {
+    var hostBar = shell ? shell.bar : null
+    if (!hostBar || typeof hostBar.isBarWidgetOpen !== "function"
+        || typeof hostBar.summonBarWidget !== "function"
+        || typeof hostBar.hideBarWidget !== "function") return false
+
+    var id = pluginId()
+    var wasOpen = hostBar.isBarWidgetOpen(id) === true
+    var changed = wasOpen ? hostBar.hideBarWidget(id) : hostBar.summonBarWidget(id)
+    if (changed !== true) return false
+    quickPanelProxyOpen = !wasOpen
+    return true
+  }
+
   function open(payloadJson) {
-    var payload = ({})
-    var rawPayload = typeof payloadJson === "string" ? payloadJson : ""
-    if (rawPayload.length <= 4096) {
-      try { payload = JSON.parse(rawPayload || "{}") } catch (e) { payload = ({}) }
-    }
-    if (!payload || typeof payload !== "object" || Array.isArray(payload)) payload = ({})
-    activeTab = payload.tab === "bluetooth" ? 1
-      : payload.tab === "policy" ? 2
-      : payload.tab === "scenes" ? 3
-      : payload.tab === "routing" ? 4
-      : payload.tab === "diagnostics" ? 5 : 0
+    var request = Model.parseAudioOpenRequest(payloadJson)
+    if (!request.advanced && toggleQuickPanel()) return
+
+    quickPanelProxyOpen = false
+    activeTab = request.tab
     openRequested = true
     closingFromHost = false
     cursorActive = false
@@ -225,6 +282,9 @@ Item {
     bluetoothAutoswitchError = ""
     bluetoothPreferenceError = ""
     settingsSaveError = ""
+    sceneStatus = ""
+    outputGroupStatus = ""
+    routingStatus = ""
     policy.clearError()
   }
 
@@ -240,6 +300,12 @@ Item {
   }
 
   function close() {
+    if (quickPanelProxyOpen) {
+      var hostBar = shell ? shell.bar : null
+      if (hostBar && typeof hostBar.hideBarWidget === "function")
+        hostBar.hideBarWidget(pluginId())
+      quickPanelProxyOpen = false
+    }
     openRequested = false
     closingFromHost = true
     closeProfileMenus()
@@ -262,6 +328,7 @@ Item {
 
   function refresh() {
     if (!window.visible) return
+    outputGroupController.scheduleReconcile()
     if (!profilesProc.running && !profileSetProc.running) profilesProc.running = true
     if (!bluetoothAutoswitchProc.running) {
       autoswitchReconcileTimer.stop()
@@ -319,7 +386,8 @@ Item {
 
   function usableInputNode(node) {
     try {
-      return !!node && node.isStream !== true && node.isSink !== true
+      return !!node && node.ready === true && !!node.audio
+        && node.isStream !== true && node.isSink !== true
         && Model.nodeName(node) !== "" && Model.isAudioSource(node)
         && !Model.isMonitorSource(node)
         && !Model.isInternalAudioNode(Model.nodeName(node), Model.nodeProps(node))
@@ -331,6 +399,19 @@ Item {
   function audioNodeMuted(node, fallback) {
     if (!mutableAudioNode(node)) return fallback === true
     try { return node.audio.muted === true } catch (_error) { return fallback === true }
+  }
+
+  function setOutputGroupMemberVolume(node, value) {
+    if (audioMutationBusy || routingMutation || !mutableAudioNode(node)) return false
+    var requested = Number(value)
+    var maximum = outputOverdrive ? 1.5 : 1.0
+    if (!isFinite(requested)) return false
+    try {
+      node.audio.volume = Math.max(0, Math.min(maximum, requested))
+      return true
+    } catch (_error) {
+      return false
+    }
   }
 
   function enforceOutputVolumeLimit() {
@@ -427,6 +508,9 @@ Item {
   }
 
   function nodeLabel(node) {
+    var name = Model.nodeName(node)
+    var alias = name !== "" ? rulesStore.aliasFor(name) : ""
+    if (alias !== "") return alias
     return Model.nodeLabel(node)
   }
 
@@ -500,7 +584,9 @@ Item {
     if (bluetoothPreferenceRow) bluetoothPreferenceRow.closePreferenceMenu()
     if (newAppDropdown) newAppDropdown.close()
     if (newDeviceDropdown) newDeviceDropdown.close()
-    var repeaters = [deviceProfileRepeater, bluetoothProfileRepeater, audioPortRepeater, routingRuleRepeater]
+    if (outputGroupCreateRow) outputGroupCreateRow.closeMemberMenu()
+    var repeaters = [deviceProfileRepeater, bluetoothProfileRepeater,
+      audioPortRepeater, outputGroupRepeater, routingRuleRepeater]
     for (var r = 0; r < repeaters.length; r++) {
       var repeater = repeaters[r]
       if (!repeater) continue
@@ -510,6 +596,7 @@ Item {
         if (typeof row.closeProfileMenu === "function") row.closeProfileMenu()
         if (typeof row.closePortMenu === "function") row.closePortMenu()
         if (typeof row.closeTargetMenu === "function") row.closeTargetMenu()
+        if (typeof row.closeMemberMenu === "function") row.closeMemberMenu()
       }
     }
   }
@@ -548,13 +635,17 @@ Item {
       return
     }
     if (activeTab === 4) {
-      if (selectedIndex === 0) newRuleAppRow.toggleAppMenu()
-      else if (selectedIndex === 1) newRuleDeviceRow.toggleDeviceMenu()
-      else if (selectedIndex < 2 + audioRules.appRules.length) {
-        var ruleRow = routingRuleRepeater.itemAt(selectedIndex - 2)
+      if (selectedIndex === outputGroupCreateIndex) outputGroupCreateRow.activate()
+      else if (selectedIndex < newRuleAppIndex) {
+        var groupRow = outputGroupRepeater.itemAt(selectedIndex - outputGroupStartIndex)
+        if (groupRow) groupRow.toggleMemberMenu()
+      } else if (selectedIndex === newRuleAppIndex) newRuleAppRow.toggleAppMenu()
+      else if (selectedIndex === newRuleDeviceIndex) newRuleDeviceRow.toggleDeviceMenu()
+      else if (selectedIndex < managedDeviceStartIndex) {
+        var ruleRow = routingRuleRepeater.itemAt(selectedIndex - routingRuleStartIndex)
         if (ruleRow) ruleRow.toggleTargetMenu()
       } else {
-        var deviceIndex = selectedIndex - 2 - audioRules.appRules.length
+        var deviceIndex = selectedIndex - managedDeviceStartIndex
         if (deviceIndex >= 0 && deviceIndex < managedDevices.length) {
           var managed = managedDevices[deviceIndex]
           if (managed) toggleDeviceFavorite(managed.name, managed.favorite)
@@ -803,6 +894,7 @@ Item {
   }
 
   function runRuleWrite(args) {
+    routingStatus = ""
     return rulesStore.write(args)
   }
 
@@ -870,6 +962,30 @@ Item {
     sceneStatusTimer.restart()
   }
 
+  Timer {
+    id: outputGroupStatusTimer
+    interval: 6000
+    onTriggered: root.outputGroupStatus = ""
+  }
+
+  function showOutputGroupStatus(text, isError) {
+    outputGroupStatus = text
+    outputGroupStatusIsError = isError
+    outputGroupStatusTimer.restart()
+  }
+
+  Timer {
+    id: routingStatusTimer
+    interval: 6000
+    onTriggered: root.routingStatus = ""
+  }
+
+  function showRoutingStatus(text, isError) {
+    routingStatus = text
+    routingStatusIsError = isError
+    routingStatusTimer.restart()
+  }
+
   function nextSceneName() {
     var used = []
     for (var i = 0; i < audioScenes.length; i++) used.push(audioScenes[i].name)
@@ -920,8 +1036,39 @@ Item {
     return rulesStore.optionsFor("recording", storedTarget)
   }
 
+  readonly property var outputGroups: rulesStore.outputGroups
+  readonly property var outputGroupMemberOptions: rulesStore.outputGroupMemberOptions
   readonly property var managedDevices: rulesStore.managedDevices
   readonly property var newRuleAppOptions: rulesStore.availableApplicationLabels
+
+  function createOutputGroup() {
+    var name = String(newOutputGroupName || "").trim()
+    var members = Model.listSnapshot(newOutputGroupMembers)
+    if (name === "" || members.length < 2 || routingMutation) return
+    outputGroupStatus = ""
+    if (!outputGroupController.createGroup(name, members))
+      showOutputGroupStatus("Another routing change is still finishing", true)
+  }
+
+  function updateOutputGroup(group, members) {
+    if (!group || routingMutation) return
+    var next = Model.listSnapshot(members)
+    if (next.length < 2) {
+      showOutputGroupStatus("An output group needs at least two devices", true)
+      return
+    }
+    outputGroupStatus = ""
+    if (!outputGroupController.updateGroup(group.id, group.name, next))
+      showOutputGroupStatus("Another routing change is still finishing", true)
+  }
+
+  function deleteOutputGroup(group) {
+    if (!group || routingMutation) return
+    outputGroupStatus = ""
+    if (!outputGroupController.deleteGroup(group.id))
+      showOutputGroupStatus("Another routing change is still finishing", true)
+  }
+
   onManagedDevicesChanged: {
     if (aliasEditingDevice === "") return
     for (var i = 0; i < managedDevices.length; i++)
@@ -943,7 +1090,7 @@ Item {
   function commitAliasEdit(name, text) {
     var trimmed = String(text || "").trim()
     if (runRuleWrite(["set-alias", name, trimmed])) cancelAliasEdit()
-    else showSceneStatus("Another routing change is still finishing", true)
+    else showRoutingStatus("Another routing change is still finishing", true)
   }
 
   function toggleDeviceFavorite(name, currentFavorite) {
@@ -1924,6 +2071,107 @@ Item {
                 width: parent.width
                 spacing: Style.space(8)
 
+                PanelSectionHeader {
+                  text: "OUTPUT GROUPS"
+                  foreground: root.foreground
+                  fontFamily: root.fontFamily
+                }
+
+                Text {
+                  width: parent.width
+                  text: "Play through two or more connected outputs at once. Groups appear as one destination everywhere else in the mixer. Devices with separate clocks—especially Bluetooth—may drift slightly."
+                  color: Qt.darker(root.foreground, 1.35)
+                  font.family: root.fontFamily
+                  font.pixelSize: Style.font.bodySmall
+                  wrapMode: Text.WordWrap
+                }
+
+                AudioOutputGroupCreateRow {
+                  id: outputGroupCreateRow
+                  width: parent.width
+                  groupName: root.newOutputGroupName
+                  selectedMembers: root.newOutputGroupMembers
+                  options: root.outputGroupMemberOptions
+                  busy: root.routingMutation
+                  hasCursor: root.cursorActive && root.activeTab === 4
+                    && root.selectedIndex === root.outputGroupCreateIndex
+                  onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(outputGroupCreateRow)
+                  foreground: root.foreground
+                  fill: root.hoverFill
+                  fontFamily: root.fontFamily
+                  onNameEdited: function(value) { root.newOutputGroupName = value }
+                  onMembersEdited: function(values) { root.newOutputGroupMembers = values }
+                  onCreateRequested: root.createOutputGroup()
+                  onCursorRequested: root.setCursor(root.outputGroupCreateIndex)
+                  onMenuToggled: function(open) {
+                    root.updateProfileMenu(open)
+                    if (!open) Qt.callLater(function() { keyCatcher.forceActiveFocus() })
+                  }
+                }
+
+                Repeater {
+                  id: outputGroupRepeater
+                  model: root.outputGroups
+
+                  AudioOutputGroupRow {
+                    id: outputGroupDelegate
+                    required property var modelData
+                    required property int index
+                    width: parent.width
+                    groupName: modelData ? String(modelData.name || "") : ""
+                    groupId: modelData ? String(modelData.id || "") : ""
+                    members: modelData && modelData.members ? modelData.members : []
+                    memberLevels: rulesStore.outputGroupMemberLevels(modelData)
+                    options: rulesStore.memberOptionsFor(modelData)
+                    available: rulesStore.outputGroupAvailable(modelData)
+                    statusText: rulesStore.outputGroupStatusText(modelData)
+                    busy: root.routingMutation
+                    memberVolumeBusy: root.audioMutationBusy || root.routingMutation
+                    volumeMaximum: root.outputOverdrive ? 1.5 : 1.0
+                    hasCursor: root.cursorActive && root.activeTab === 4
+                      && root.selectedIndex === root.outputGroupStartIndex
+                        + outputGroupDelegate.index
+                    onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(outputGroupDelegate)
+                    foreground: root.foreground
+                    fill: root.hoverFill
+                    urgent: root.urgent
+                    fontFamily: root.fontFamily
+                    onMembersChosen: function(values) {
+                      root.updateOutputGroup(outputGroupDelegate.modelData, values)
+                    }
+                    onMemberVolumeMoved: function(node, value) {
+                      root.setOutputGroupMemberVolume(node, value)
+                    }
+                    onDeleted: root.deleteOutputGroup(outputGroupDelegate.modelData)
+                    onCursorRequested: root.setCursor(
+                      root.outputGroupStartIndex + outputGroupDelegate.index)
+                    onMenuToggled: function(open) {
+                      root.updateProfileMenu(open)
+                      if (!open) Qt.callLater(function() { keyCatcher.forceActiveFocus() })
+                    }
+                  }
+                }
+
+                Text {
+                  visible: root.outputGroupStatus !== ""
+                    || outputGroupController.error !== ""
+                  width: parent.width
+                  text: root.outputGroupStatus !== "" ? root.outputGroupStatus
+                    : outputGroupController.error
+                  color: root.outputGroupStatus !== ""
+                    ? (root.outputGroupStatusIsError ? root.urgent : root.foreground)
+                    : root.urgent
+                  font.family: root.fontFamily
+                  font.pixelSize: Style.font.bodySmall
+                  wrapMode: Text.WordWrap
+                }
+
+                PanelSectionHeader {
+                  text: "APPLICATION ROUTING"
+                  foreground: root.foreground
+                  fontFamily: root.fontFamily
+                }
+
                 Text {
                   width: parent.width
                   text: "Pin an application to a device and it is routed there every time it starts, whenever the device is present. Rules keep working while the application or device is offline."
@@ -1937,7 +2185,8 @@ Item {
                   id: newRuleAppRow
                   width: parent.width
                   implicitHeight: Math.max(newAppLabels.implicitHeight, newAppDropdown.implicitHeight) + Style.space(18)
-                  hasCursor: root.cursorActive && root.activeTab === 4 && root.selectedIndex === 0
+                  hasCursor: root.cursorActive && root.activeTab === 4
+                    && root.selectedIndex === root.newRuleAppIndex
                   onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(newRuleAppRow)
                   foreground: root.foreground
                   fill: root.hoverFill
@@ -1999,7 +2248,7 @@ Item {
                       fontFamily: root.fontFamily
                       anchors.verticalCenter: parent.verticalCenter
 
-                      onHovered: function(on) { if (on) root.setCursor(0) }
+                      onHovered: function(on) { if (on) root.setCursor(root.newRuleAppIndex) }
                       onChanged: function(value) { root.newRuleApp = value }
                       onPopupOpenChanged: {
                         root.updateProfileMenu(popupOpen)
@@ -2012,7 +2261,7 @@ Item {
                     anchors.fill: parent
                     acceptedButtons: Qt.NoButton
                     hoverEnabled: true
-                    onContainsMouseChanged: if (containsMouse) root.setCursor(0)
+                    onContainsMouseChanged: if (containsMouse) root.setCursor(root.newRuleAppIndex)
                   }
                 }
 
@@ -2020,7 +2269,8 @@ Item {
                   id: newRuleDeviceRow
                   width: parent.width
                   implicitHeight: Math.max(newDeviceLabels.implicitHeight, newDeviceDropdown.implicitHeight) + Style.space(18)
-                  hasCursor: root.cursorActive && root.activeTab === 4 && root.selectedIndex === 1
+                  hasCursor: root.cursorActive && root.activeTab === 4
+                    && root.selectedIndex === root.newRuleDeviceIndex
                   onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(newRuleDeviceRow)
                   foreground: root.foreground
                   fill: root.hoverFill
@@ -2077,13 +2327,13 @@ Item {
                       fontFamily: root.fontFamily
                       anchors.verticalCenter: parent.verticalCenter
 
-                      onHovered: function(on) { if (on) root.setCursor(1) }
+                      onHovered: function(on) { if (on) root.setCursor(root.newRuleDeviceIndex) }
                       onChanged: function(value) {
                         if (value === "") return
                         var direction = rulesStore.directionForTarget(value)
                         if (direction === "" || !root.runRuleWrite(
                             ["set-app", root.newRuleApp, direction, value])) return
-                        root.showSceneStatus("Pinned '" + root.newRuleApp + "'", false)
+                        root.showRoutingStatus("Pinned '" + root.newRuleApp + "'", false)
                         root.newRuleApp = ""
                       }
                       onPopupOpenChanged: {
@@ -2097,7 +2347,7 @@ Item {
                     anchors.fill: parent
                     acceptedButtons: Qt.NoButton
                     hoverEnabled: true
-                    onContainsMouseChanged: if (containsMouse) root.setCursor(1)
+                    onContainsMouseChanged: if (containsMouse) root.setCursor(root.newRuleDeviceIndex)
                   }
                 }
 
@@ -2120,13 +2370,15 @@ Item {
                       : root.ruleTargetOptions(routingRuleDelegate.currentValue)
                     menuEnabled: !root.routingMutation
                     hasCursor: root.cursorActive && root.activeTab === 4
-                      && root.selectedIndex === 2 + routingRuleDelegate.index
+                      && root.selectedIndex === root.routingRuleStartIndex
+                        + routingRuleDelegate.index
                     onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(routingRuleDelegate)
                     foreground: root.foreground
                     fill: root.hoverFill
                     urgent: root.urgent
                     fontFamily: root.fontFamily
-                    onCursorRequested: root.setCursor(2 + routingRuleDelegate.index)
+                    onCursorRequested: root.setCursor(
+                      root.routingRuleStartIndex + routingRuleDelegate.index)
                     onMenuToggled: function(open) {
                       root.updateProfileMenu(open)
                       if (!open) Qt.callLater(function() { keyCatcher.forceActiveFocus() })
@@ -2178,14 +2430,15 @@ Item {
                     }
                     busy: root.routingMutation
                     hasCursor: root.cursorActive && root.activeTab === 4
-                      && root.selectedIndex === 2 + root.audioRules.appRules.length + managedDeviceDelegate.index
+                      && root.selectedIndex === root.managedDeviceStartIndex
+                        + managedDeviceDelegate.index
                     onHasCursorChanged: if (hasCursor) root.ensureCursorVisible(managedDeviceDelegate)
                     foreground: root.foreground
                     fill: root.hoverFill
                     urgent: root.urgent
                     fontFamily: root.fontFamily
                     onCursorRequested: root.setCursor(
-                      2 + root.audioRules.appRules.length + managedDeviceDelegate.index)
+                      root.managedDeviceStartIndex + managedDeviceDelegate.index)
                     onAliasEditStarted: root.aliasEditingDevice = managedDeviceDelegate.deviceName
                     onAliasCommitted: function(text) {
                       root.commitAliasEdit(managedDeviceDelegate.deviceName, text)
@@ -2199,10 +2452,12 @@ Item {
                 }
 
                 Text {
-                  visible: root.sceneStatus !== ""
+                  visible: root.routingStatus !== "" || rulesStore.error !== ""
                   width: parent.width
-                  text: root.sceneStatus
-                  color: root.sceneStatusIsError ? root.urgent : root.foreground
+                  text: root.routingStatus !== "" ? root.routingStatus : rulesStore.error
+                  color: root.routingStatus !== ""
+                    ? (root.routingStatusIsError ? root.urgent : root.foreground)
+                    : root.urgent
                   font.family: root.fontFamily
                   font.pixelSize: Style.font.bodySmall
                   wrapMode: Text.WordWrap

--- a/AudioOutputGroupCreateRow.qml
+++ b/AudioOutputGroupCreateRow.qml
@@ -1,0 +1,134 @@
+import QtQuick
+import QtQuick.Controls
+import qs.Ui
+import qs.Commons
+
+CursorSurface {
+  id: root
+
+  required property string groupName
+  required property var selectedMembers
+  required property var options
+  required property bool busy
+  property string fontFamily: Style.font.family
+
+  signal nameEdited(string value)
+  signal membersEdited(var values)
+  signal createRequested()
+  signal cursorRequested()
+  signal menuToggled(bool open)
+
+  property bool memberMenuReportedOpen: false
+
+  readonly property bool ready: groupName.trim() !== ""
+    && selectedMembers && selectedMembers.length >= 2 && !busy
+
+  width: parent ? parent.width : 0
+  implicitHeight: Math.max(groupNameField.implicitHeight,
+    Math.max(memberSelect.implicitHeight, createButton.height)) + Style.space(18)
+  bordered: true
+
+  function activate() {
+    if (root.groupName.trim() === "") {
+      groupNameField.forceActiveFocus()
+      groupNameField.selectAll()
+    } else if (!root.selectedMembers || root.selectedMembers.length < 2) {
+      memberSelect.toggle()
+    } else if (root.ready) {
+      root.createRequested()
+    }
+  }
+  function closeMemberMenu() { memberSelect.close() }
+  function reportMemberMenu(open) {
+    var next = open === true
+    if (memberMenuReportedOpen === next) return
+    memberMenuReportedOpen = next
+    menuToggled(next)
+  }
+  function syncMemberValues() {
+    memberSelect.values = root.selectedMembers || []
+  }
+  function focusName() {
+    groupNameField.forceActiveFocus()
+    groupNameField.selectAll()
+  }
+
+  onSelectedMembersChanged: syncMemberValues()
+  Component.onCompleted: syncMemberValues()
+  Component.onDestruction: reportMemberMenu(false)
+
+  Row {
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.verticalCenter: parent.verticalCenter
+    anchors.leftMargin: Style.space(12)
+    anchors.rightMargin: Style.space(12)
+    spacing: Style.space(10)
+
+    TextField {
+      id: groupNameField
+      width: Math.max(Style.space(150), parent.width * 0.28)
+      text: root.groupName
+      placeholderText: "Group name"
+      color: root.foreground
+      placeholderTextColor: Qt.darker(root.foreground, 1.8)
+      font.family: root.fontFamily
+      font.pixelSize: Style.font.body
+      selectByMouse: true
+      enabled: !root.busy
+      verticalAlignment: TextInput.AlignVCenter
+      background: Rectangle {
+        color: "transparent"
+        border.width: 1
+        border.color: groupNameField.activeFocus ? Color.accent
+          : Qt.darker(root.foreground, 1.8)
+        radius: Style.space(3)
+      }
+      onTextEdited: root.nameEdited(text)
+      onAccepted: {
+        if (root.ready) root.createRequested()
+        else memberSelect.toggle()
+      }
+      onActiveFocusChanged: if (activeFocus) root.cursorRequested()
+    }
+
+    MultiSelect {
+      id: memberSelect
+      width: parent.width - groupNameField.width - createButton.width - parent.spacing * 2
+      showLabel: false
+      values: []
+      options: root.options
+      triggerLabel: "Choose at least two outputs"
+      noSelectionText: "Choose at least two outputs"
+      emptyText: "Connect two outputs to create a group"
+      hasCursor: root.hasCursor
+      enabled: !root.busy && root.options.length >= 2
+      opacity: enabled ? 1 : 0.6
+      foreground: root.foreground
+      fontFamily: root.fontFamily
+
+      onHovered: function(on) { if (on) root.cursorRequested() }
+      onChanged: function(values) { root.membersEdited(values) }
+      onPopupOpenChanged: root.reportMemberMenu(popupOpen)
+    }
+
+    PanelActionButton {
+      id: createButton
+      iconText: "󰐕"
+      tooltipText: "Create output group"
+      foreground: root.foreground
+      fontFamily: root.fontFamily
+      bordered: true
+      enabled: root.ready
+      anchors.verticalCenter: parent.verticalCenter
+      onClicked: root.createRequested()
+    }
+  }
+
+  MouseArea {
+    anchors.fill: parent
+    acceptedButtons: Qt.NoButton
+    hoverEnabled: true
+    onContainsMouseChanged: if (containsMouse) root.cursorRequested()
+  }
+}

--- a/AudioOutputGroupMemberLevel.qml
+++ b/AudioOutputGroupMemberLevel.qml
@@ -1,0 +1,81 @@
+import QtQuick
+import qs.Ui
+import qs.Commons
+
+Item {
+  id: root
+
+  required property string label
+  required property var node
+  required property bool connected
+  property real maximum: 1
+  property bool busy: false
+  property color foreground: Color.foreground
+  property color urgent: Color.urgent
+  property string fontFamily: Style.font.family
+
+  signal volumeMoved(var node, real value)
+
+  readonly property real currentVolume: {
+    try {
+      if (!connected || !node || !node.audio) return 0
+      var value = Number(node.audio.volume)
+      return isFinite(value) ? value : 0
+    } catch (_error) {
+      return 0
+    }
+  }
+
+  implicitHeight: memberContent.implicitHeight
+
+  Column {
+    id: memberContent
+    width: parent.width
+    spacing: Style.space(4)
+
+    Item {
+      width: parent.width
+      height: Math.max(memberLabel.implicitHeight, memberValue.implicitHeight)
+
+      Text {
+        id: memberLabel
+        text: root.label
+        color: root.connected ? root.foreground : Qt.darker(root.foreground, 1.4)
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.bodySmall
+        font.bold: true
+        elide: Text.ElideRight
+        width: parent.width - memberValue.width - Style.space(12)
+        anchors.left: parent.left
+        anchors.verticalCenter: parent.verticalCenter
+      }
+
+      Text {
+        id: memberValue
+        text: root.connected
+          ? Math.round((memberSlider.dragging
+            ? memberSlider.liveValue : root.currentVolume) * 100) + "%"
+          : "OFFLINE"
+        color: root.connected ? Qt.darker(root.foreground, 1.35) : root.urgent
+        font.family: root.fontFamily
+        font.pixelSize: Style.font.caption
+        font.bold: true
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+      }
+    }
+
+    PanelSlider {
+      id: memberSlider
+      width: parent.width
+      minimum: 0
+      maximum: root.maximum
+      step: 0.05
+      tickCount: root.maximum > 1 ? 7 : 5
+      value: root.currentVolume
+      enabled: root.enabled && root.connected && !root.busy
+      opacity: enabled ? 1 : 0.45
+      onMoved: function(value) { root.volumeMoved(root.node, value) }
+    }
+  }
+}

--- a/AudioOutputGroupRow.qml
+++ b/AudioOutputGroupRow.qml
@@ -1,0 +1,189 @@
+import QtQuick
+import qs.Ui
+import qs.Commons
+
+CursorSurface {
+  id: root
+
+  required property string groupName
+  required property string groupId
+  required property var members
+  required property var memberLevels
+  required property var options
+  required property bool available
+  required property string statusText
+  required property bool busy
+  property bool memberVolumeBusy: false
+  property real volumeMaximum: 1
+  property color urgent: Color.urgent
+  property string fontFamily: Style.font.family
+
+  signal membersChosen(var values)
+  signal deleted()
+  signal cursorRequested()
+  signal menuToggled(bool open)
+  signal memberVolumeMoved(var node, real value)
+
+  property bool memberMenuReportedOpen: false
+
+  width: parent ? parent.width : 0
+  implicitHeight: groupContent.implicitHeight + Style.space(18)
+  bordered: true
+
+  function toggleMemberMenu() { if (memberSelect.enabled) memberSelect.toggle() }
+  function closeMemberMenu() { memberSelect.close() }
+  function reportMemberMenu(open) {
+    var next = open === true
+    if (memberMenuReportedOpen === next) return
+    memberMenuReportedOpen = next
+    menuToggled(next)
+  }
+  function syncMemberValues() { memberSelect.values = root.members || [] }
+
+  onMembersChanged: syncMemberValues()
+  Component.onCompleted: syncMemberValues()
+  Component.onDestruction: reportMemberMenu(false)
+
+  Column {
+    id: groupContent
+    anchors.left: parent.left
+    anchors.right: parent.right
+    anchors.verticalCenter: parent.verticalCenter
+    anchors.leftMargin: Style.space(12)
+    anchors.rightMargin: Style.space(12)
+    spacing: Style.space(9)
+
+    Row {
+      id: groupHeader
+      width: parent.width
+      spacing: Style.space(10)
+
+      Column {
+        id: groupLabels
+        width: Math.max(Style.space(150), parent.width * 0.28 - deleteButton.width)
+        anchors.verticalCenter: parent.verticalCenter
+        spacing: Style.space(3)
+
+        Text {
+          width: parent.width
+          text: root.groupName
+          color: root.foreground
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.body
+          font.bold: true
+          elide: Text.ElideRight
+        }
+
+        Text {
+          width: parent.width
+          text: root.statusText
+          color: root.available ? Qt.darker(root.foreground, 1.35) : root.urgent
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.caption
+          elide: Text.ElideRight
+        }
+      }
+
+      MultiSelect {
+        id: memberSelect
+        width: parent.width - groupLabels.width - deleteButton.width - parent.spacing * 2
+        showLabel: false
+        values: []
+        options: root.options
+        triggerLabel: "Choose outputs"
+        emptyText: "No physical outputs available"
+        hasCursor: root.hasCursor
+        enabled: !root.busy
+        opacity: enabled ? 1 : 0.6
+        foreground: root.foreground
+        fontFamily: root.fontFamily
+
+        onHovered: function(on) { if (on) root.cursorRequested() }
+        onChanged: function(values) {
+          root.membersChosen(values)
+          // The helper commits transactionally. Retain the stored selection
+          // until the watched rules file confirms the new member set.
+          Qt.callLater(function() { memberSelect.values = root.members })
+        }
+        onPopupOpenChanged: root.reportMemberMenu(popupOpen)
+      }
+
+      PanelActionButton {
+        id: deleteButton
+        iconText: "󰆴"
+        tooltipText: "Delete output group"
+        foreground: root.foreground
+        hoverColor: root.urgent
+        fontFamily: root.fontFamily
+        bordered: true
+        enabled: !root.busy
+        anchors.verticalCenter: parent.verticalCenter
+        onClicked: root.deleted()
+      }
+    }
+
+    Column {
+      width: parent.width
+      visible: root.memberLevels.length > 0
+      spacing: Style.space(6)
+
+      Rectangle {
+        width: parent.width
+        height: 1
+        color: Util.alpha(root.foreground, 0.14)
+      }
+
+      Item {
+        width: parent.width
+        height: Math.max(memberLevelsTitle.implicitHeight, sharedVolumeHint.implicitHeight)
+
+        Text {
+          id: memberLevelsTitle
+          text: "MEMBER LEVELS"
+          color: root.foreground
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.caption
+          font.bold: true
+          anchors.left: parent.left
+          anchors.verticalCenter: parent.verticalCenter
+        }
+
+        Text {
+          id: sharedVolumeHint
+          text: "SHARED DEVICE VOLUME"
+          color: Qt.darker(root.foreground, 1.4)
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.caption
+          anchors.right: parent.right
+          anchors.verticalCenter: parent.verticalCenter
+        }
+      }
+
+      Repeater {
+        model: root.memberLevels.length
+
+        AudioOutputGroupMemberLevel {
+          required property int index
+          readonly property var descriptor: root.memberLevels[index]
+          width: groupContent.width
+          label: descriptor ? String(descriptor.label || descriptor.name || "Output") : "Output"
+          node: descriptor ? descriptor.node : null
+          connected: !!descriptor && descriptor.connected === true
+          maximum: root.volumeMaximum
+          busy: root.memberVolumeBusy
+          foreground: root.foreground
+          urgent: root.urgent
+          fontFamily: root.fontFamily
+          onVolumeMoved: function(node, value) { root.memberVolumeMoved(node, value) }
+        }
+      }
+    }
+  }
+
+  MouseArea {
+    anchors.fill: parent
+    acceptedButtons: Qt.NoButton
+    hoverEnabled: true
+    onContainsMouseChanged: if (containsMouse) root.cursorRequested()
+  }
+}

--- a/AudioOutputGroupsController.qml
+++ b/AudioOutputGroupsController.qml
@@ -1,0 +1,104 @@
+import QtQuick
+import Quickshell.Io
+
+// Owns only the lifecycle edge around PipeWire's virtual combine sinks. Group
+// definitions remain in AudioRulesController, while every existing routing
+// path continues to treat a live group as an ordinary output node.
+Item {
+  id: root
+
+  required property string scriptPath
+  property var groups: []
+  property bool autoReconcile: false
+  property bool reconcilePending: false
+  property string error: ""
+  readonly property bool busy: groupProc.running
+  readonly property bool mutating: busy && groupProc.action !== "reconcile"
+
+  signal operationFinished(string action, string groupId, bool success, int exitCode)
+
+  function scheduleReconcile() {
+    if (!autoReconcile) return
+    if (busy) {
+      reconcilePending = true
+      return
+    }
+    reconcileDebounce.restart()
+  }
+
+  function run(action, args, groupId) {
+    if (busy) return false
+    reconcileDebounce.stop()
+    error = ""
+    groupProc.action = action
+    groupProc.groupId = String(groupId || "")
+    groupProc.command = ["/bin/bash", scriptPath, action].concat(args || [])
+    groupProc.running = true
+    return true
+  }
+
+  function createGroup(name, members) {
+    return run("create", [String(name || ""), JSON.stringify(members || [])], "")
+  }
+
+  function updateGroup(groupId, name, members) {
+    return run("update", [String(groupId || ""), String(name || ""),
+      JSON.stringify(members || [])], groupId)
+  }
+
+  function deleteGroup(groupId) {
+    return run("delete", [String(groupId || "")], groupId)
+  }
+
+  onGroupsChanged: scheduleReconcile()
+  onAutoReconcileChanged: if (autoReconcile) scheduleReconcile()
+  Component.onCompleted: scheduleReconcile()
+
+  Timer {
+    id: reconcileDebounce
+    interval: 350
+    onTriggered: {
+      if (!root.autoReconcile || root.busy) {
+        root.reconcilePending = root.autoReconcile
+        return
+      }
+      root.run("reconcile", [], "")
+    }
+  }
+
+  Timer {
+    interval: 30000
+    repeat: true
+    running: root.autoReconcile
+    onTriggered: root.scheduleReconcile()
+  }
+
+  Process {
+    id: groupProc
+    property string action: ""
+    property string groupId: ""
+
+    onExited: function(exitCode) {
+      var completedAction = action
+      var completedId = groupId
+      var success = exitCode === 0
+      if (success) root.error = ""
+      else if (completedAction === "reconcile")
+        root.error = "Some output groups could not be restored"
+      else if (exitCode === 3)
+        root.error = "That output group is unavailable or still in use"
+      else if (exitCode === 4)
+        root.error = "The output group changed and could not be fully restored"
+      else
+        root.error = "Could not update the output group"
+
+      action = ""
+      groupId = ""
+      root.operationFinished(completedAction, completedId, success, exitCode)
+      if (root.reconcilePending) {
+        root.reconcilePending = false
+        Qt.callLater(root.scheduleReconcile)
+      }
+    }
+  }
+}

--- a/AudioRulesController.qml
+++ b/AudioRulesController.qml
@@ -22,23 +22,188 @@ Item {
   readonly property var nodeGroups: Model.classifyAudioNodes(nodes)
   readonly property var sinks: nodeGroups.sinks
   readonly property var sources: nodeGroups.sources
+  readonly property var liveSources: buildLiveSources()
   readonly property var playbackStreams: nodeGroups.playbackStreams
   readonly property var recordingStreams: nodeGroups.recordingStreams
+  readonly property var outputGroups: rules && rules.outputGroups ? rules.outputGroups : []
+  readonly property var physicalSinks: buildPhysicalSinks()
   readonly property var availableApplicationLabels: Model.availableRuleApplicationLabels(
     playbackStreams, recordingStreams, rules.appRules)
   readonly property var targetOptions: buildTargetOptions()
+  readonly property var outputGroupMemberOptions: memberOptionsFor(null)
   readonly property var managedDevices: buildManagedDevices()
 
   signal writeFinished(bool success)
 
   function aliasFor(name) {
+    var group = groupForSink(name)
+    if (group) return String(group.name || "")
     return String(Model.mapValue(
       rules && rules.devices ? rules.devices.aliases : null,
       String(name || ""), "") || "")
   }
 
   function isHidden(name) {
+    if (groupForSink(name)) return false
     return rules.devices.hidden.indexOf(String(name || "")) !== -1
+  }
+
+  function groupForSink(name) {
+    return Model.outputGroupForSink(outputGroups, String(name || ""))
+  }
+
+  function groupById(id) {
+    var key = String(id || "")
+    for (var i = 0; i < outputGroups.length && i < 64; i++)
+      if (outputGroups[i] && outputGroups[i].id === key) return outputGroups[i]
+    return null
+  }
+
+  function buildPhysicalSinks() {
+    var values = []
+    for (var i = 0; i < sinks.length && i < 512; i++)
+      if (Model.isOutputGroupMemberSink(sinks[i])) values.push(sinks[i])
+    return values
+  }
+
+  function buildLiveSources() {
+    var values = []
+    for (var i = 0; i < sources.length && i < 512; i++) {
+      var node = sources[i]
+      try {
+        if (node && node.ready === true && !!node.audio
+            && Model.nodeName(node) !== "" && Model.isAudioSource(node)
+            && !Model.isMonitorSource(node)
+            && !Model.isInternalAudioNode(Model.nodeName(node), Model.nodeProps(node)))
+          values.push(node)
+      } catch (_error) { }
+    }
+    return values
+  }
+
+  function physicalSinkInfo(name) {
+    var target = String(name || "")
+    var info = { count: 0, node: null }
+    for (var i = 0; i < physicalSinks.length && i < 512; i++) {
+      if (Model.nodeName(physicalSinks[i]) !== target) continue
+      info.count++
+      info.node = info.count === 1 ? physicalSinks[i] : null
+    }
+    return info
+  }
+
+  function outputGroupMembers(group) {
+    return group && group.members ? Model.listSnapshot(group.members) : []
+  }
+
+  function outputGroupAvailable(group) {
+    var members = outputGroupMembers(group)
+    if (!group || members.length < 2) return false
+    var virtualInfo = liveTargetInfo(group.sink)
+    if (virtualInfo.count !== 1 || virtualInfo.direction !== "playback"
+        || !Model.isManagedOutputGroupSink(virtualInfo.node)) return false
+    for (var i = 0; i < members.length && i < 8; i++)
+      if (physicalSinkInfo(members[i]).count !== 1) return false
+    return true
+  }
+
+  function outputGroupFallbackNode(group) {
+    var names = []
+    for (var i = 0; i < physicalSinks.length && i < 512; i++)
+      names.push(Model.nodeName(physicalSinks[i]))
+    var fallbackName = Model.outputGroupFallbackMember(group, names)
+    if (fallbackName === "") return null
+    var info = physicalSinkInfo(fallbackName)
+    return info.count === 1 ? info.node : null
+  }
+
+  function outputGroupMemberLevels(group) {
+    var members = outputGroupMembers(group)
+    var levels = []
+    for (var i = 0; i < members.length && i < 8; i++) {
+      var member = members[i]
+      var info = physicalSinkInfo(member)
+      var connected = false
+      try {
+        connected = info.count === 1 && !!info.node
+          && info.node.ready === true && !!info.node.audio
+      } catch (_error) { }
+      levels.push({
+        name: member,
+        label: deviceLabel(member),
+        node: connected ? info.node : null,
+        connected: connected
+      })
+    }
+    return levels
+  }
+
+  function outputGroupMemberSummary(group) {
+    var members = outputGroupMembers(group)
+    if (!group) return ""
+    var labels = []
+    for (var i = 0; i < members.length && i < 8; i++) {
+      var member = members[i]
+      labels.push(deviceLabel(member))
+    }
+    return labels.join(" + ")
+  }
+
+  function outputGroupStatusText(group) {
+    var members = outputGroupMembers(group)
+    if (!group || members.length < 2)
+      return "Unavailable · choose at least two outputs"
+
+    var base = members.length + (members.length === 1 ? " output" : " outputs")
+    var disconnected = []
+    var ambiguous = []
+    for (var i = 0; i < members.length && i < 8; i++) {
+      var member = members[i]
+      var info = physicalSinkInfo(member)
+      if (info.count === 0) disconnected.push(deviceLabel(member))
+      else if (info.count > 1) ambiguous.push(deviceLabel(member))
+    }
+    if (disconnected.length > 0)
+      return base + " · " + disconnected.join(", ") + " disconnected"
+    if (ambiguous.length > 0)
+      return base + " · duplicate device name"
+
+    var virtualInfo = liveTargetInfo(group.sink)
+    if (virtualInfo.count !== 1 || virtualInfo.direction !== "playback")
+      return base + " · restoring…"
+    return base
+  }
+
+  function routingTargetLabel(name) {
+    var label = deviceLabel(name)
+    return groupForSink(name) ? label + " · Output group" : label
+  }
+
+  function memberOptionsFor(group) {
+    var options = []
+    var seen = []
+    var stored = outputGroupMembers(group)
+    for (var i = 0; i < physicalSinks.length && i < 512; i++) {
+      var name = Model.nodeName(physicalSinks[i])
+      if (name === "" || seen.indexOf(name) !== -1
+          || physicalSinkInfo(name).count !== 1) continue
+      seen.push(name)
+      options.push({
+        value: name,
+        label: deviceLabel(name),
+        description: "Connected output"
+      })
+    }
+    for (i = 0; i < stored.length && i < 8; i++) {
+      if (seen.indexOf(stored[i]) !== -1) continue
+      seen.push(stored[i])
+      options.push({
+        value: stored[i],
+        label: deviceLabel(stored[i]),
+        description: "Not connected"
+      })
+    }
+    return options
   }
 
   function liveTargetInfo(name) {
@@ -47,7 +212,7 @@ Item {
     if (target === "") return info
     var groups = [
       { nodes: sinks, direction: "playback" },
-      { nodes: sources, direction: "recording" }
+      { nodes: liveSources, direction: "recording" }
     ]
     for (var g = 0; g < groups.length; g++) {
       for (var i = 0; i < groups[g].nodes.length && i < 512; i++) {
@@ -86,12 +251,14 @@ Item {
   }
 
   function targetIsLive(name) {
+    var group = groupForSink(name)
+    if (Model.isOutputGroupSink(name)) return !!group && outputGroupAvailable(group)
     return liveTargetInfo(name).count === 1
   }
 
   function optionsFor(direction, storedTarget) {
     var recording = direction === "recording"
-    var devices = recording ? sources : sinks
+    var devices = recording ? liveSources : sinks
     var options = [{
       value: "",
       label: recording ? "Follow default input" : "Follow default output"
@@ -101,26 +268,27 @@ Item {
     for (var i = 0; i < devices.length && i < 512 && options.length < 513; i++) {
       var name = Model.nodeName(devices[i])
       if (name !== "" && name !== stored && seen.indexOf(name) === -1
-          && directionNameCount(devices, name) === 1 && !isHidden(name)) {
+          && directionNameCount(devices, name) === 1 && !isHidden(name)
+          && targetIsLive(name)) {
         seen.push(name)
-        options.push({ value: name, label: deviceLabel(name) })
+        options.push({ value: name, label: routingTargetLabel(name) })
       }
     }
-    if (stored !== "") options.push({ value: stored, label: deviceLabel(stored) })
+    if (stored !== "") options.push({ value: stored, label: routingTargetLabel(stored) })
     return options
   }
 
   function buildTargetOptions() {
     var options = []
     var seen = []
-    var groups = [sinks, sources]
+    var groups = [sinks, liveSources]
     for (var g = 0; g < groups.length; g++) {
       for (var i = 0; i < groups[g].length && i < 512 && options.length < 512; i++) {
         var name = Model.nodeName(groups[g][i])
         if (name === "" || seen.indexOf(name) !== -1 || isHidden(name)
-            || liveTargetInfo(name).count !== 1) continue
+            || liveTargetInfo(name).count !== 1 || !targetIsLive(name)) continue
         seen.push(name)
-        options.push({ value: name, label: deviceLabel(name) })
+        options.push({ value: name, label: routingTargetLabel(name) })
       }
     }
     return options
@@ -137,7 +305,8 @@ Item {
 
     function push(name, liveLabel) {
       var key = String(name || "")
-      if (key === "" || seen.indexOf(key) !== -1 || devices.length >= 512) return
+      if (key === "" || Model.isOutputGroupSink(key)
+          || seen.indexOf(key) !== -1 || devices.length >= 512) return
       seen.push(key)
       var alias = root.aliasFor(key)
       devices.push({
@@ -150,9 +319,10 @@ Item {
 
     var i
     for (i = 0; i < sinks.length; i++)
-      push(Model.nodeName(sinks[i]), Model.nodeLabel(sinks[i]))
-    for (i = 0; i < sources.length; i++)
-      push(Model.nodeName(sources[i]), Model.nodeLabel(sources[i]))
+      if (!Model.isOutputGroupSink(sinks[i]))
+        push(Model.nodeName(sinks[i]), Model.nodeLabel(sinks[i]))
+    for (i = 0; i < liveSources.length; i++)
+      push(Model.nodeName(liveSources[i]), Model.nodeLabel(liveSources[i]))
     for (i = 0; i < rules.devices.favorites.length; i++)
       push(rules.devices.favorites[i], rules.devices.favorites[i])
     for (i = 0; i < rules.devices.hidden.length; i++)

--- a/AudioSinkRow.qml
+++ b/AudioSinkRow.qml
@@ -15,6 +15,7 @@ CursorSurface {
   required property string preferredName
   required property bool defaultSetBusy
   required property string label
+  required property bool outputGroup
 
   signal claimed(string section, int index)
   signal activated(var node)
@@ -52,6 +53,18 @@ CursorSurface {
       font.bold: root.isActive
       elide: Text.ElideRight
       width: parent.width - Style.space(22) - Style.space(8)
+        - (groupTag.visible ? groupTag.implicitWidth + Style.space(8) : 0)
+      anchors.verticalCenter: parent.verticalCenter
+    }
+
+    Text {
+      id: groupTag
+      visible: root.outputGroup
+      text: "GROUP"
+      color: Color.accent
+      font.family: root.bar.fontFamily
+      font.pixelSize: Style.font.caption
+      font.bold: true
       anchors.verticalCenter: parent.verticalCenter
     }
   }

--- a/AudioStreamRow.qml
+++ b/AudioStreamRow.qml
@@ -50,7 +50,8 @@ CursorSurface {
   readonly property string routeOptionValue: routeMode !== "" && targetSerial !== ""
     ? routeMode + ":" + targetSerial : ""
   readonly property bool routeIsExplicit: routeMode === "override"
-  readonly property bool routeMenuAvailable: root.routeOptions.length > 1
+  readonly property bool routeMenuAvailable: Model.streamRouteDestinationCount(
+    root.routeOptions) > 1
     && root.targetSerial !== ""
 
   implicitHeight: streamColumn.implicitHeight + Style.spacing.xl

--- a/Model.js
+++ b/Model.js
@@ -53,6 +53,8 @@ function isInternalAudioNode(name, properties) {
     return value === "quickshell"
       || value.indexOf("omarchy_audio_test") === 0
       || value.indexOf("omarchy_speaker_tuning") === 0
+      || value.indexOf("omarchy_audio_group_") === 0
+      || value.indexOf("output.omarchy_audio_group_") === 0
       || String(props["application.id"] || "") === "ssupt.audio-control"
   } catch (e) {
     return false
@@ -81,6 +83,19 @@ function classifyAudioNodes(nodes) {
     try {
       var node = values[i]
       if (!node) continue
+      // PipeWire's Pulse compatibility layer exposes module-combine-sink as
+      // both a sink and a live stream. Quickshell therefore reports isStream
+      // on some versions even though this is the user-selectable endpoint.
+      // Recognize only our fully marked endpoint before classifying streams.
+      if (isOutputGroupSink(node) && node.isSink === true) {
+        // An unbound endpoint has no properties yet. Track the exact reserved
+        // name once so PwObjectTracker can bind it, then require all ownership
+        // markers as soon as it becomes ready.
+        if (result.sinks.length < 512
+            && (node.ready !== true || isManagedOutputGroupSink(node)))
+          result.sinks.push(node)
+        continue
+      }
       if (node.isStream) {
         if (isInternalAudioNode(nodeName(node), nodeProps(node))) continue
         if (isPlaybackStream(node) && result.playbackStreams.length < 512)
@@ -89,7 +104,8 @@ function classifyAudioNodes(nodes) {
           result.recordingStreams.push(node)
         continue
       }
-      if (node.isSink === true && result.sinks.length < 512) result.sinks.push(node)
+      if (node.isSink === true && result.sinks.length < 512
+          && !isInternalAudioNode(nodeName(node), nodeProps(node))) result.sinks.push(node)
       else if (result.sources.length < 512 && isAudioSource(node)
           && !isInternalAudioNode(nodeName(node), nodeProps(node)) && !isMonitorSource(node))
         result.sources.push(node)
@@ -184,6 +200,7 @@ function isAudioRulesDocument(raw) {
   var parsed = storedObjectDocument(raw, 1048576)
   if (!parsed || !hasVersionOneOrNone(parsed)) return false
   if (hasOwn(parsed, "appRules") && !Array.isArray(parsed.appRules)) return false
+  if (hasOwn(parsed, "outputGroups") && !Array.isArray(parsed.outputGroups)) return false
   if (hasOwn(parsed, "devices") && (!parsed.devices
       || typeof parsed.devices !== "object" || Array.isArray(parsed.devices))) return false
   return true
@@ -288,6 +305,40 @@ function parseAudioControlSettings(raw) {
     version: 1,
     outputOverdrive: parsed.outputOverdrive === true,
     captureNotifications: parsed.captureNotifications !== false
+  }
+}
+
+// Bare shell summons are the same gesture Omarchy uses for its built-in audio
+// pullout. Advanced views must opt in so a cloned replacement does not turn
+// SUPER+CTRL+A into a settings-window shortcut. A recognized tab also counts
+// as an explicit advanced request for companion plugins and old deep links.
+function parseAudioOpenRequest(raw) {
+  var result = { advanced: false, tab: 0 }
+  var text = boundedSerializedInput(raw, 4096)
+  if (text === null) return result
+
+  var parsed
+  try {
+    parsed = JSON.parse(text || "{}")
+  } catch (e) {
+    return result
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return result
+  if (parsed.view === "quick") return result
+
+  var tabs = {
+    devices: 0,
+    bluetooth: 1,
+    policy: 2,
+    scenes: 3,
+    routing: 4,
+    diagnostics: 5
+  }
+  var tabName = typeof parsed.tab === "string" ? parsed.tab : ""
+  var tab = mapValue(tabs, tabName, -1)
+  return {
+    advanced: parsed.view === "advanced" || parsed.advanced === true || tab >= 0,
+    tab: tab >= 0 ? tab : 0
   }
 }
 
@@ -469,6 +520,45 @@ function parseAudioRules(raw) {
     appRules.push({ app: app, direction: direction, target: target })
   }
 
+  var outputGroups = []
+  var rawGroups = Array.isArray(parsed.outputGroups) ? parsed.outputGroups : []
+  var seenGroupIds = {}
+  var seenGroupNames = {}
+  var seenGroupMembers = {}
+  for (i = 0; i < rawGroups.length && i < 64 && outputGroups.length < 16; i++) {
+    var group = rawGroups[i]
+    if (!group || typeof group !== "object" || Array.isArray(group)) continue
+    var groupId = typeof group.id === "string" && /^[0-9a-f]{16}$/.test(group.id)
+      ? group.id : ""
+    var groupName = sanitizeSceneString(group.name, "", 48)
+    var groupNameKey = normalizeAppKey(groupName)
+    var expectedSink = groupId === "" ? "" : "omarchy_audio_group_" + groupId
+    if (groupId === "" || groupName === "" || group.sink !== expectedSink
+        || hasOwn(seenGroupIds, groupId) || hasOwn(seenGroupNames, groupNameKey)) continue
+
+    var members = []
+    var rawMembers = Array.isArray(group.members) ? group.members : []
+    for (var m = 0; m < rawMembers.length && m < 32 && members.length < 8; m++) {
+      var member = sanitizeIdentifier(rawMembers[m], 160)
+      if (!/^[A-Za-z0-9_.:-]{1,160}$/.test(member)
+          || /^omarchy_audio_group_[0-9a-f]{16}$/.test(member)
+          || members.indexOf(member) !== -1) continue
+      members.push(member)
+    }
+    members.sort()
+    var memberKey = members.join("\u001f")
+    if (members.length < 2 || hasOwn(seenGroupMembers, memberKey)) continue
+    setMapValue(seenGroupIds, groupId, true)
+    setMapValue(seenGroupNames, groupNameKey, true)
+    setMapValue(seenGroupMembers, memberKey, true)
+    outputGroups.push({
+      id: groupId,
+      name: groupName,
+      sink: expectedSink,
+      members: members
+    })
+  }
+
   var devices = parsed.devices && typeof parsed.devices === "object" && !Array.isArray(parsed.devices)
     ? parsed.devices : {}
   var aliases = {}
@@ -496,11 +586,81 @@ function parseAudioRules(raw) {
   return {
     version: 1,
     appRules: appRules,
+    outputGroups: outputGroups,
     devices: {
       aliases: aliases,
       favorites: stringList(devices.favorites, 64),
       hidden: stringList(devices.hidden, 64)
     }
+  }
+}
+
+function outputGroupForSink(groups, sinkName) {
+  var values = Array.isArray(groups) ? groups : []
+  var name = sanitizeIdentifier(sinkName, 160)
+  if (name === "") return null
+  for (var i = 0; i < values.length && i < 64; i++) {
+    var group = values[i]
+    if (group && group.sink === name) return group
+  }
+  return null
+}
+
+// Pick a deterministic physical destination when a selected output group is
+// degraded. A duplicated live name is deliberately skipped: changing a
+// default by name in that state could address the wrong PipeWire object.
+function outputGroupFallbackMember(group, liveSinkNames) {
+  var members = group && Array.isArray(group.members) ? group.members : []
+  var live = Array.isArray(liveSinkNames) ? liveSinkNames : []
+  for (var i = 0; i < members.length && i < 8; i++) {
+    var member = sanitizeIdentifier(members[i], 160)
+    if (member === "" || isOutputGroupSink(member)) continue
+    var matches = 0
+    for (var j = 0; j < live.length && j < 512; j++) {
+      if (live[j] !== member) continue
+      matches++
+      if (matches > 1) break
+    }
+    if (matches === 1) return member
+  }
+  return ""
+}
+
+function isOutputGroupSink(value) {
+  var name = typeof value === "string" ? value : nodeName(value)
+  return /^omarchy_audio_group_[0-9a-f]{16}$/.test(String(name || ""))
+}
+
+function isManagedOutputGroupSink(node) {
+  try {
+    if (!node || node.isSink !== true || !isOutputGroupSink(node)) return false
+    var name = nodeName(node)
+    var groupId = name.substring("omarchy_audio_group_".length)
+    var properties = nodeProps(node)
+    var virtualValue = String(properties["node.virtual"] || "").toLowerCase()
+    return String(properties["application.id"] || "") === "ssupt.audio-control"
+      && String(properties["omarchy.audio.group.id"] || "") === groupId
+      && (virtualValue === "true" || virtualValue === "1")
+  } catch (e) {
+    return false
+  }
+}
+
+function isOutputGroupMemberSink(node) {
+  try {
+    if (!node || node.ready !== true || node.isSink !== true || node.isStream === true
+        || isOutputGroupSink(node)) return false
+    var properties = nodeProps(node)
+    var virtualValue = String(properties["node.virtual"] || "").toLowerCase()
+    var deviceClass = String(properties["device.class"] || "").toLowerCase()
+    var factoryName = String(properties["factory.name"] || "").toLowerCase()
+    return virtualValue !== "true" && virtualValue !== "1"
+      && deviceClass !== "filter" && deviceClass !== "monitor"
+      && factoryName.indexOf("null-audio-sink") === -1
+      && factoryName.indexOf("filter-chain") === -1
+      && String(properties["application.id"] || "") !== "ssupt.audio-control"
+  } catch (e) {
+    return false
   }
 }
 
@@ -1155,6 +1315,23 @@ function recordingInputOptions(inputs, defaultInput, labelFor) {
     "Follow default input", "Always use ", labelFor)
 }
 
+// "Follow default" and "Always use the current default" are different
+// policies, but they are not different destinations while only one endpoint
+// exists. Count target serials instead of menu rows so playback/recording rows
+// do not advertise a route picker that cannot move the stream anywhere.
+function streamRouteDestinationCount(options) {
+  var values = options && typeof options.length === "number" ? options : []
+  var seen = []
+  for (var i = 0; i < values.length && i < 513; i++) {
+    var option = values[i]
+    var raw = option && typeof option === "object" ? option.value : option
+    var parsed = parseStreamOutputOption(raw)
+    if (parsed.sink !== "" && seen.indexOf(parsed.sink) === -1)
+      seen.push(parsed.sink)
+  }
+  return seen.length
+}
+
 function parseStreamOutputOption(value) {
   var text = String(value || "")
   var separator = text.indexOf(":")
@@ -1567,12 +1744,18 @@ if (typeof module !== "undefined") {
     preferredAudioProfile: preferredAudioProfile,
     preferredAudioNodeName: preferredAudioNodeName,
     parseAudioControlSettings: parseAudioControlSettings,
+    parseAudioOpenRequest: parseAudioOpenRequest,
     parseAudioScenes: parseAudioScenes,
     sanitizeSceneEntry: sanitizeSceneEntry,
     sanitizeIdentifier: sanitizeIdentifier,
     normalizeAppKey: normalizeAppKey,
     sceneSummary: sceneSummary,
     parseAudioRules: parseAudioRules,
+    outputGroupForSink: outputGroupForSink,
+    outputGroupFallbackMember: outputGroupFallbackMember,
+    isOutputGroupSink: isOutputGroupSink,
+    isManagedOutputGroupSink: isManagedOutputGroupSink,
+    isOutputGroupMemberSink: isOutputGroupMemberSink,
     findAppRule: findAppRule,
     availableRuleApplicationLabels: availableRuleApplicationLabels,
     deviceSortComparator: deviceSortComparator,
@@ -1598,6 +1781,7 @@ if (typeof module !== "undefined") {
     uniqueNodeSerial: uniqueNodeSerial,
     streamOutputOptions: streamOutputOptions,
     recordingInputOptions: recordingInputOptions,
+    streamRouteDestinationCount: streamRouteDestinationCount,
     parseStreamOutputOption: parseStreamOutputOption,
     parseAudioStreamRoutes: parseAudioStreamRoutes,
     nodeLabel: nodeLabel,

--- a/Panel.qml
+++ b/Panel.qml
@@ -15,13 +15,14 @@ Panel {
 
   AudioRuntime { id: runtime }
 
+  readonly property var nodes: Pipewire.nodes ? Pipewire.nodes.values : []
   readonly property var sink: Pipewire.defaultAudioSink
   readonly property var rawSource: Pipewire.defaultAudioSource
   // PipeWire permits a sink monitor to be the default source. Treating that
   // loopback node as a microphone would expose the wrong mute/level controls
   // and produce misleading capture state in the panel.
-  readonly property var source: usableInputNode(rawSource) ? rawSource : null
-  readonly property var nodes: Pipewire.nodes ? Pipewire.nodes.values : []
+  readonly property var source: usableInputNode(rawSource) && mutableAudioNode(rawSource)
+    ? rawSource : null
   AudioRulesController {
     id: rulesStore
     nodes: root.nodes
@@ -30,12 +31,25 @@ Panel {
     onRulesChanged: {
       root.resetRoutingEnforcement()
       Qt.callLater(root.enforceRoutingRules)
+      Qt.callLater(root.scheduleOutputTopologyRecovery)
     }
     onWriteFinished: function(success) {
       if (success) return
       root.streamRouteSetError = "Application route changed, but its saved rule could not be updated"
       root.resetRoutingEnforcement()
       Qt.callLater(root.enforceRoutingRules)
+    }
+  }
+  AudioOutputGroupsController {
+    id: outputGroups
+    scriptPath: runtime.script("audio-output-groups")
+    groups: rulesStore.outputGroups
+    // A degraded group that is still the default must first move its
+    // following streams to a surviving member. Reconciliation can safely
+    // unload the virtual sink after that transactional default change ends.
+    autoReconcile: !defaultSinkProc.running
+    onOperationFinished: function(_action, _groupId, success, _exitCode) {
+      if (success) Qt.callLater(root.enforceRoutingRules)
     }
   }
   readonly property var mprisPlayers: Mpris.players ? Mpris.players.values : []
@@ -72,7 +86,8 @@ Panel {
 
   function usableInputNode(node) {
     try {
-      return !!node && node.isStream !== true && node.isSink !== true
+      return !!node && node.ready === true && !!node.audio
+        && node.isStream !== true && node.isSink !== true
         && Model.nodeName(node) !== "" && Model.isAudioSource(node)
         && !Model.isMonitorSource(node)
         && !Model.isInternalAudioNode(Model.nodeName(node), Model.nodeProps(node))
@@ -109,12 +124,23 @@ Panel {
   property var cachedAudioSinks: []
   property var cachedAudioSources: []
 
+  // A combine sink can survive temporarily while one of its physical members
+  // is disconnected. Keep the current default visible so the user can move
+  // away from it, but never offer a degraded or unowned group as a new route.
+  function outputSinkRouteAvailable(node) {
+    var name = Model.nodeName(node)
+    if (name === "" || !sinkAvailable(node)) return false
+    if (!Model.isOutputGroupSink(name)) return true
+    var group = rulesStore.groupForSink(name)
+    return !!group && rulesStore.outputGroupAvailable(group)
+  }
+
   readonly property var rawAudioSinks: {
     var list = []
     for (var i = 0; i < candidateSinks.length; i++) {
       var candidate = candidateSinks[i]
       var candidateName = Model.nodeName(candidate)
-      if (candidateName !== "" && sinkAvailable(candidate)
+      if (candidateName !== "" && outputSinkRouteAvailable(candidate)
           && !deviceHidden(candidateName)) list.push(candidate)
     }
     var sinkName = Model.nodeName(sink)
@@ -130,10 +156,12 @@ Panel {
     for (var i = 0; i < candidateSources.length; i++) {
       var candidate = candidateSources[i]
       var candidateName = Model.nodeName(candidate)
-      if (candidateName !== "" && !deviceHidden(candidateName)) list.push(candidate)
+      if (candidateName !== "" && usableInputNode(candidate)
+          && mutableAudioNode(candidate) && !deviceHidden(candidateName)) list.push(candidate)
     }
     var sourceName = Model.nodeName(source)
-    if (sourceName !== "" && !Model.isMonitorSource(source) && !deviceHidden(sourceName)
+    if (sourceName !== "" && usableInputNode(source) && mutableAudioNode(source)
+        && !deviceHidden(sourceName)
         && list.indexOf(source) < 0) list.unshift(source)
     var sorted = list.slice()
     sorted.sort(Model.deviceSortComparator(audioRules.devices.favorites))
@@ -142,18 +170,19 @@ Panel {
 
   readonly property var cachedVisibleAudioSinks: cachedAudioSinks.filter(function(node) {
     var name = Model.nodeName(node)
-    return name !== "" && sinkAvailable(node) && !deviceHidden(name)
+    return name !== "" && outputSinkRouteAvailable(node) && !deviceHidden(name)
   })
   readonly property var cachedVisibleAudioSources: cachedAudioSources.filter(function(node) {
     var name = Model.nodeName(node)
-    return name !== "" && !deviceHidden(name) && !Model.isMonitorSource(node)
+    return name !== "" && usableInputNode(node) && mutableAudioNode(node)
+      && !deviceHidden(name)
   })
   readonly property var audioSinks: rawAudioSinks.length > 0
     ? rawAudioSinks : cachedVisibleAudioSinks
   readonly property var audioSources: rawAudioSources.length > 0
     ? rawAudioSources : cachedVisibleAudioSources
   readonly property var routingSinks: candidateSinks.filter(function(node) {
-    return root.sinkAvailable(node)
+    return root.outputSinkRouteAvailable(node)
   })
   readonly property var routingSources: candidateSources
   readonly property string preferredOutputName: Model.preferredAudioNodeName(
@@ -231,6 +260,10 @@ Panel {
   // removal signal; rebuilding a Repeater from that signal path has crashed
   // in Quickshell's PipeWire service. The snapshot timer lets that mutation
   // settle first, and closed panels keep their repeaters detached entirely.
+  // The Repeaters below use only the snapshot lengths as their models and
+  // resolve each node by index. Passing native PwNode objects as JavaScript
+  // list rows makes Qt synthesize delegate properties from an object that may
+  // disappear mid-regeneration when hardware is unplugged.
   property var displayAudioSinks: []
   property var displayAudioSources: []
   property var displayAudioStreams: []
@@ -252,25 +285,38 @@ Panel {
     ? streamRouteSetError : streamRouteReadError
   property string defaultOutputError: ""
   property string defaultInputError: ""
+  // Suppress immediate retry loops after a transactional fallback failure.
+  // A new physical topology makes the attempt eligible again.
+  property string degradedGroupFallbackFrom: ""
+  property string degradedGroupFallbackBlockedSink: ""
+  property string degradedGroupFallbackBlockedTopology: ""
   readonly property string defaultDeviceError: defaultOutputError !== ""
     ? defaultOutputError : defaultInputError
   readonly property string panelError: defaultDeviceError !== ""
-    ? defaultDeviceError : (streamRouteError !== "" ? streamRouteError : rulesStore.error)
+    ? defaultDeviceError : (streamRouteError !== "" ? streamRouteError
+      : (outputGroups.error !== "" ? outputGroups.error : rulesStore.error))
   property var pendingStreamRoute: null
   readonly property bool routeMutationBusy: defaultSinkProc.running
     || defaultSourceProc.running || streamRouteSetProc.running
-    || pendingStreamRoute !== null || rulesStore.busy
+    || pendingStreamRoute !== null || rulesStore.busy || outputGroups.busy
   readonly property bool directDeviceMutationBusy: sceneController.busy
     || defaultSinkProc.running || defaultSourceProc.running
   onDirectDeviceMutationBusyChanged: if (!directDeviceMutationBusy)
     enforceOutputVolumeLimit()
   readonly property bool sceneMutationBusy: sceneController.busy || routeMutationBusy
     || streamOutputMenuOpen
+  readonly property bool outputTopologyRecoveryBusy: !rulesLoaded
+    || sceneController.busy || rulesStore.busy || outputGroups.busy
+    || defaultSinkProc.running || defaultSourceProc.running
+    || streamRouteSetProc.running || pendingStreamRoute !== null
 
   // The default is ordered first and named by behavior. Applications on that
   // option follow later default changes; all other choices are persistent.
+  readonly property var streamRouteSinks: displayAudioSinks.filter(function(node) {
+    return root.outputSinkRouteAvailable(node)
+  })
   readonly property var streamOutputOptions: Model.streamOutputOptions(
-    displayAudioSinks, sink, nodeLabel)
+    streamRouteSinks, sink, routeNodeLabel)
   readonly property var recordingInputOptions: Model.recordingInputOptions(
     displayAudioSources, source, nodeLabel)
 
@@ -312,10 +358,15 @@ Panel {
   // Re-resolve whenever the selected output changes; the timer below is only a
   // safety net for the tuning being applied or removed underneath us.
   onSinkChanged: {
+    if (Model.nodeName(sink) !== degradedGroupFallbackBlockedSink) {
+      degradedGroupFallbackBlockedSink = ""
+      degradedGroupFallbackBlockedTopology = ""
+    }
     // Never expose the physical endpoint resolved for the previous default
     // while a newer asynchronous lookup is still in flight.
     volumeSinkName = ""
     resolveVolumeSink()
+    Qt.callLater(scheduleOutputTopologyRecovery)
   }
 
   function resolveVolumeSink() {
@@ -455,7 +506,7 @@ Panel {
   function sectionVisible(section) {
     if (section === "scenes") return audioScenes.length > 0
     if (section === "output") return true
-    if (section === "input") return displayAudioSources.length > 0 || !!source
+    if (section === "input") return displayAudioSources.length > 0 || hasInput
     if (section === "streams") return displayAudioStreams.length > 0
     if (section === "recording") return displayRecordingStreams.length > 0
     return false
@@ -463,7 +514,7 @@ Panel {
 
   function sectionHasSlider(section) {
     if (section === "output") return true
-    if (section === "input") return !!source
+    if (section === "input") return hasInput
     return false  // stream rows carry their own sliders inline; not a section-level slider
   }
 
@@ -615,9 +666,11 @@ Panel {
     if (sceneMutationBusy) return
     controller.hide()
     if (bar && bar.shell && typeof bar.shell.summon === "function")
-      bar.shell.summon("ssupt.audio-control", "{}")
+      bar.shell.summon("ssupt.audio-control", '{"view":"advanced"}')
     else
-      Quickshell.execDetached(["omarchy-shell", "shell", "summon", "ssupt.audio-control", "{}"])
+      Quickshell.execDetached([
+        "omarchy-shell", "shell", "summon", "ssupt.audio-control", '{"view":"advanced"}'
+      ])
   }
 
   function updateStreamOutputMenu(open) {
@@ -648,6 +701,7 @@ Panel {
   // routed as soon as it appears, panel open or not.
   onAudioSinksChanged: {
     scheduleDisplayAudioModelRefresh()
+    scheduleOutputTopologyRecovery()
     Qt.callLater(enforceRoutingRules)
   }
   onAudioSourcesChanged: {
@@ -867,6 +921,7 @@ Panel {
 
   function enforceRoutingRules() {
     if (!rulesLoaded || rulesStore.busy || sceneController.busy
+        || outputGroups.busy
         || defaultSinkProc.running || defaultSourceProc.running || streamRouteSetProc.running
         || pendingStreamRoute || streamOutputMenuOpen) return
     pruneRoutingEnforcement()
@@ -1038,11 +1093,33 @@ Panel {
     if (hasInput) setAudioNodeMuted(source, mute)
   }
 
+  function scheduleOutputTopologyRecovery() {
+    outputTopologyRecoveryTimer.restart()
+  }
+
+  function recoverDegradedDefaultGroup() {
+    if (outputTopologyRecoveryBusy) return false
+    var currentSinkName = Model.nodeName(sink)
+    var group = rulesStore.groupForSink(currentSinkName)
+    if (!group || rulesStore.outputGroupAvailable(group)) return false
+
+    var topology = serialSignature(rulesStore.physicalSinks)
+    if (degradedGroupFallbackBlockedSink === group.sink
+        && degradedGroupFallbackBlockedTopology === topology) return false
+
+    var fallback = rulesStore.outputGroupFallbackNode(group)
+    if (!mutableAudioNode(fallback)) return false
+    degradedGroupFallbackFrom = group.sink
+    if (setDefaultSink(fallback)) return true
+    degradedGroupFallbackFrom = ""
+    return false
+  }
+
   function setDefaultSink(node) {
     var objectId = Model.nodeObjectId(node)
     var name = Model.nodeName(node)
     if (!mutableAudioNode(node) || objectId === "" || name === ""
-        || sceneController.busy || routeMutationBusy) return
+        || sceneController.busy || routeMutationBusy) return false
     var previousSinkName = Model.nodeName(sink)
     var previousSinkObjectId = Model.nodeObjectId(sink)
     defaultOutputError = ""
@@ -1053,6 +1130,7 @@ Panel {
       previousSinkObjectId
     ])
     defaultSinkProc.running = true
+    return true
   }
 
   function setDefaultSource(node) {
@@ -1102,6 +1180,11 @@ Panel {
       if (alias !== "") return alias
     }
     return Model.nodeLabel(node)
+  }
+
+  function routeNodeLabel(node) {
+    var label = nodeLabel(node)
+    return Model.isOutputGroupSink(node) ? label + " · Output group" : label
   }
 
   function nodeProps(node) {
@@ -1349,10 +1432,25 @@ Panel {
   Process {
     id: defaultSinkProc
     onExited: function(exitCode) {
+      var fallbackFrom = root.degradedGroupFallbackFrom
+      root.degradedGroupFallbackFrom = ""
       root.defaultOutputError = exitCode === 0 ? ""
         : (exitCode === 2 ? "Default output changed, but its preference could not be saved"
           : (exitCode === 4 ? "Default output change could not be fully restored"
             : "Could not change the default audio output"))
+      if (fallbackFrom === "") return
+
+      if (Model.nodeName(root.sink) !== fallbackFrom) {
+        root.degradedGroupFallbackBlockedSink = ""
+        root.degradedGroupFallbackBlockedTopology = ""
+        root.scheduleOutputTopologyRecovery()
+      } else {
+        root.degradedGroupFallbackBlockedSink = fallbackFrom
+        root.degradedGroupFallbackBlockedTopology = root.serialSignature(
+          rulesStore.physicalSinks)
+        outputTopologyRecoveryTimer.stop()
+        outputGroups.scheduleReconcile()
+      }
     }
   }
 
@@ -1437,6 +1535,20 @@ Panel {
     interval: 75
     repeat: false
     onTriggered: root.refreshDisplayAudioModels()
+  }
+
+  Timer {
+    id: outputTopologyRecoveryTimer
+    interval: 350
+    repeat: false
+    onTriggered: {
+      if (!root.rulesLoaded) return
+      if (root.outputTopologyRecoveryBusy) {
+        restart()
+        return
+      }
+      if (!root.recoverDegradedDefaultGroup()) outputGroups.scheduleReconcile()
+    }
   }
 
   Timer {
@@ -1834,18 +1946,18 @@ Panel {
             }
 
             Repeater {
-              model: root.displayAudioSinks
+              model: root.displayAudioSinks.length
 
               AudioSinkRow {
                 id: sinkDelegate
-                required property var modelData
                 required property int index
                 width: panelColumn.width
-                node: modelData
+                node: root.displayAudioSinks[index]
                 rowIndex: index
                 bar: root.bar
                 preferredName: root.preferredOutputName
                 label: root.nodeLabel(sinkDelegate.node)
+                outputGroup: Model.isOutputGroupSink(sinkDelegate.node)
                 defaultSetBusy: root.sceneMutationBusy
                 hasCursor: root.cursorActive && root.focusSection === "output"
                   && root.selectedIndex === sinkDelegate.rowIndex
@@ -1865,14 +1977,14 @@ Panel {
 
           // ---- Input ----
           PanelSeparator {
-            visible: root.displayAudioSources.length > 0 || !!root.source
+            visible: root.displayAudioSources.length > 0 || root.hasInput
             foreground: root.bar.foreground
           }
 
           Column {
             width: parent.width
             spacing: Style.space(6)
-            visible: root.displayAudioSources.length > 0 || !!root.source
+            visible: root.displayAudioSources.length > 0 || root.hasInput
 
             Item {
               width: parent.width
@@ -1905,7 +2017,7 @@ Panel {
 
             CursorSurface {
               id: inputSliderRow
-              visible: !!root.source
+              visible: root.hasInput
               width: parent.width
               height: inputControls.implicitHeight + Style.spacing.controlGap
               hasCursor: root.cursorActive && root.focusSection === "input" && root.selectedIndex === -1
@@ -1970,14 +2082,13 @@ Panel {
             }
 
             Repeater {
-              model: root.displayAudioSources
+              model: root.displayAudioSources.length
 
               AudioSourceRow {
                 id: sourceDelegate
-                required property var modelData
                 required property int index
                 width: panelColumn.width
-                node: modelData
+                node: root.displayAudioSources[index]
                 rowIndex: index
                 bar: root.bar
                 preferredName: root.preferredInputName
@@ -2018,14 +2129,13 @@ Panel {
 
             Repeater {
               id: streamRepeater
-              model: root.displayAudioStreams
+              model: root.displayAudioStreams.length
 
               AudioStreamRow {
                 id: streamDelegate
-                required property var modelData
                 required property int index
                 width: panelColumn.width
-                node: modelData
+                node: root.displayAudioStreams[index]
                 nodeLive: root.mutableAudioNode(streamDelegate.node)
                 rowIndex: index
                 recording: false
@@ -2091,14 +2201,13 @@ Panel {
 
             Repeater {
               id: recordingStreamRepeater
-              model: root.displayRecordingStreams
+              model: root.displayRecordingStreams.length
 
               AudioStreamRow {
                 id: recordingStreamDelegate
-                required property var modelData
                 required property int index
                 width: panelColumn.width
-                node: modelData
+                node: root.displayRecordingStreams[index]
                 nodeLive: root.mutableAudioNode(recordingStreamDelegate.node)
                 rowIndex: index
                 recording: true

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ instead of introducing a separate mixer application.
   absent are skipped and reported.
 - Pin any application to a device with offline routing rules that are enforced
   whenever the application starts and the device is present.
+- Create named output groups that play through two to eight connected outputs
+  at once, then use them as defaults or per-application destinations.
 - Rename devices with aliases, mark favorites so they sort first, and hide
   devices everywhere.
 - Inspect PipeWire and WirePlumber health from a Diagnostics tab: graph rate,
@@ -46,6 +48,9 @@ instead of introducing a separate mixer application.
 The bar audio icon uses left-click for the quick mixer, middle-click to mute or
 unmute the microphone, right-click to mute or unmute all audio, and the wheel to
 adjust output volume. Hovering it lists applications with active microphone access.
+
+`Super+Ctrl+A` opens the same quick mixer as Omarchy's built-in audio widget.
+Use the gear in that pullout—or **Setup > Audio**—for the advanced window.
 
 The optional [Advanced Bluetooth Audio](https://github.com/ssupt/omarchy-bluetooth-audio)
 companion brings the same codec controls into Omarchy's Bluetooth panel while
@@ -92,6 +97,24 @@ preferences in `~/.config/omarchy/audio-rules.json`; both are plugin-owned and
 edited through the **Scenes** and **Routing** tabs. Manual route changes on a
 pinned application update its rule, and choosing follow-default deletes it.
 Hidden devices disappear from the mixer until shown again in the Routing tab.
+
+Output groups are configured under **Routing > Output groups**. A live group
+behaves like one regular output throughout the plugin, so it can be selected as
+the default, used by a running stream or saved as an offline application rule.
+The quick mixer marks these destinations as **GROUP**. If a member disconnects,
+the definition stays saved and the Routing tab names the missing output. If the
+group was selected, following applications move to the first surviving member
+before the broken virtual output disappears from the mixer. The group is
+restored automatically when every member is available again. Each group card
+also exposes member-level sliders; these change the physical device volumes, so
+the same levels apply when those devices are used outside the group.
+The plugin creates PipeWire's
+[`module-combine-sink`](https://docs.pipewire.org/page_pulse_module_combine_sink.html)
+only while the group exists and reconciles its own marked modules without a
+background service. Updating or deleting a group first requires moving the
+default and active applications away from it. Outputs driven by separate clocks,
+especially Bluetooth devices, can drift slightly; this is a limitation of
+combining independent hardware rather than a UI synchronization issue.
 
 The Diagnostics tab refreshes only while it is visible. Its support report
 contains versions, health counters, human-readable device formats, service

--- a/manifest.json
+++ b/manifest.json
@@ -2,9 +2,9 @@
   "schemaVersion": 1,
   "id": "ssupt.audio-control",
   "name": "Advanced Audio Control",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "author": "ssupt",
-  "description": "Advanced PipeWire and WirePlumber audio mixer for Omarchy: devices, Bluetooth codecs, safety policies, microphone privacy, audio scenes, persistent routing rules, graph and service diagnostics, channel tests, support reports, and guarded recovery",
+  "description": "Advanced PipeWire and WirePlumber audio mixer for Omarchy: devices, multi-output groups, Bluetooth codecs, safety policies, microphone privacy, audio scenes, persistent routing rules, graph and service diagnostics, channel tests, support reports, and guarded recovery",
   "kinds": [
     "bar-widget",
     "panel"
@@ -15,7 +15,7 @@
   },
   "barWidget": {
     "displayName": "Advanced Audio Control",
-    "description": "Advanced PipeWire and WirePlumber audio mixer for Omarchy: devices, Bluetooth codecs, safety policies, microphone privacy, audio scenes, persistent routing rules, graph and service diagnostics, channel tests, support reports, and guarded recovery",
+    "description": "Advanced PipeWire and WirePlumber audio mixer for Omarchy: devices, multi-output groups, Bluetooth codecs, safety policies, microphone privacy, audio scenes, persistent routing rules, graph and service diagnostics, channel tests, support reports, and guarded recovery",
     "category": "Audio",
     "allowMultiple": false
   },

--- a/scripts/audio-app-rules
+++ b/scripts/audio-app-rules
@@ -1,20 +1,23 @@
 #!/bin/bash
 
-# omarchy:summary=Manage offline application routing rules and device preferences
+# omarchy:summary=Manage offline application routes, output groups, and device preferences
 # omarchy:group=audio
-# omarchy:args=[set-app <app> <playback|recording> <target> | del-app <app> <playback|recording> | set-alias <node> <label> | set-flag <node> <favorite|hidden> <true|false>]
+# omarchy:args=[show | set-app <app> <playback|recording> <target> | del-app <app> <playback|recording> | set-output-group <id> <name> <members-json> | del-output-group <id> | set-alias <node> <label> | set-flag <node> <favorite|hidden> <true|false>]
 
 set -euo pipefail
 
 script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
 source "$script_dir/.audio-common"
 rules_file=${OMARCHY_AUDIO_RULES_FILE:-${XDG_CONFIG_HOME:-${HOME:?}/.config}/omarchy/audio-rules.json}
-action=${1:-}
+action=${1:-show}
 maximum_store_bytes=1048576
 
 usage() {
-  echo "Usage: audio-app-rules set-app <app> <playback|recording> <target>" >&2
+  echo "Usage: audio-app-rules [show]" >&2
+  echo "       audio-app-rules set-app <app> <playback|recording> <target>" >&2
   echo "       audio-app-rules del-app <app> <playback|recording>" >&2
+  echo "       audio-app-rules set-output-group <id> <name> <members-json>" >&2
+  echo "       audio-app-rules del-output-group <id>" >&2
   echo "       audio-app-rules set-alias <node> <label>" >&2
   echo "       audio-app-rules set-flag <node> <favorite|hidden> <true|false>" >&2
   exit 1
@@ -25,7 +28,7 @@ read_rules() {
     echo "Audio rules are not stored in a regular file" >&2
     return 1
   elif [[ ! -s $rules_file ]]; then
-    printf '%s\n' '{"version":1,"appRules":[],"devices":{"aliases":{},"favorites":[],"hidden":[]}}'
+    printf '%s\n' '{"version":1,"appRules":[],"outputGroups":[],"devices":{"aliases":{},"favorites":[],"hidden":[]}}'
   elif (( $(stat -c %s -- "$rules_file" 2>/dev/null || printf '%s' "$((maximum_store_bytes + 1))") > maximum_store_bytes )); then
     echo "Audio rules are too large; refusing to overwrite them" >&2
     return 1
@@ -74,10 +77,36 @@ read_rules() {
           | select($node != "" and $label != "")
           | {key: $node, value: $label})][]) as $entry
           ({}; if length >= 128 or has($entry.key) then . else .[$entry.key] = $entry.value end);
+      def normalized_groups:
+        reduce ([((if (.outputGroups | type) == "array" then .outputGroups else [] end)[:64][]?
+          | select(type == "object")
+          | ((.id // "") | select(type == "string" and test("^[0-9a-f]{16}$"))) as $id
+          | ((.name // "") | clean(48)) as $name
+          | ("omarchy_audio_group_" + $id) as $sink
+          | ([((if (.members | type) == "array" then .members else [] end)[:32][]?
+              | identifier(160)
+              | select(test("^[A-Za-z0-9_.:-]{1,160}$"))
+              | select(test("^omarchy_audio_group_[0-9a-f]{16}$") | not))]
+              | unique | sort) as $members
+          | select($name != "" and .sink == $sink
+              and ($members | length) >= 2 and ($members | length) <= 8)
+          | {id: $id, name: $name, sink: $sink, members: $members})][]) as $group
+          ({ids: {}, names: {}, members: {}, values: []};
+            ($group.name | ascii_downcase) as $nameKey
+            | ($group.members | join("\u001f")) as $memberKey
+            | if (.ids | has($group.id)) or (.names | has($nameKey))
+                or (.members | has($memberKey))
+                or (.values | length) >= 16 then .
+              else .ids[$group.id] = true
+                | .names[$nameKey] = true
+                | .members[$memberKey] = true
+                | .values += [$group] end)
+        | .values;
       .[0]
       | {
         version: 1,
         appRules: normalized_rules,
+        outputGroups: normalized_groups,
         devices: {
           aliases: normalized_aliases,
           favorites: ordered_strings(
@@ -149,6 +178,10 @@ validate_identifier() {
 }
 
 case "$action" in
+  show)
+    (( $# == 0 || $# == 1 )) || usage
+    read_rules
+    ;;
   set-app)
     (( $# == 4 )) || usage
     app=$(normalize_app "$2")
@@ -176,6 +209,60 @@ case "$action" in
       | .appRules |= map(select(.direction != $direction
         or .app != $app))' \
       --arg app "$app" --arg direction "$direction"
+    ;;
+  set-output-group)
+    (( $# == 4 )) || usage
+    group_id=${2:-}
+    group_name=$(normalize_string "${3:-}" 48)
+    group_members=$(jq -cer '
+      if type != "array" or length < 2 or length > 8
+          or (all(.[];
+            type == "string"
+            and length > 0 and length <= 160
+            and test("^[A-Za-z0-9_.:-]{1,160}$")
+            and (test("^omarchy_audio_group_[0-9a-f]{16}$") | not)) | not)
+        then error("invalid members")
+        else unique | sort
+        | if length < 2 or length > 8 then error("invalid members") else . end
+      end
+    ' <<<"${4:-}") || usage
+    [[ $group_id =~ ^[0-9a-f]{16}$ && -n $group_name ]] || usage
+    group_sink=omarchy_audio_group_$group_id
+    write_rules '
+      ($name | ascii_downcase) as $nameKey
+      | if any(.outputGroups[]?;
+          .id != $id and (((.name | ascii_downcase) == $nameKey)
+            or .members == $members))
+        then error("duplicate output group")
+        else . end
+      | if (([.outputGroups[]? | select(.id == $id)] | length) == 0
+          and (.outputGroups | length) >= 16)
+        then error("output group limit reached")
+        else . end
+      | .version = 1
+      | .outputGroups = (
+          (.outputGroups | map(select(.id != $id)))
+          + [{id: $id, name: $name, sink: $sink, members: $members}]
+          | .[-16:]
+        )
+    ' --arg id "$group_id" --arg name "$group_name" --arg sink "$group_sink" \
+      --argjson members "$group_members"
+    ;;
+  del-output-group)
+    (( $# == 2 )) || usage
+    group_id=${2:-}
+    [[ $group_id =~ ^[0-9a-f]{16}$ ]] || usage
+    group_sink=omarchy_audio_group_$group_id
+    write_rules '
+      if any(.appRules[]?; .target == $sink)
+        then error("output group is used by an application rule")
+        else . end
+      | .version = 1
+      | .outputGroups |= map(select(.id != $id))
+      | .devices.aliases |= del(.[$sink])
+      | .devices.favorites |= map(select(. != $sink))
+      | .devices.hidden |= map(select(. != $sink))
+    ' --arg id "$group_id" --arg sink "$group_sink"
     ;;
   set-alias)
     (( $# == 3 )) || usage

--- a/scripts/audio-menu-entry
+++ b/scripts/audio-menu-entry
@@ -12,7 +12,7 @@ source "$script_dir/.audio-common"
 action=${1:-install}
 menu_file=${AUDIO_CONTROL_MENU_FILE:-$HOME/.config/omarchy/extensions/omarchy-menu.jsonc}
 marker="  // Added by ssupt.audio-control"
-entry='  "setup.audio": {"icon":"","label":"Audio","action":"omarchy-shell shell summon ssupt.audio-control"}'
+entry='  "setup.audio": {"icon":"","label":"Audio","action":"omarchy-shell shell summon ssupt.audio-control '\''{\"view\":\"advanced\"}'\''"}'
 maximum_menu_bytes=1048576
 
 command -v jq >/dev/null || {

--- a/scripts/audio-output-groups
+++ b/scripts/audio-output-groups
@@ -1,0 +1,571 @@
+#!/bin/bash
+
+# omarchy:summary=Create and reconcile named multi-output audio groups
+# omarchy:group=audio
+# omarchy:args=[reconcile | create <name> <members-json> | update <id> <name> <members-json> | delete <id> | show]
+
+set -u -o pipefail
+LC_ALL=C
+
+script_dir=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)
+# shellcheck source=.audio-common
+source "$script_dir/.audio-common"
+
+action=${1:-reconcile}
+rules_helper=$script_dir/audio-app-rules
+group_prefix=omarchy_audio_group_
+owner_id=ssupt.audio-control
+
+usage() {
+  echo "Usage: audio-output-groups [reconcile | show]" >&2
+  echo "       audio-output-groups create <name> <members-json>" >&2
+  echo "       audio-output-groups update <id> <name> <members-json>" >&2
+  echo "       audio-output-groups delete <id>" >&2
+  exit 1
+}
+
+rules_show() {
+  /bin/bash "$rules_helper" show
+}
+
+normalize_name() {
+  local value=${1:-}
+  jq -ner --arg value "$value" '
+    $value
+    | gsub("[\u0000-\u001f\u007f-\u009f\u200e\u200f\u2028-\u202e\u2066-\u2069]"; " ")
+    | gsub(" +"; " ")
+    | sub("^ +"; "") | sub(" +$"; "")
+    | .[0:48]
+    | select(length > 0)
+  '
+}
+
+normalize_members() {
+  jq -cer '
+    if type != "array" or length < 2 or length > 8
+      or (all(.[];
+        type == "string"
+        and length > 0 and length <= 160
+        and test("^[A-Za-z0-9_.:-]{1,160}$")
+        and (test("^omarchy_audio_group_[0-9a-f]{16}$") | not)) | not)
+      then error("invalid output group members")
+      else unique | sort
+      | if length < 2 or length > 8
+          then error("duplicate output group members") else . end
+    end
+  ' <<<"${1:-}"
+}
+
+new_group_id() {
+  local rules=$1 id attempt existing
+  for (( attempt = 0; attempt < 16; attempt++ )); do
+    id=$(od -An -N8 -tx1 /dev/urandom | tr -d ' \n') || return 1
+    [[ $id =~ ^[0-9a-f]{16}$ ]] || continue
+    existing=$(jq -r --arg id "$id" '[.outputGroups[]? | select(.id == $id)] | length' \
+      <<<"$rules") || return 1
+    if [[ $existing == 0 ]]; then
+      printf '%s\n' "$id"
+      return 0
+    fi
+  done
+  return 1
+}
+
+valid_group_id() {
+  [[ ${1:-} =~ ^[0-9a-f]{16}$ ]]
+}
+
+read_sinks() {
+  audio_capture_bounded AUDIO_GROUP_SINKS 16777216 \
+    timeout 3 pactl -f json list sinks
+}
+
+read_modules() {
+  audio_capture_bounded AUDIO_GROUP_MODULES 8388608 \
+    timeout 3 pactl -f json list modules
+}
+
+owned_sink_record() {
+  local id=$1 sink=$2
+  read_sinks || return 1
+  jq -er --arg id "$id" --arg sink "$sink" --arg owner "$owner_id" '
+    if type != "array" or length > 512 then error("invalid sink list") else . end
+    | [.[] | select(.name == $sink)] as $matches
+    | if ($matches | length) == 0 then "__absent__"
+      elif ($matches | length) != 1 then error("ambiguous group sink")
+      else ($matches[0]) as $match
+        | ($match.properties // {}) as $properties
+        | (($properties."application.id" // "") | tostring) as $application
+        | (($properties."omarchy.audio.group.id" // "") | tostring) as $group
+        | (($properties."node.virtual" // "") | tostring | ascii_downcase) as $virtual
+        | (($match.owner_module // "") | tostring) as $module
+        | (($properties."pulse.module.id" // "") | tostring) as $pulseModule
+        | if (($application == $owner and $group == $id)
+              or ($application == "" and $group == ""
+                and (($match.description // "") == "Omarchy_Output_Group"))) | not
+            or ($virtual != "true" and $virtual != "1")
+            or (($match.index | tostring) | test("^[0-9]{1,20}$") | not)
+            or ($module | test("^[0-9]{1,20}$") | not)
+            or $pulseModule != $module
+          then error("group sink is not plugin-owned")
+          else [($match.index | tostring), $module] | @tsv
+          end
+      end
+  ' <<<"$AUDIO_GROUP_SINKS" 2>/dev/null
+}
+
+owned_sink_index() {
+  local record
+  record=$(owned_sink_record "$1" "$2") || return 1
+  if [[ $record == __absent__ ]]; then
+    printf '%s\n' "$record"
+  else
+    printf '%s\n' "${record%%$'\t'*}"
+  fi
+}
+
+owned_sink_module_id() {
+  local record
+  record=$(owned_sink_record "$1" "$2") || return 1
+  if [[ $record == __absent__ ]]; then
+    printf '%s\n' "$record"
+  else
+    printf '%s\n' "${record#*$'\t'}"
+  fi
+}
+
+owned_module_match_count() {
+  local id=$1 sink=$2
+  read_modules || return 1
+  jq -er --arg id "$id" --arg sink "$sink" --arg owner "$owner_id" '
+    if type != "array" or length > 1024 then error("invalid module list") else . end
+    | [.[]
+      | select(.name == "module-combine-sink")
+      | (.argument // "" | tostring) as $argument
+      | select($argument | contains("sink_name=" + $sink))
+      | select($argument | contains("application.id=" + $owner))
+      | select($argument | contains("omarchy.audio.group.id=" + $id))
+    ] | length
+  ' <<<"$AUDIO_GROUP_MODULES" 2>/dev/null
+}
+
+owned_module_index() {
+  local id=$1 sink=$2 count module_id
+  count=$(owned_module_match_count "$id" "$sink") || return 1
+  if [[ $count == 0 ]]; then
+    printf '%s\n' __absent__
+    return 0
+  fi
+  [[ $count == 1 ]] || return 1
+  module_id=$(owned_sink_module_id "$id" "$sink") || return 1
+  [[ $module_id != __absent__ ]] || return 1
+  printf '%s\n' "$module_id"
+}
+
+module_id_is_owned() {
+  local module_id=$1 id=$2 sink=$3 count observed
+  count=$(owned_module_match_count "$id" "$sink") || return 1
+  [[ $count == 1 ]] || return 1
+  observed=$(owned_sink_module_id "$id" "$sink") || return 1
+  [[ $observed == "$module_id" ]]
+}
+
+group_live_state() {
+  local id=$1 sink=$2 sink_index module_index
+  sink_index=$(owned_sink_index "$id" "$sink") || return 2
+  module_index=$(owned_module_index "$id" "$sink") || return 2
+  if [[ $sink_index == __absent__ && $module_index == __absent__ ]]; then
+    return 1
+  fi
+  [[ $sink_index != __absent__ && $module_index != __absent__ ]] || return 2
+  return 0
+}
+
+members_are_live() {
+  local members=$1 status
+  read_sinks || return 1
+  jq -e --argjson members "$members" --arg owner "$owner_id" '
+    if type != "array" or length > 512 then error("invalid sink list") else . end
+    | . as $sinks
+    | all($members[];
+        . as $member
+        | ([$sinks[] | select(.name == $member)] | length) == 1
+          and ([$sinks[] | select(.name == $member)][0]
+            | ((.properties."application.id" // "") != $owner)
+              and (.name | test("^omarchy_audio_group_[0-9a-f]{16}$") | not)
+              and (((.properties."node.virtual" // "") | tostring | ascii_downcase)
+                | . != "true" and . != "1")
+              and (((.properties."device.class" // "") | tostring | ascii_downcase)
+                | . != "filter" and . != "monitor")
+              and (((.properties."factory.name" // "") | tostring | ascii_downcase)
+                | contains("null-audio-sink") | not)
+              and (((.properties."factory.name" // "") | tostring | ascii_downcase)
+                | contains("filter-chain") | not)))
+  ' <<<"$AUDIO_GROUP_SINKS" >/dev/null 2>&1
+  status=$?
+  (( status == 0 )) && return 0
+  # jq uses 1 for a valid false result and a different status for malformed
+  # input. Keep a disconnected endpoint distinct from an unsafe graph read.
+  (( status == 1 )) && return 3
+  return 1
+}
+
+load_group() {
+  local id=$1 sink=$2 members=$3 members_csv module_output module_id
+  local sink_index module_index attempt member_status
+
+  sink_index=$(owned_sink_index "$id" "$sink") || return 1
+  module_index=$(owned_module_index "$id" "$sink") || return 1
+  if [[ $sink_index != __absent__ || $module_index != __absent__ ]]; then
+    [[ $sink_index != __absent__ && $module_index != __absent__ ]] || {
+      echo "Output group ownership could not be verified" >&2
+      return 1
+    }
+    return 0
+  fi
+
+  members_are_live "$members"
+  member_status=$?
+  if (( member_status != 0 )); then
+    if (( member_status == 3 )); then
+      echo "Every output in the group must be connected" >&2
+      return 3
+    fi
+    echo "Output group members could not be inspected safely" >&2
+    return 1
+  fi
+  members_csv=$(jq -r 'join(",")' <<<"$members") || return 1
+  module_output=$(timeout 4 pactl load-module module-combine-sink \
+    "sink_name=$sink" \
+    "sinks=$members_csv" \
+    "sink_properties=\"device.description=Omarchy_Output_Group application.id=$owner_id node.virtual=true omarchy.audio.group.id=$id\"" \
+    latency_compensate=true 2>/dev/null) || {
+      echo "PipeWire could not create the output group" >&2
+      return 1
+    }
+  module_id=${module_output//$'\n'/}
+  [[ $module_id =~ ^[0-9]{1,20}$ ]] || {
+    echo "PipeWire returned an invalid module identity" >&2
+    return 1
+  }
+  for (( attempt = 0; attempt < 20; attempt++ )); do
+    if module_id_is_owned "$module_id" "$id" "$sink"; then
+      return 0
+    fi
+    sleep 0.05
+  done
+
+  # The numeric identity came directly from this load request, so it remains
+  # the only safe rollback handle when the sink never becomes inspectable.
+  timeout 3 pactl unload-module "$module_id" >/dev/null 2>&1 || true
+  echo "The new output group did not appear" >&2
+  return 1
+}
+
+group_in_use() {
+  local sink=$1 sink_index=$2 default_sink inputs
+  audio_capture_bounded default_sink 1024 timeout 3 pactl get-default-sink || return 1
+  [[ $default_sink != "$sink" ]] || return 3
+  audio_capture_bounded inputs 16777216 \
+    timeout 3 pactl -f json list sink-inputs || return 1
+  jq -e --arg sink "$sink_index" '
+    if type != "array" or length > 2048 then error("invalid stream list") else . end
+    | any(.[]; ((.sink // "") | tostring) == $sink) | not
+  ' <<<"$inputs" >/dev/null 2>&1 || return 3
+  return 0
+}
+
+unload_group() {
+  local id=$1 sink=$2 sink_index module_index use_status
+  sink_index=$(owned_sink_index "$id" "$sink") || return 1
+  module_index=$(owned_module_index "$id" "$sink") || return 1
+  if [[ $sink_index == __absent__ && $module_index == __absent__ ]]; then
+    return 0
+  fi
+  [[ $sink_index != __absent__ && $module_index != __absent__ ]] || {
+    echo "Output group ownership could not be verified" >&2
+    return 1
+  }
+
+  group_in_use "$sink" "$sink_index"
+  use_status=$?
+  if (( use_status != 0 )); then
+    if (( use_status == 3 )); then
+      echo "Switch applications and the default output away from this group first" >&2
+      return 3
+    fi
+    echo "Output group use could not be inspected safely" >&2
+    return 1
+  fi
+
+  timeout 3 pactl unload-module "$module_index" >/dev/null 2>&1 || {
+    echo "PipeWire could not remove the output group" >&2
+    return 1
+  }
+  sink_index=$(owned_sink_index "$id" "$sink") || return 1
+  module_index=$(owned_module_index "$id" "$sink") || return 1
+  [[ $sink_index == __absent__ && $module_index == __absent__ ]] || {
+    echo "The output group remained after removal" >&2
+    return 1
+  }
+}
+
+group_record() {
+  local rules=$1 id=$2
+  jq -cer --arg id "$id" '
+    [.outputGroups[]? | select(.id == $id)] as $matches
+    | if ($matches | length) == 1 then $matches[0]
+      else error("unknown or ambiguous output group") end
+  ' <<<"$rules"
+}
+
+definition_conflicts() {
+  local rules=$1 id=$2 name=$3 members=$4
+  jq -e --arg id "$id" --arg name "$name" --argjson members "$members" '
+    ($name | ascii_downcase) as $nameKey
+    | any(.outputGroups[]?;
+        .id != $id and (((.name | ascii_downcase) == $nameKey) or .members == $members))
+  ' <<<"$rules" >/dev/null 2>&1
+}
+
+store_group() {
+  /bin/bash "$rules_helper" set-output-group "$1" "$2" "$3"
+}
+
+delete_stored_group() {
+  /bin/bash "$rules_helper" del-output-group "$1"
+}
+
+create_group() {
+  local name members id sink rules group_count was_live=false rollback_status
+  name=$(normalize_name "${1:-}") || usage
+  members=$(normalize_members "${2:-}") || usage
+  rules=$(rules_show) || return 1
+  group_count=$(jq -er '.outputGroups | length' <<<"$rules") || return 1
+  if (( group_count >= 16 )); then
+    echo "Up to 16 output groups can be stored" >&2
+    return 1
+  fi
+  id=$(new_group_id "$rules") || return 1
+  sink=$group_prefix$id
+  if definition_conflicts "$rules" "$id" "$name" "$members"; then
+    echo "An output group already uses that name or device set" >&2
+    return 1
+  fi
+
+  group_live_state "$id" "$sink"
+  case $? in
+    0) was_live=true ;;
+    1) ;;
+    *) echo "Output group ownership could not be verified" >&2; return 1 ;;
+  esac
+  load_group "$id" "$sink" "$members" || return $?
+  if store_group "$id" "$name" "$members"; then
+    printf '%s\n' "$id"
+    return 0
+  fi
+
+  if [[ $was_live == false ]]; then
+    unload_group "$id" "$sink"
+    rollback_status=$?
+    (( rollback_status == 0 )) || return 4
+  fi
+  return 1
+}
+
+update_group() {
+  local id=$1 name members rules record sink old_members was_live=false
+  local status rollback_complete=true
+  valid_group_id "$id" || usage
+  name=$(normalize_name "${2:-}") || usage
+  members=$(normalize_members "${3:-}") || usage
+  rules=$(rules_show) || return 1
+  record=$(group_record "$rules" "$id") || {
+    echo "That output group no longer exists" >&2
+    return 3
+  }
+  sink=$(jq -r '.sink' <<<"$record")
+  old_members=$(jq -c '.members' <<<"$record")
+  if definition_conflicts "$rules" "$id" "$name" "$members"; then
+    echo "An output group already uses that name or device set" >&2
+    return 1
+  fi
+
+  if [[ $members == "$old_members" ]]; then
+    load_group "$id" "$sink" "$members" || return $?
+    store_group "$id" "$name" "$members"
+    return $?
+  fi
+  members_are_live "$members"
+  status=$?
+  if (( status != 0 )); then
+    if (( status == 3 )); then
+      echo "Every output in the group must be connected" >&2
+      return 3
+    fi
+    echo "Output group members could not be inspected safely" >&2
+    return 1
+  fi
+
+  group_live_state "$id" "$sink"
+  case $? in
+    0) was_live=true ;;
+    1) ;;
+    *) echo "Output group ownership could not be verified" >&2; return 1 ;;
+  esac
+  if [[ $was_live == true ]]; then
+    unload_group "$id" "$sink"
+    status=$?
+    (( status == 0 )) || return "$status"
+  fi
+  load_group "$id" "$sink" "$members"
+  status=$?
+  if (( status != 0 )); then
+    if [[ $was_live == true ]]; then
+      load_group "$id" "$sink" "$old_members" || rollback_complete=false
+    fi
+    [[ $rollback_complete == true ]] && return 1
+    return 4
+  fi
+  if store_group "$id" "$name" "$members"; then
+    return 0
+  fi
+
+  unload_group "$id" "$sink" || rollback_complete=false
+  if [[ $was_live == true ]]; then
+    load_group "$id" "$sink" "$old_members" || rollback_complete=false
+  fi
+  [[ $rollback_complete == true ]] && return 1
+  return 4
+}
+
+delete_group() {
+  local id=$1 rules record sink members was_live=false status rollback_complete=true
+  valid_group_id "$id" || usage
+  rules=$(rules_show) || return 1
+  record=$(group_record "$rules" "$id") || {
+    echo "That output group no longer exists" >&2
+    return 3
+  }
+  sink=$(jq -r '.sink' <<<"$record")
+  members=$(jq -c '.members' <<<"$record")
+  if jq -e --arg sink "$sink" 'any(.appRules[]?; .target == $sink)' \
+      <<<"$rules" >/dev/null 2>&1; then
+    echo "Remove application rules using this output group first" >&2
+    return 3
+  fi
+
+  group_live_state "$id" "$sink"
+  case $? in
+    0) was_live=true ;;
+    1) ;;
+    *) echo "Output group ownership could not be verified" >&2; return 1 ;;
+  esac
+  if [[ $was_live == true ]]; then
+    unload_group "$id" "$sink"
+    status=$?
+    (( status == 0 )) || return "$status"
+  fi
+  if delete_stored_group "$id"; then
+    return 0
+  fi
+  if [[ $was_live == true ]]; then
+    load_group "$id" "$sink" "$members" || rollback_complete=false
+  fi
+  [[ $rollback_complete == true ]] && return 1
+  return 4
+}
+
+reconcile_groups() {
+  local rules row id sink members module_rows argument stale_id stale_sink status
+  local failed=false
+  local -a rows
+  rules=$(rules_show) || return 1
+  mapfile -t rows < <(jq -c '.outputGroups[]?' <<<"$rules") || return 1
+  for row in "${rows[@]}"; do
+    id=$(jq -r '.id' <<<"$row")
+    sink=$(jq -r '.sink' <<<"$row")
+    members=$(jq -c '.members' <<<"$row")
+    members_are_live "$members"
+    status=$?
+    if (( status == 0 )); then
+      load_group "$id" "$sink" "$members" || failed=true
+    elif (( status == 3 )); then
+      # An unused degraded group is safer absent: it cannot be selected by a
+      # client that bypasses the plugin, and reconnecting every member will
+      # recreate it on the next reconciliation. Never interrupt a current
+      # default or a group with active streams.
+      unload_group "$id" "$sink"
+      status=$?
+      (( status == 0 || status == 3 )) || failed=true
+    else
+      failed=true
+    fi
+  done
+
+  read_modules || return 1
+  module_rows=$(jq -r --arg owner "$owner_id" '
+    if type != "array" or length > 1024 then error("invalid module list") else . end
+    | .[]
+    | select(.name == "module-combine-sink")
+    | (.argument // "" | tostring) as $argument
+    | select($argument | contains("application.id=" + $owner))
+    | $argument
+  ' <<<"$AUDIO_GROUP_MODULES") || return 1
+  while IFS= read -r argument; do
+    [[ -n $argument ]] || continue
+    if [[ $argument =~ omarchy\.audio\.group\.id=([0-9a-f]{16}) ]]; then
+      stale_id=${BASH_REMATCH[1]}
+    else
+      continue
+    fi
+    stale_sink=$group_prefix$stale_id
+    [[ $argument == *"sink_name=$stale_sink"* ]] || continue
+    if jq -e --arg id "$stale_id" 'any(.outputGroups[]?; .id == $id)' \
+        <<<"$rules" >/dev/null 2>&1; then
+      continue
+    fi
+    unload_group "$stale_id" "$stale_sink"
+    status=$?
+    (( status == 0 || status == 3 )) || failed=true
+  done <<<"$module_rows"
+
+  [[ $failed == false ]]
+}
+
+case "$action" in
+  show)
+    (( $# == 1 )) || usage
+    rules_show
+    ;;
+  create)
+    (( $# == 3 )) || usage
+    command -v jq >/dev/null && command -v od >/dev/null \
+      && command -v tr >/dev/null && command -v pactl >/dev/null || exit 1
+    audio_prepare_private_runtime || exit 1
+    audio_acquire_mutation_lock || exit 1
+    create_group "$2" "$3"
+    ;;
+  update)
+    (( $# == 4 )) || usage
+    command -v jq >/dev/null && command -v pactl >/dev/null || exit 1
+    audio_prepare_private_runtime || exit 1
+    audio_acquire_mutation_lock || exit 1
+    update_group "$2" "$3" "$4"
+    ;;
+  delete)
+    (( $# == 2 )) || usage
+    command -v jq >/dev/null && command -v pactl >/dev/null || exit 1
+    audio_prepare_private_runtime || exit 1
+    audio_acquire_mutation_lock || exit 1
+    delete_group "$2"
+    ;;
+  reconcile)
+    (( $# == 0 || $# == 1 )) || usage
+    command -v jq >/dev/null && command -v pactl >/dev/null || exit 1
+    audio_prepare_private_runtime || exit 1
+    audio_acquire_mutation_lock || exit 1
+    reconcile_groups
+    ;;
+  *) usage ;;
+esac

--- a/scripts/audio-output-set-default
+++ b/scripts/audio-output-set-default
@@ -180,6 +180,7 @@ if [[ -n $old_sink_index && $old_sink_name != "$sink_name" ]]; then
   input_rows=$(jq -r --arg sink "$old_sink_index" '
     if type != "array" or length > 1024 then error("invalid stream list") else . end
     | [.[]
+      | select(.owner_module == null)
       | select((.sink | tostring) == $sink)
       | select((.properties."application.name" // "") != "EasyEffects")
     ] as $streams

--- a/scripts/audio-stream-route-set
+++ b/scripts/audio-stream-route-set
@@ -43,7 +43,9 @@ audio_capture_bounded state 16777216 timeout 2 pactl -f json list || exit 1
 stream_record=$(jq -cer --arg key "$streams_key" --arg stream "$stream" '
   if type != "object" or (.[$key] | type) != "array" or (.[$key] | length) > 1024
     then error("invalid stream list")
-  else [.[$key][] | select((.index | tostring) == $stream)] as $matches
+  else [.[$key][]
+      | select(.owner_module == null)
+      | select((.index | tostring) == $stream)] as $matches
     | if ($matches | length) == 1 then $matches[0]
       else error("ambiguous stream identity") end
   end

--- a/scripts/audio-stream-routes
+++ b/scripts/audio-stream-routes
@@ -74,8 +74,12 @@ if jq -c --argjson explicit "$explicit_targets" '
       else ($entries[:512] | map(del(.object)) | from_entries) end;
 
   if type != "object" then error("expected a route object") else . end
-  | (bounded_array("sink_inputs"; 2048)) as $sinkInputs
-  | (bounded_array("source_outputs"; 2048)) as $sourceOutputs
+  | (bounded_array("sink_inputs"; 2048)) as $allSinkInputs
+  | (bounded_array("source_outputs"; 2048)) as $allSourceOutputs
+  # Module-owned loopback/combine streams are implementation details, not
+  # applications. They must never appear in the mixer or accept manual routes.
+  | [$allSinkInputs[] | select(.owner_module == null)] as $sinkInputs
+  | [$allSourceOutputs[] | select(.owner_module == null)] as $sourceOutputs
   | {
       playback: routes($sinkInputs; "sink"),
       recording: routes($sourceOutputs; "source")

--- a/test/all
+++ b/test/all
@@ -129,6 +129,24 @@ if command -v qmllint >/dev/null 2>&1; then
   echo "PASS: QML lint"
 fi
 
+# Native PwNode QObjects can disappear between a PipeWire removal event and a
+# Repeater regeneration. Keep them out of Qt's JavaScript-list delegate model;
+# delegates may resolve the panel snapshot by a stable integer index instead.
+for live_model in displayAudioSinks displayAudioSources \
+    displayAudioStreams displayRecordingStreams; do
+  rg -q "model: root\\.${live_model}\\.length$" "$ROOT/Panel.qml" ||
+    fail "safe numeric Repeater model: $live_model"
+  if rg -q "model: root\\.${live_model}$" "$ROOT/Panel.qml"; then
+    fail "native PipeWire objects used directly as Repeater rows: $live_model"
+  fi
+done
+rg -q 'model: root\.memberLevels\.length$' "$ROOT/AudioOutputGroupRow.qml" ||
+  fail "safe numeric output-group member level model"
+if rg -q 'model: root\.memberLevels$' "$ROOT/AudioOutputGroupRow.qml"; then
+  fail "native PipeWire group members used directly as Repeater rows"
+fi
+echo "PASS: unplug-safe PipeWire delegate models"
+
 node - "$ROOT/Model.js" <<'JS'
 const assert = require('node:assert/strict')
 const model = require(process.argv[2])
@@ -155,6 +173,20 @@ assert.deepEqual(model.parseAudioControlSettings('not json'), {
   captureNotifications: true
 })
 assert.equal(model.parseAudioControlSettings('{"captureNotifications":false}').captureNotifications, false)
+assert.deepEqual(model.parseAudioOpenRequest(''), { advanced: false, tab: 0 })
+assert.deepEqual(model.parseAudioOpenRequest('{}'), { advanced: false, tab: 0 })
+assert.deepEqual(model.parseAudioOpenRequest('{"view":"advanced"}'), { advanced: true, tab: 0 })
+assert.deepEqual(model.parseAudioOpenRequest('{"advanced":true,"tab":"routing"}'), {
+  advanced: true, tab: 4
+})
+assert.deepEqual(model.parseAudioOpenRequest('{"tab":"bluetooth"}'), { advanced: true, tab: 1 })
+assert.deepEqual(model.parseAudioOpenRequest('{"view":"quick","tab":"diagnostics"}'), {
+  advanced: false, tab: 0
+})
+assert.deepEqual(model.parseAudioOpenRequest('{"tab":"unknown"}'), { advanced: false, tab: 0 })
+assert.deepEqual(model.parseAudioOpenRequest('[' + '0,'.repeat(4096) + '0]'), {
+  advanced: false, tab: 0
+})
 assert.equal(model.sanitizeIdentifier(' exact identifier ', 160), ' exact identifier ')
 assert.equal(model.sanitizeIdentifier('invalid\nidentifier', 160), '')
 assert.equal(model.sanitizeIdentifier('x'.repeat(161), 160), '')
@@ -168,6 +200,7 @@ assert.equal(model.isAudioScenesDocument('{"version":2,"scenes":[]}'), false)
 assert.equal(model.isAudioScenesDocument('{"scenes":{}}'), false)
 assert.equal(model.isAudioRulesDocument('{"appRules":[],"devices":{}}'), true)
 assert.equal(model.isAudioRulesDocument('{"appRules":{}}'), false)
+assert.equal(model.isAudioRulesDocument('{"outputGroups":{}}'), false)
 assert.equal(model.isAudioRulesDocument('x'.repeat(1048577)), false)
 assert.deepEqual(
   model.parseAudioScenes(JSON.stringify({
@@ -388,6 +421,10 @@ assert.deepEqual(model.streamOutputOptions([defaultOutput, headphones], defaultO
   { value: 'override:10', label: 'Always use Desk Speakers' },
   { value: 'override:11', label: 'Always use Headphones' }
 ])
+assert.equal(model.streamRouteDestinationCount(
+  model.streamOutputOptions([defaultOutput], defaultOutput)), 1)
+assert.equal(model.streamRouteDestinationCount(
+  model.streamOutputOptions([defaultOutput, headphones], defaultOutput)), 2)
 assert.deepEqual(model.recordingInputOptions([defaultInput, headsetInput], defaultInput), [
   { value: 'default:20', label: 'Follow default input' },
   { value: 'override:20', label: 'Always use Desk Microphone' },
@@ -399,6 +436,12 @@ assert.deepEqual(model.streamOutputOptions([headphones], defaultOutput), [
   { value: 'default:10', label: 'Follow default output' },
   { value: 'override:11', label: 'Always use Headphones' }
 ])
+assert.equal(model.streamRouteDestinationCount(
+  model.streamOutputOptions([headphones], defaultOutput)), 2)
+assert.equal(model.streamRouteDestinationCount([
+  { value: 'default:10' }, { value: 'override:10' },
+  { value: 'invalid' }, null
+]), 1)
 assert.deepEqual(model.streamOutputOptions([
   defaultOutput,
   { name: 'duplicate-default', ready: true, properties: { 'object.serial': 10 } },
@@ -440,6 +483,24 @@ const obsStream = {
 }
 const classified = model.classifyAudioNodes([
   { name: 'speakers', isStream: false, isSink: true },
+  {
+    name: 'omarchy_audio_group_0123456789abcdef',
+    isStream: true,
+    isSink: true,
+    ready: true,
+    properties: {
+      'application.id': 'ssupt.audio-control',
+      'node.virtual': 'true',
+      'omarchy.audio.group.id': '0123456789abcdef'
+    }
+  },
+  {
+    name: 'omarchy_audio_group_fedcba9876543210',
+    isStream: true,
+    isSink: true,
+    ready: true,
+    properties: { 'application.id': 'untrusted.application' }
+  },
   { name: 'microphone', isStream: false, isSink: false, ready: true, audio: {} },
   { name: 'audio-filter', isStream: false, ready: true, audio: {}, type: 'Audio/Filter' },
   { name: 'speakers.monitor', isStream: false, isSink: false, ready: true, audio: {} },
@@ -452,7 +513,9 @@ const classified = model.classifyAudioNodes([
     properties: { 'application.id': 'ssupt.audio-control' }
   }
 ])
-assert.deepEqual(classified.sinks.map(node => node.name), ['speakers'])
+assert.deepEqual(classified.sinks.map(node => node.name), [
+  'speakers', 'omarchy_audio_group_0123456789abcdef'
+])
 assert.deepEqual(classified.sources.map(node => node.name), ['microphone'])
 assert.deepEqual(classified.playbackStreams.map(node => node.name), ['firefox'])
 assert.deepEqual(classified.recordingStreams.map(node => node.name), ['firefox-capture'])
@@ -495,6 +558,78 @@ assert.equal(model.findAppRule(Array.from({ length: 300 }, (_, index) => ({
 assert.deepEqual(model.parseAudioRules(JSON.stringify({
   devices: { favorites: ['speakers', 'speakers'], hidden: ['mic', 'mic'] }
 })).devices, { aliases: {}, favorites: ['speakers'], hidden: ['mic'] })
+const parsedOutputGroups = model.parseAudioRules(JSON.stringify({
+  outputGroups: [{
+    id: '0123456789abcdef',
+    name: 'Desk',
+    sink: 'omarchy_audio_group_0123456789abcdef',
+    members: ['speakers', 'headphones', 'speakers']
+  }, {
+    id: 'fedcba9876543210',
+    name: 'Recursive',
+    sink: 'omarchy_audio_group_fedcba9876543210',
+    members: ['speakers', 'omarchy_audio_group_0123456789abcdef']
+  }, {
+    id: '1111111111111111',
+    name: 'Duplicate members',
+    sink: 'omarchy_audio_group_1111111111111111',
+    members: ['headphones', 'speakers']
+  }]
+})).outputGroups
+assert.deepEqual(parsedOutputGroups, [{
+  id: '0123456789abcdef',
+  name: 'Desk',
+  sink: 'omarchy_audio_group_0123456789abcdef',
+  members: ['headphones', 'speakers']
+}])
+assert.equal(model.outputGroupForSink(
+  parsedOutputGroups, 'omarchy_audio_group_0123456789abcdef').name, 'Desk')
+assert.equal(model.outputGroupForSink(parsedOutputGroups, 'speakers'), null)
+assert.equal(model.outputGroupFallbackMember(parsedOutputGroups[0], ['speakers']), 'speakers')
+assert.equal(model.outputGroupFallbackMember(parsedOutputGroups[0], ['headphones']), 'headphones')
+assert.equal(model.outputGroupFallbackMember(
+  parsedOutputGroups[0], ['headphones', 'speakers']), 'headphones')
+assert.equal(model.outputGroupFallbackMember(
+  parsedOutputGroups[0], ['headphones', 'headphones', 'speakers']), 'speakers')
+assert.equal(model.outputGroupFallbackMember(
+  parsedOutputGroups[0], ['headphones', 'headphones']), '')
+assert.equal(model.outputGroupFallbackMember(null, ['speakers']), '')
+assert.equal(model.isOutputGroupSink('omarchy_audio_group_0123456789abcdef'), true)
+assert.equal(model.isOutputGroupSink('omarchy_audio_group_not-a-group'), false)
+assert.equal(model.isManagedOutputGroupSink({
+  name: 'omarchy_audio_group_0123456789abcdef',
+  isStream: true,
+  isSink: true,
+  ready: true,
+  properties: {
+    'application.id': 'ssupt.audio-control',
+    'node.virtual': true,
+    'omarchy.audio.group.id': '0123456789abcdef'
+  }
+}), true)
+assert.equal(model.isManagedOutputGroupSink({
+  name: 'omarchy_audio_group_0123456789abcdef',
+  isStream: true,
+  isSink: true,
+  ready: true,
+  properties: {
+    'application.id': 'ssupt.audio-control',
+    'node.virtual': true,
+    'omarchy.audio.group.id': 'fedcba9876543210'
+  }
+}), false)
+assert.equal(model.isOutputGroupMemberSink({
+  name: 'speakers', ready: true, isSink: true, isStream: false,
+  properties: { 'device.api': 'alsa', 'factory.name': 'api.alsa.pcm.sink' }
+}), true)
+assert.equal(model.isOutputGroupMemberSink({
+  name: 'effects', ready: true, isSink: true, isStream: false,
+  properties: { 'node.virtual': true, 'factory.name': 'support.null-audio-sink' }
+}), false)
+assert.equal(model.isOutputGroupMemberSink({
+  name: 'filter', ready: true, isSink: true, isStream: false,
+  properties: { 'device.class': 'filter' }
+}), false)
 const prototypeRules = model.parseAudioRules(
   '{"appRules":[{"app":"__proto__","direction":"playback","target":"speakers"},' +
   '{"app":"constructor","direction":"recording","target":"mic"}],' +
@@ -585,7 +720,7 @@ diagnostics_snapshot=$(
 )
 jq -e '
   .healthy == false
-  and .versions == {"plugin":"0.7.1","pipewire":"1.6.8","wireplumber":"0.5.15"}
+  and .versions == {"plugin":"0.8.0","pipewire":"1.6.8","wireplumber":"0.5.15"}
   and .graph.rate == 48000
   and .graph.quantum == 256
   and .graph.latencyMs == 5.3
@@ -619,7 +754,7 @@ support_report=$(
 )
 grep -q '^  playback: Browser -> Output Filter -> Wireless Headphones$' <<<"$support_report" ||
   fail "support report active route"
-grep -q '^  Advanced Audio Control: 0.7.1$' <<<"$support_report" ||
+grep -q '^  Advanced Audio Control: 0.8.0$' <<<"$support_report" ||
   fail "support report plugin version"
 grep -q '^  Peak DSP load: 5%$' <<<"$support_report" || fail "support report DSP load"
 ! grep -q 'bluez_output.test\|alsa_input.usb-microphone' <<<"$support_report" ||
@@ -767,6 +902,14 @@ pw-metadata -n default -- 900 target.node 1001 Spa:Id
 EOF
 )
 [[ $(<"$route_log") == "$expected_route_log" ]] || fail "persistent stream target"
+
+: >"$route_log"
+if AUDIO_CONTROL_ROUTE_LOG="$route_log" AUDIO_CONTROL_ROUTE_STREAM_OWNER_MODULE=1 \
+  PATH="$TEST_DIR/mocks:$PATH" \
+  "$ROOT/scripts/audio-stream-route-set" playback 300 101 override >/dev/null 2>&1; then
+  fail "module-owned playback stream accepted a manual route"
+fi
+[[ ! -s $route_log ]] || fail "module-owned playback stream was moved"
 
 : >"$route_log"
 AUDIO_CONTROL_ROUTE_LOG="$route_log" PATH="$TEST_DIR/mocks:$PATH" \
@@ -1623,8 +1766,48 @@ jq -e '(.devices.aliases | has("speakers") | not)
   fail "device preference removal"
 printf '%s\n' '{}' >"$rules_file"
 "$ROOT/scripts/audio-app-rules" set-alias missing ""
-jq -e '.appRules == [] and .devices == {"aliases":{},"favorites":[],"hidden":[]}' \
+jq -e '.appRules == [] and .outputGroups == []
+  and .devices == {"aliases":{},"favorites":[],"hidden":[]}' \
   "$rules_file" >/dev/null || fail "sparse audio rules normalization"
+"$ROOT/scripts/audio-app-rules" set-output-group 0123456789abcdef Desk \
+  '["speakers","headphones"]'
+jq -e '.outputGroups == [{
+    "id":"0123456789abcdef",
+    "name":"Desk",
+    "sink":"omarchy_audio_group_0123456789abcdef",
+    "members":["headphones","speakers"]
+  }]' "$rules_file" >/dev/null || fail "output group rule storage"
+if "$ROOT/scripts/audio-app-rules" set-output-group fedcba9876543210 Recursive \
+    '["speakers","omarchy_audio_group_0123456789abcdef"]' >/dev/null 2>&1; then
+  fail "recursive output group member accepted"
+fi
+"$ROOT/scripts/audio-app-rules" set-app player playback \
+  omarchy_audio_group_0123456789abcdef
+if "$ROOT/scripts/audio-app-rules" del-output-group 0123456789abcdef \
+    >/dev/null 2>&1; then
+  fail "output group used by an application rule was deleted"
+fi
+"$ROOT/scripts/audio-app-rules" del-app player playback
+"$ROOT/scripts/audio-app-rules" del-output-group 0123456789abcdef
+jq -e '.outputGroups == []' "$rules_file" >/dev/null ||
+  fail "output group rule deletion"
+jq -nc '
+  {version:1, appRules:[], outputGroups:[
+    range(0; 16) as $index
+    | (("000000000000000" + ($index | tostring))[-16:]) as $id
+    | {id:$id, name:("Group " + ($index | tostring)),
+       sink:("omarchy_audio_group_" + $id),
+       members:[("left-" + ($index | tostring)),
+         ("right-" + ($index | tostring))]}
+  ], devices:{aliases:{},favorites:[],hidden:[]}}
+' >"$rules_file"
+full_group_rules_before=$(<"$rules_file")
+if "$ROOT/scripts/audio-app-rules" set-output-group ffffffffffffffff Overflow \
+    '["speakers","headphones"]' >/dev/null 2>&1; then
+  fail "output group storage limit was exceeded"
+fi
+[[ $(<"$rules_file") == "$full_group_rules_before" ]] ||
+  fail "output group limit evicted an existing definition"
 jq -nc '
   {version:1, appRules:[], devices:{
     aliases:(reduce range(0; 128) as $index
@@ -1652,6 +1835,218 @@ fi
 unset OMARCHY_AUDIO_RULES_FILE
 echo "PASS: application rules and device preference store"
 rm -rf -- "$scenes_dir"
+
+output_group_dir=$(mktemp -d)
+output_group_rules="$output_group_dir/audio-rules.json"
+output_group_state="$output_group_dir/pactl-state.json"
+output_group_log="$output_group_dir/pactl.log"
+output_group_runtime="$output_group_dir/runtime"
+mkdir -m 700 -- "$output_group_runtime"
+printf '%s\n' \
+  '{"version":1,"appRules":[],"outputGroups":[],"devices":{"aliases":{},"favorites":[],"hidden":[]}}' \
+  >"$output_group_rules"
+printf '%s\n' \
+  '{"nextModule":70,"defaultSink":"speakers","modules":[],"sinkInputs":[],"sinks":[{"index":10,"name":"speakers","properties":{"object.id":"110"}},{"index":11,"name":"headphones","properties":{"object.id":"111"}},{"index":12,"name":"hdmi","properties":{"object.id":"112"}},{"index":13,"name":"virtual-filter","properties":{"object.id":"113","node.virtual":true,"device.class":"filter","factory.name":"support.null-audio-sink"}}]}' \
+  >"$output_group_state"
+
+run_output_group() {
+  AUDIO_CONTROL_PRIVATE_RUNTIME_DIR="$output_group_runtime" \
+    AUDIO_CONTROL_GROUP_STATE="$output_group_state" \
+    AUDIO_CONTROL_GROUP_LOG="$output_group_log" \
+    OMARCHY_AUDIO_RULES_FILE="$output_group_rules" \
+    PATH="$TEST_DIR/mocks:$PATH" \
+    "$ROOT/scripts/audio-output-groups" "$@"
+}
+
+output_group_id=$(run_output_group create Desk '["speakers","headphones"]')
+[[ $output_group_id =~ ^[0-9a-f]{16}$ ]] || fail "output group identity"
+output_group_sink=omarchy_audio_group_$output_group_id
+jq -e --arg id "$output_group_id" --arg sink "$output_group_sink" '
+  .outputGroups == [{
+    id: $id,
+    name: "Desk",
+    sink: $sink,
+    members: ["headphones", "speakers"]
+  }]
+' "$output_group_rules" >/dev/null || fail "output group definition"
+jq -e --arg id "$output_group_id" --arg sink "$output_group_sink" '
+  (.modules | length) == 1
+  and .modules[0].name == "module-combine-sink"
+  and (.modules[0].argument | contains("sinks=headphones,speakers"))
+  and (.modules[0].argument | contains("application.id=ssupt.audio-control"))
+  and ([.sinks[] | select(.name == $sink
+      and .properties."application.id" == "ssupt.audio-control"
+      and .properties."omarchy.audio.group.id" == $id)] | length) == 1
+' "$output_group_state" >/dev/null || fail "owned combine sink creation"
+[[ $(stat -c '%a' "$output_group_rules") == 600 ]] ||
+  fail "output group store permissions"
+
+if run_output_group create Solo '["speakers"]' >/dev/null 2>&1; then
+  fail "single-device output group accepted"
+fi
+if run_output_group create Recursive \
+    '["hdmi","omarchy_audio_group_0123456789abcdef"]' >/dev/null 2>&1; then
+  fail "nested output group accepted"
+fi
+if run_output_group create Virtual '["speakers","virtual-filter"]' \
+    >/dev/null 2>&1; then
+  fail "virtual sink accepted as an output group member"
+fi
+
+run_output_group update "$output_group_id" Desk '["speakers","hdmi"]'
+jq -e '.outputGroups[0].members == ["hdmi", "speakers"]' \
+  "$output_group_rules" >/dev/null || fail "output group member update"
+jq -e --arg sink "$output_group_sink" '
+  (.modules | length) == 1
+  and (.modules[0].argument | contains("sinks=hdmi,speakers"))
+  and ([.sinks[] | select(.name == $sink)] | length) == 1
+' "$output_group_state" >/dev/null || fail "combine sink member update"
+
+output_group_state_next="$output_group_dir/state-next.json"
+jq --arg sink "$output_group_sink" '.defaultSink = $sink' \
+  "$output_group_state" >"$output_group_state_next"
+mv -f -- "$output_group_state_next" "$output_group_state"
+if run_output_group update "$output_group_id" Desk \
+    '["speakers","headphones"]' >/dev/null 2>&1; then
+  fail "active default output group was replaced"
+else
+  [[ $? == 3 ]] || fail "active output group update exit code"
+fi
+jq -e '.outputGroups[0].members == ["hdmi", "speakers"]' \
+  "$output_group_rules" >/dev/null || fail "active output group definition changed"
+jq '.defaultSink = "speakers"' "$output_group_state" >"$output_group_state_next"
+mv -f -- "$output_group_state_next" "$output_group_state"
+
+if AUDIO_CONTROL_GROUP_LOAD_FAIL_MEMBERS=hdmi,headphones \
+    run_output_group update "$output_group_id" Desk \
+      '["headphones","hdmi"]' >/dev/null 2>&1; then
+  fail "failed combine sink replacement reported success"
+fi
+jq -e '.outputGroups[0].members == ["hdmi", "speakers"]' \
+  "$output_group_rules" >/dev/null || fail "failed output group update was persisted"
+jq -e '(.modules | length) == 1
+  and (.modules[0].argument | contains("sinks=hdmi,speakers"))' \
+  "$output_group_state" >/dev/null || fail "failed output group update was not rolled back"
+
+original_pair_id=$(run_output_group create "Original pair" \
+  '["speakers","headphones"]') || fail "original member set could not be reused"
+[[ $original_pair_id =~ ^[0-9a-f]{16}$ && $original_pair_id != "$output_group_id" ]] ||
+  fail "output group identities were not independent of member sets"
+run_output_group delete "$original_pair_id"
+
+# Reconciliation removes an unused group while a physical member is absent,
+# retains its definition, and restores it once every member comes back.
+jq '.sinks |= map(select(.name != "hdmi"))' \
+  "$output_group_state" >"$output_group_state_next"
+mv -f -- "$output_group_state_next" "$output_group_state"
+run_output_group reconcile
+jq -e --arg sink "$output_group_sink" '
+  (.modules | length) == 0
+  and ([.sinks[] | select(.name == $sink)] | length) == 0
+' "$output_group_state" >/dev/null || fail "degraded output group remained selectable"
+jq -e '(.outputGroups | length) == 1
+  and .outputGroups[0].members == ["hdmi", "speakers"]' \
+  "$output_group_rules" >/dev/null || fail "degraded output group definition was removed"
+jq '.sinks += [{index:12,name:"hdmi",properties:{"object.id":"112"}}]' \
+  "$output_group_state" >"$output_group_state_next"
+mv -f -- "$output_group_state_next" "$output_group_state"
+run_output_group reconcile
+jq -e --arg sink "$output_group_sink" '
+  (.modules | length) == 1
+  and ([.sinks[] | select(.name == $sink)] | length) == 1
+' "$output_group_state" >/dev/null || fail "reconnected output group was not restored"
+
+OMARCHY_AUDIO_RULES_FILE="$output_group_rules" \
+  "$ROOT/scripts/audio-app-rules" set-app player playback "$output_group_sink"
+if run_output_group delete "$output_group_id" >/dev/null 2>&1; then
+  fail "output group used by an offline rule was deleted"
+else
+  [[ $? == 3 ]] || fail "used output group delete exit code"
+fi
+OMARCHY_AUDIO_RULES_FILE="$output_group_rules" \
+  "$ROOT/scripts/audio-app-rules" del-app player playback
+
+if AUDIO_CONTROL_GROUP_UNLOAD_NO_EFFECT=1 \
+    run_output_group delete "$output_group_id" >/dev/null 2>&1; then
+  fail "unverified output group removal reported success"
+fi
+jq -e '(.outputGroups | length) == 1' "$output_group_rules" >/dev/null ||
+  fail "unverified output group removal changed storage"
+run_output_group delete "$output_group_id"
+jq -e '.outputGroups == []' "$output_group_rules" >/dev/null ||
+  fail "output group deletion"
+jq -e '(.modules | length) == 0
+  and ([.sinks[].name | select(startswith("omarchy_audio_group_"))] | length) == 0' \
+  "$output_group_state" >/dev/null || fail "output group module cleanup"
+
+if AUDIO_CONTROL_GROUP_LOAD_FAIL_MEMBERS=hdmi,headphones \
+    run_output_group create Broken '["headphones","hdmi"]' >/dev/null 2>&1; then
+  fail "failed output group creation reported success"
+fi
+jq -e '.outputGroups == []' "$output_group_rules" >/dev/null &&
+  jq -e '(.modules | length) == 0' "$output_group_state" >/dev/null ||
+  fail "failed output group creation left state"
+
+# PipeWire-Pulse does not include module indexes in `list modules`; recover a
+# group created by the earlier unquoted-property implementation through the
+# owning sink's verified pulse.module.id instead.
+legacy_group_id=eeeeeeeeeeeeeeee
+legacy_group_sink=omarchy_audio_group_$legacy_group_id
+jq --arg sink "$legacy_group_sink" --arg id "$legacy_group_id" '
+  .modules += [{
+    index: 98,
+    name: "module-combine-sink",
+    argument: ("sink_name=" + $sink
+      + " sinks=speakers,headphones"
+      + " sink_properties=device.description=Omarchy_Output_Group"
+      + " application.id=ssupt.audio-control node.virtual=true"
+      + " omarchy.audio.group.id=" + $id),
+    sink: $sink
+  }]
+  | .sinks += [{
+    index: 1098,
+    name: $sink,
+    description: "Omarchy_Output_Group",
+    owner_module: 98,
+    properties: {
+      "object.id":"2098",
+      "node.virtual":"true",
+      "pulse.module.id":"98"
+    }
+  }]
+' "$output_group_state" >"$output_group_state_next"
+mv -f -- "$output_group_state_next" "$output_group_state"
+run_output_group reconcile
+jq -e --arg sink "$legacy_group_sink" '
+  ([.modules[] | select(.index == 98)] | length) == 0
+  and ([.sinks[] | select(.name == $sink)] | length) == 0
+' "$output_group_state" >/dev/null || fail "legacy orphan output group was not cleaned"
+
+foreign_group_id=ffffffffffffffff
+foreign_group_sink=omarchy_audio_group_$foreign_group_id
+jq --arg sink "$foreign_group_sink" '
+  .modules += [{
+    index: 99,
+    name: "module-combine-sink",
+    argument: ("sink_name=" + $sink + " sinks=speakers,headphones"),
+    sink: $sink
+  }]
+  | .sinks += [{
+    index: 1099,
+    name: $sink,
+    properties: {"application.id":"someone.else"}
+  }]
+' "$output_group_state" >"$output_group_state_next"
+mv -f -- "$output_group_state_next" "$output_group_state"
+run_output_group reconcile
+jq -e --arg sink "$foreign_group_sink" '
+  ([.modules[] | select(.index == 99)] | length) == 1
+  and ([.sinks[] | select(.name == $sink)] | length) == 1
+' "$output_group_state" >/dev/null || fail "foreign combine sink was removed"
+
+rm -rf -- "$output_group_dir"
+unset -f run_output_group
+echo "PASS: named multi-output groups"
 
 microphone_test_dir=$(mktemp -d)
 microphone_test_log="$microphone_test_dir/commands.log"
@@ -2337,6 +2732,8 @@ const raw = fs.readFileSync(process.argv[2], 'utf8')
 const parsed = JSON.parse(raw.replace(/^\s*\/\/[^\n]*(\n|$)/gm, '').replace(/,(\s*[}\]])/g, '$1'))
 assert.equal(parsed['personal.notes'].label, 'Notes')
 assert.equal(parsed['setup.audio'].label, 'Audio')
+assert.equal(parsed['setup.audio'].action,
+  'omarchy-shell shell summon ssupt.audio-control \'{"view":"advanced"}\'')
 assert.equal((raw.match(/"setup\.audio"/g) || []).length, 1)
 JS
 
@@ -2399,7 +2796,7 @@ echo "PASS: menu integration"
 jq -e '
   .schemaVersion == 1
   and .id == "ssupt.audio-control"
-  and .version == "0.7.1"
+  and .version == "0.8.0"
   and .author == "ssupt"
   and (.kinds | index("bar-widget") != null)
   and (.kinds | index("panel") != null)

--- a/test/all
+++ b/test/all
@@ -134,15 +134,15 @@ fi
 # delegates may resolve the panel snapshot by a stable integer index instead.
 for live_model in displayAudioSinks displayAudioSources \
     displayAudioStreams displayRecordingStreams; do
-  rg -q "model: root\\.${live_model}\\.length$" "$ROOT/Panel.qml" ||
+  grep -q "model: root\\.${live_model}\\.length$" "$ROOT/Panel.qml" ||
     fail "safe numeric Repeater model: $live_model"
-  if rg -q "model: root\\.${live_model}$" "$ROOT/Panel.qml"; then
+  if grep -q "model: root\\.${live_model}$" "$ROOT/Panel.qml"; then
     fail "native PipeWire objects used directly as Repeater rows: $live_model"
   fi
 done
-rg -q 'model: root\.memberLevels\.length$' "$ROOT/AudioOutputGroupRow.qml" ||
+grep -q 'model: root\.memberLevels\.length$' "$ROOT/AudioOutputGroupRow.qml" ||
   fail "safe numeric output-group member level model"
-if rg -q 'model: root\.memberLevels$' "$ROOT/AudioOutputGroupRow.qml"; then
+if grep -q 'model: root\.memberLevels$' "$ROOT/AudioOutputGroupRow.qml"; then
   fail "native PipeWire group members used directly as Repeater rows"
 fi
 echo "PASS: unplug-safe PipeWire delegate models"

--- a/test/mocks/pactl
+++ b/test/mocks/pactl
@@ -1,5 +1,109 @@
 #!/bin/bash
 
+if [[ -n ${AUDIO_CONTROL_GROUP_STATE:-} ]]; then
+  group_state_write() {
+    local temporary
+    temporary=${AUDIO_CONTROL_GROUP_STATE}.tmp
+    jq "$@" "$AUDIO_CONTROL_GROUP_STATE" >"$temporary" || return 1
+    mv -f -- "$temporary" "$AUDIO_CONTROL_GROUP_STATE"
+  }
+
+  case "$*" in
+    "-f json list sinks")
+      jq -c '.sinks' "$AUDIO_CONTROL_GROUP_STATE"
+      exit $?
+      ;;
+    "-f json list modules")
+      # PipeWire-Pulse omits a module index from JSON even though load-module
+      # and unload-module use one. The owning sink exposes it instead.
+      jq -c '.modules | map(del(.index, .sink))' "$AUDIO_CONTROL_GROUP_STATE"
+      exit $?
+      ;;
+    "-f json list sink-inputs")
+      jq -c '.sinkInputs' "$AUDIO_CONTROL_GROUP_STATE"
+      exit $?
+      ;;
+    "get-default-sink")
+      jq -er '.defaultSink | select(type == "string" and length > 0)' \
+        "$AUDIO_CONTROL_GROUP_STATE"
+      exit $?
+      ;;
+    load-module\ module-combine-sink\ *)
+      group_sink=
+      group_members=
+      group_id=
+      group_argument=
+      for group_arg in "${@:3}"; do
+        group_argument+="${group_argument:+ }$group_arg"
+        [[ $group_arg != sink_name=* ]] || group_sink=${group_arg#sink_name=}
+        [[ $group_arg != sinks=* ]] || group_members=${group_arg#sinks=}
+        if [[ $group_arg =~ omarchy\.audio\.group\.id=([0-9a-f]{16}) ]]; then
+          group_id=${BASH_REMATCH[1]}
+        fi
+      done
+      [[ $group_sink =~ ^omarchy_audio_group_[0-9a-f]{16}$
+          && $group_id =~ ^[0-9a-f]{16}$ && -n $group_members ]] || exit 1
+      [[ ${AUDIO_CONTROL_GROUP_LOAD_FAIL_MEMBERS:-} != "$group_members" ]] || exit 1
+      jq -e --arg sink "$group_sink" 'any(.sinks[]; .name == $sink) | not' \
+        "$AUDIO_CONTROL_GROUP_STATE" >/dev/null || exit 1
+      group_module=$(jq -er '.nextModule | select(type == "number")' \
+        "$AUDIO_CONTROL_GROUP_STATE") || exit 1
+      group_sink_index=$((group_module + 1000))
+      group_object_id=$((group_module + 2000))
+      group_state_write --argjson module "$group_module" \
+        --argjson sinkIndex "$group_sink_index" --arg object "$group_object_id" \
+        --arg sink "$group_sink" --arg id "$group_id" --arg argument "$group_argument" '
+        .nextModule += 1
+        | .modules += [{
+            index: $module,
+            name: "module-combine-sink",
+            argument: $argument,
+            sink: $sink
+          }]
+        | .sinks += [{
+            index: $sinkIndex,
+            name: $sink,
+            description: "Omarchy_Output_Group",
+            owner_module: $module,
+            properties: {
+              "object.id": $object,
+              "application.id": "ssupt.audio-control",
+              "omarchy.audio.group.id": $id,
+              "node.virtual": "true",
+              "pulse.module.id": ($module | tostring)
+            }
+          }]
+      ' || exit 1
+      [[ -z ${AUDIO_CONTROL_GROUP_LOG:-} ]] ||
+        printf 'load %s %s %s\n' "$group_module" "$group_sink" "$group_members" \
+          >>"$AUDIO_CONTROL_GROUP_LOG"
+      printf '%s\n' "$group_module"
+      exit 0
+      ;;
+    unload-module\ *)
+      group_module=${2:-}
+      [[ $group_module =~ ^[0-9]{1,20}$ ]] || exit 1
+      [[ ${AUDIO_CONTROL_GROUP_UNLOAD_FAIL:-0} != 1 ]] || exit 1
+      group_sink=$(jq -er --arg module "$group_module" '
+        [.modules[] | select((.index | tostring) == $module)] as $matches
+        | if ($matches | length) == 1 then $matches[0].sink
+          else error("unknown module") end
+      ' "$AUDIO_CONTROL_GROUP_STATE") || exit 1
+      if [[ ${AUDIO_CONTROL_GROUP_UNLOAD_NO_EFFECT:-0} != 1 ]]; then
+        group_state_write --arg module "$group_module" --arg sink "$group_sink" '
+          .modules |= map(select((.index | tostring) != $module))
+          | .sinks |= map(select(.name != $sink))
+        ' || exit 1
+      fi
+      [[ -z ${AUDIO_CONTROL_GROUP_LOG:-} ]] ||
+        printf 'unload %s %s\n' "$group_module" "$group_sink" \
+          >>"$AUDIO_CONTROL_GROUP_LOG"
+      exit 0
+      ;;
+  esac
+  exit 1
+fi
+
 if [[ $* == "-f json list sinks" && -n ${AUDIO_CONTROL_DIAGNOSTIC_SINK_FIXTURE:-} ]]; then
   command cat "$AUDIO_CONTROL_DIAGNOSTIC_SINK_FIXTURE"
   exit 0
@@ -159,10 +263,10 @@ if [[ -n ${AUDIO_CONTROL_OUTPUT_DEFAULT_LOG:-} ]]; then
         fi
       done <"$AUDIO_CONTROL_OUTPUT_DEFAULT_LOG"
       if [[ ${AUDIO_CONTROL_DEFAULT_DUPLICATE_STREAM:-} == output ]]; then
-        printf '[{"index":300,"sink":%s,"properties":{"object.id":"900","application.name":"Player"}},{"index":302,"sink":%s,"properties":{"object.id":"900","application.name":"Duplicate"}},{"index":301,"sink":100,"properties":{"object.id":"901","application.name":"Pinned"}}]\n' \
+        printf '[{"index":300,"sink":%s,"properties":{"object.id":"900","application.name":"Player"}},{"index":302,"sink":%s,"properties":{"object.id":"900","application.name":"Duplicate"}},{"index":301,"sink":100,"properties":{"object.id":"901","application.name":"Pinned"}},{"index":303,"sink":100,"owner_module":77,"properties":{"object.id":"903","application.name":"Combine follower"}}]\n' \
           "$input_sink" "$input_sink"
       else
-        printf '[{"index":300,"sink":%s,"properties":{"object.id":"900","application.name":"Player"}},{"index":301,"sink":100,"properties":{"object.id":"901","application.name":"Pinned"}}]\n' "$input_sink"
+        printf '[{"index":300,"sink":%s,"properties":{"object.id":"900","application.name":"Player"}},{"index":301,"sink":100,"properties":{"object.id":"901","application.name":"Pinned"}},{"index":303,"sink":100,"owner_module":77,"properties":{"object.id":"903","application.name":"Combine follower"}}]\n' "$input_sink"
       fi
       exit 0
       ;;
@@ -187,7 +291,7 @@ if [[ -n ${AUDIO_CONTROL_ROUTE_LIST:-} && $* == "-f json list" ]]; then
   if [[ -n ${AUDIO_CONTROL_ROUTE_LIST_JSON:-} ]]; then
     printf '%s\n' "$AUDIO_CONTROL_ROUTE_LIST_JSON"
   else
-    echo '{"sink_inputs":[{"index":300,"sink":101,"properties":{"object.id":"900"}}],"source_outputs":[{"index":400,"source":201,"properties":{"object.id":"901"}}]}'
+    echo '{"sink_inputs":[{"index":300,"sink":101,"properties":{"object.id":"900"}},{"index":301,"sink":100,"owner_module":77,"properties":{"object.id":"902"}}],"source_outputs":[{"index":400,"source":201,"properties":{"object.id":"901"}},{"index":401,"source":200,"owner_module":78,"properties":{"object.id":"903"}}]}'
   fi
   exit 0
 fi
@@ -318,6 +422,9 @@ if [[ -n ${AUDIO_CONTROL_ROUTE_LOG:-} ]]; then
         sink_inputs='[{"index":300,"sink":100,"properties":{"object.id":"999"}},{"index":302,"sink":'"$route_sink"',"properties":{"object.id":"900"}}]'
       elif (( route_read_count > 1 )) && [[ ${AUDIO_CONTROL_ROUTE_DUPLICATE_STREAM_OBJECT:-0} == 1 ]]; then
         sink_inputs='[{"index":300,"sink":'"$route_sink"',"properties":{"object.id":"900"}},{"index":302,"sink":'"$route_sink"',"properties":{"object.id":"900"}}]'
+      fi
+      if [[ ${AUDIO_CONTROL_ROUTE_STREAM_OWNER_MODULE:-0} == 1 ]]; then
+        sink_inputs='[{"index":300,"sink":'"$route_sink"',"owner_module":77,"properties":{"object.id":"900"}}]'
       fi
       sinks='[{"index":'"$route_original_index"',"properties":{"object.id":"1000"}},{"index":'"$route_target_index"',"properties":{"object.id":"1001"}}]'
       if (( route_read_count > 1 )) && [[ ${AUDIO_CONTROL_ROUTE_TARGET_REINDEX:-0} == 1 ]]; then


### PR DESCRIPTION
## Summary

- add reusable named output groups under Routing and expose them as normal default and per-application destinations
- safely create, reconcile, and remove plugin-owned PipeWire combine sinks without recursive groups or a background service
- fall back to a surviving member when an active group degrades, filter stale input and internal follower nodes, and mark groups in the mixer
- add shared per-member device volume controls and release version 0.8.0

## UX note

Group membership is configured once in the Routing tab instead of duplicating multi-selection state in every output dropdown. The resulting group remains selectable globally and for individual applications.

## Verification

- env AUDIO_CONTROL_PRIVATE_RUNTIME_DIR=/tmp/codex-audio-test-runtime ./test/all
- live group creation, playback, member unplug fallback, stale-input removal, and Quickshell UI smoke tests

Closes #11