### PR TITLE
Allow lock directories reached through a safe symlink

### DIFF
--- a/scripts/.audio-common
+++ b/scripts/.audio-common
@@ -49,7 +49,11 @@ audio_open_lock_path() {
   [[ -n $lock_path && $descriptor =~ ^[89]$
       && $wait_seconds =~ ^[0-9]+([.][0-9]+)?$ ]] || return 1
   lock_dir=$(dirname -- "$lock_path") || return 1
-  [[ ! -L $lock_dir && -d $lock_dir ]] || {
+  lock_dir=$(readlink -f -- "$lock_dir") || {
+    echo "The audio lock directory is not safe" >&2
+    return 1
+  }
+  [[ -d $lock_dir ]] || {
     echo "The audio lock directory is not safe" >&2
     return 1
   }

--- a/test/all
+++ b/test/all
@@ -63,6 +63,29 @@ else
   [[ $? != 124 ]] || fail "hard-linked runtime lock blocked"
 fi
 
+# A symlinked config directory (e.g. a dotfiles-managed ~/.config/omarchy)
+# must still be usable as a lock directory once it resolves to a real,
+# safely-permissioned directory the user owns.
+symlinked_lock_target="$runtime_safety_dir/real-config"
+mkdir -m 755 -- "$symlinked_lock_target"
+symlinked_lock_dir="$runtime_safety_dir/linked-config"
+ln -s -- "$symlinked_lock_target" "$symlinked_lock_dir"
+bash -c 'source "$1"; audio_open_lock_path "$2/lock" 9' _ \
+  "$ROOT/scripts/.audio-common" "$symlinked_lock_dir" ||
+  fail "symlinked but safe lock directory rejected"
+[[ -f $symlinked_lock_target/lock ]] ||
+  fail "symlinked lock directory did not resolve to its real target"
+
+# A symlink to a non-sticky, world-writable directory must still be rejected.
+unsafe_lock_target="$runtime_safety_dir/unsafe-config"
+mkdir -m 777 -- "$unsafe_lock_target"
+unsafe_lock_dir="$runtime_safety_dir/linked-unsafe-config"
+ln -s -- "$unsafe_lock_target" "$unsafe_lock_dir"
+if bash -c 'source "$1"; audio_open_lock_path "$2/lock" 9' _ \
+  "$ROOT/scripts/.audio-common" "$unsafe_lock_dir" >/dev/null 2>&1; then
+  fail "symlink to a world-writable directory accepted"
+fi
+
 # Bounded capture must validate its producer even when the sourcing shell did
 # not enable pipefail itself.
 if AUDIO_CONTROL_PRIVATE_RUNTIME_DIR="$runtime_private" \


### PR DESCRIPTION
## Summary
- `audio_open_lock_path()` in `scripts/.audio-common` rejected any lock directory that was itself a symlink. That breaks every default-output/input switch, port change, profile change, and scene for anyone whose `~/.config/omarchy` is a symlink into a dotfiles repo (stow, chezmoi, or a manual symlink layout) — a common way to manage dotfiles. The visible symptom is "The audio lock directory is not safe" the moment you try to switch outputs.
- Fix resolves the lock directory with `readlink -f` and validates the resulting real directory, instead of flatly refusing any symlinked path. The existing permission/sticky-bit check right below it still rejects a directory writable by another user, and the later per-file checks still require the lock file to be a regular file owned by the current user with a single link — so a symlink into an unsafe location is still rejected.
- Added two `test/all` cases: a symlink to a safe, user-owned directory now succeeds and resolves to the real target, and a symlink to a non-sticky world-writable directory is still rejected.

## Test plan
- [x] `bash test/all` passes, including the two new cases
- [x] Reproduced the original failure locally with `~/.config/omarchy` symlinked into a dotfiles repo, confirmed it's fixed
- [x] Manually ran `audio-output-set-default` against a real PipeWire session to switch outputs both ways after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018bpzX5oHbAM7EVATBNDH5T