### PR TITLE
Keep stream-player association working on Omarchy 4.0.3 scoped hosts

### DIFF
--- a/Model.js
+++ b/Model.js
@@ -1714,6 +1714,56 @@ function audioScenePlan(scene) {
   return steps
 }
 
+// Mirrors the first-party omarchy.media selection for hosts where the media
+// service object is not reachable (Omarchy 4.0.3 capability scoping answers
+// null for firstPartyServiceFor): the first player in list order that is
+// playing and owns a matched playback stream, then any playing player, then
+// a controllable one. The host's hand-picked source preference cannot be
+// seen from here, so when the user pinned a source in the media widget this
+// fallback may pick a different-but-reasonable player.
+function pickActiveMprisPlayer(players, streams) {
+  var values = players && typeof players.length === "number" ? players : []
+  var nodes = streams && typeof streams.length === "number" ? streams : []
+  var matched = null, matchedProxy = null
+  var playing = null, playingProxy = null
+  var controllable = null, controllableProxy = null
+  for (var i = 0; i < values.length && i < 256; i++) {
+    var player = values[i]
+    if (!player) continue
+    var proxy = mprisPlayerIsProxy(player)
+    var label = mprisPlayerLabel(player)
+    var hasStream = false
+    if (label) {
+      for (var s = 0; s < nodes.length && s < 512; s++) {
+        var streamLabel = rawStreamLabel(nodes[s])
+        if (streamLabel && !streamLabelIsGeneric(streamLabel)
+            && streamRepresentsMprisPlayer(streamLabel, label)) {
+          hasStream = true
+          break
+        }
+      }
+    }
+    var isPlaying = false
+    var canControl = false
+    try { isPlaying = player.isPlaying === true } catch (e) { }
+    try { canControl = player.canControl === true } catch (e) { }
+    if (isPlaying) {
+      if (hasStream) {
+        if (!proxy && !matched) matched = player
+        else if (proxy && !matchedProxy) matchedProxy = player
+      } else {
+        if (!proxy && !playing) playing = player
+        else if (proxy && !playingProxy) playingProxy = player
+      }
+    } else if (canControl) {
+      if (!proxy && !controllable) controllable = player
+      else if (proxy && !controllableProxy) controllableProxy = player
+    }
+  }
+  return matched || matchedProxy || playing || playingProxy
+    || controllable || controllableProxy || null
+}
+
 function streamRepresentsPlayer(node, player, players, streams) {
   if (!node || !player) return false
   var playerLabel = mprisPlayerLabel(player)
@@ -1804,6 +1854,7 @@ if (typeof module !== "undefined") {
     addedRecordingStreamLabels: addedRecordingStreamLabels,
     streamIconName: streamIconName,
     streamRepresentsPlayer: streamRepresentsPlayer,
+    pickActiveMprisPlayer: pickActiveMprisPlayer,
     audioScenePlan: audioScenePlan
   }
 }

--- a/Model.js
+++ b/Model.js
@@ -1714,18 +1714,16 @@ function audioScenePlan(scene) {
   return steps
 }
 
-// Mirrors the first-party omarchy.media selection for hosts where the media
-// service object is not reachable (Omarchy 4.0.3 capability scoping answers
-// null for firstPartyServiceFor): the first player in list order that is
-// playing and owns a matched playback stream, then any playing player, then
-// a controllable one. The host's hand-picked source preference cannot be
-// seen from here, so when the user pinned a source in the media widget this
-// fallback may pick a different-but-reasonable player.
+// Scoped hosts may hide the media service. Prefer playing players, then paused
+// players with a matching stream, then controllable players. Within each tier,
+// prefer real players over proxies and keep list order. The host's pinned source
+// and playback-start history are unavailable, so this is a fallback heuristic.
 function pickActiveMprisPlayer(players, streams) {
   var values = players && typeof players.length === "number" ? players : []
   var nodes = streams && typeof streams.length === "number" ? streams : []
   var matched = null, matchedProxy = null
   var playing = null, playingProxy = null
+  var paused = null, pausedProxy = null
   var controllable = null, controllableProxy = null
   for (var i = 0; i < values.length && i < 256; i++) {
     var player = values[i]
@@ -1755,13 +1753,16 @@ function pickActiveMprisPlayer(players, streams) {
         if (!proxy && !playing) playing = player
         else if (proxy && !playingProxy) playingProxy = player
       }
+    } else if (hasStream) {
+      if (!proxy && !paused) paused = player
+      else if (proxy && !pausedProxy) pausedProxy = player
     } else if (canControl) {
       if (!proxy && !controllable) controllable = player
       else if (proxy && !controllableProxy) controllableProxy = player
     }
   }
   return matched || matchedProxy || playing || playingProxy
-    || controllable || controllableProxy || null
+    || paused || pausedProxy || controllable || controllableProxy || null
 }
 
 function streamRepresentsPlayer(node, player, players, streams) {

--- a/Panel.qml
+++ b/Panel.qml
@@ -56,7 +56,11 @@ Panel {
   readonly property var appLibrary: bar && bar.shell ? bar.shell.appLibrary : null
   readonly property var mediaService: bar && bar.shell
     ? bar.shell.firstPartyServiceFor("omarchy.media") : null
-  readonly property var activeMediaPlayer: mediaService ? mediaService.activePlayer : null
+  readonly property var activeMediaPlayer: mediaService && mediaService.activePlayer
+    ? mediaService.activePlayer
+    // Scoped hosts do not hand out the media service object; pick a player
+    // from MPRIS directly so stream association keeps working.
+    : Model.pickActiveMprisPlayer(mprisPlayers, displayAudioStreams)
   property var audioPreferences: Model.parseAudioPreferences("")
   property bool audioPreferencesLoaded: false
   property bool outputOverdrive: false

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "ssupt.audio-control",
   "name": "Advanced Audio Control",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "author": "ssupt",
   "description": "Advanced PipeWire and WirePlumber audio mixer for Omarchy: devices, multi-output groups, Bluetooth codecs, safety policies, microphone privacy, audio scenes, persistent routing rules, graph and service diagnostics, channel tests, support reports, and guarded recovery",
   "kinds": [

--- a/test/all
+++ b/test/all
@@ -679,6 +679,26 @@ assert.equal(model.uniqueRecordingStreamLabels(Array.from({ length: 600 }, (_, i
   properties: { 'application.name': 'Recorder ' + index }
 }))).length, 512)
 assert.deepEqual(model.addedRecordingStreamLabels([], ['Recorder', 'recorder']), ['Recorder'])
+// A paused player's surviving stream must beat an unrelated idle player.
+const idleBrowser = { identity: 'Firefox', canControl: true }
+const pausedMusic = { identity: 'Spotify', canControl: true }
+const playingBrowser = { identity: 'Firefox', isPlaying: true, canControl: true }
+const playingMusic = { identity: 'Spotify', isPlaying: true, canControl: true }
+const musicStream = { ready: true, properties: { 'application.name': 'Spotify' } }
+const browserStream = { ready: true, properties: { 'application.name': 'Firefox' } }
+const proxyMusic = { identity: 'Spotify', dbusName: 'org.mpris.MediaPlayer2.playerctld', canControl: true }
+assert.equal(model.pickActiveMprisPlayer([idleBrowser, pausedMusic], [musicStream]), pausedMusic)
+assert.equal(model.pickActiveMprisPlayer([proxyMusic, pausedMusic], [musicStream]), pausedMusic)
+assert.equal(model.pickActiveMprisPlayer([idleBrowser, proxyMusic], [musicStream]), proxyMusic)
+assert.equal(model.pickActiveMprisPlayer([pausedMusic, playingBrowser], [musicStream]), playingBrowser)
+assert.equal(model.pickActiveMprisPlayer([playingBrowser, playingMusic], [musicStream]), playingMusic)
+assert.equal(model.pickActiveMprisPlayer([playingBrowser, playingMusic], [browserStream, musicStream]), playingBrowser)
+assert.equal(model.pickActiveMprisPlayer([idleBrowser, pausedMusic], []), idleBrowser)
+assert.equal(model.pickActiveMprisPlayer([], []), null)
+assert.equal(model.pickActiveMprisPlayer({ 0: idleBrowser, 1: pausedMusic, length: 2 },
+  { 0: musicStream, length: 1 }), pausedMusic)
+// Selection identifies a player's stream; it does not imply audible playback.
+assert.equal(model.streamRepresentsPlayer(musicStream, pausedMusic, [pausedMusic], [musicStream]), true)
 const lateMprisPlayers = Array.from({ length: 257 }, () => null)
 lateMprisPlayers[256] = { identity: 'Late Player', isPlaying: true, canPlay: true }
 assert.equal(model.mprisLabelsFor(lateMprisPlayers, () => true), '')
@@ -732,6 +752,8 @@ assert.equal(model.parseAudioDiagnostics('not json').valid, false)
 console.log('PASS: profile and routing model')
 JS
 
+plugin_version=$(jq -er '.version | strings | select(test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))' "$ROOT/manifest.json") ||
+  fail "manifest version"
 diagnostics_fixture="$TEST_DIR/fixtures/diagnostics"
 diagnostics_snapshot=$(
   AUDIO_CONTROL_DIAGNOSTICS_FIXTURE_DIR="$diagnostics_fixture" \
@@ -741,9 +763,9 @@ diagnostics_snapshot=$(
   AUDIO_CONTROL_CLIPBOARD_COMMAND=wl-copy \
   PATH="$TEST_DIR/mocks:$PATH" "$ROOT/scripts/audio-diagnostics" snapshot
 )
-jq -e '
+jq -e --arg plugin_version "$plugin_version" '
   .healthy == false
-  and .versions == {"plugin":"0.8.0","pipewire":"1.6.8","wireplumber":"0.5.15"}
+  and .versions == {"plugin":$plugin_version,"pipewire":"1.6.8","wireplumber":"0.5.15"}
   and .graph.rate == 48000
   and .graph.quantum == 256
   and .graph.latencyMs == 5.3
@@ -777,7 +799,7 @@ support_report=$(
 )
 grep -q '^  playback: Browser -> Output Filter -> Wireless Headphones$' <<<"$support_report" ||
   fail "support report active route"
-grep -q '^  Advanced Audio Control: 0.8.0$' <<<"$support_report" ||
+grep -Fqx "  Advanced Audio Control: $plugin_version" <<<"$support_report" ||
   fail "support report plugin version"
 grep -q '^  Peak DSP load: 5%$' <<<"$support_report" || fail "support report DSP load"
 ! grep -q 'bluez_output.test\|alsa_input.usb-microphone' <<<"$support_report" ||
@@ -2819,7 +2841,7 @@ echo "PASS: menu integration"
 jq -e '
   .schemaVersion == 1
   and .id == "ssupt.audio-control"
-  and .version == "0.8.0"
+  and (.version | test("^[0-9]+\\.[0-9]+\\.[0-9]+$"))
   and .author == "ssupt"
   and (.kinds | index("bar-widget") != null)
   and (.kinds | index("panel") != null)


### PR DESCRIPTION
Omarchy hosts that restrict `firstPartyServiceFor("omarchy.media")` return no media service to this plugin, leaving playback streams without their player association.

Use the host's active player when available; otherwise select from the existing MPRIS players and playback streams. Prefer playing players with a matching stream, then other playing players, paused players with a stream, and controllable players. Each tier prefers real players over proxies.

The fallback uses list order. It cannot read the host's pinned source or playback-start history, so its choice can differ from the media widget. A selected paused player's stream remains associated; the indicator does not imply audible playback.

The tests now read the diagnostics version from the manifest and check its format, so the 0.8.1 bump passes. Added regressions cover paused stream association, playing priority, proxy preference, list order, empty input and QML-like sequences. The paused-player regression fails on the original PR and passes with the fix; the full suite passes.

This compatibility fix also applies to the Rust migration in #15.
